### PR TITLE
feat: add config file parsing with CLI flag overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/spf13/cobra v1.10.2
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds all configuration for a godark run.
+type Config struct {
+	Repo       string `yaml:"repo"`
+	Milestone  string `yaml:"milestone"`
+	Issue      int    `yaml:"issue"`
+	MaxRetries int    `yaml:"max_retries"`
+
+	ClaudeFlags  []string     `yaml:"claude_flags"`
+	BuildCommand string       `yaml:"build_command"`
+	TestCommand  string       `yaml:"test_command"`
+	CrossCompile CrossCompile `yaml:"cross_compile"`
+
+	ProtectedPaths []string `yaml:"protected_paths"`
+	ScenarioDir    string   `yaml:"scenario_dir"`
+	ReviewDir      string   `yaml:"review_dir"`
+	LogDir         string   `yaml:"log_dir"`
+
+	Docker  Docker  `yaml:"docker"`
+	Prompts Prompts `yaml:"prompts"`
+}
+
+// CrossCompile holds cross-compilation environment variables.
+type CrossCompile struct {
+	GOOS   string `yaml:"GOOS"`
+	GOARCH string `yaml:"GOARCH"`
+}
+
+// Docker holds Docker sandbox configuration.
+type Docker struct {
+	Image      string `yaml:"image"`
+	Dockerfile string `yaml:"dockerfile"`
+	Mount      string `yaml:"mount"`
+	User       string `yaml:"user"`
+}
+
+// Prompts holds paths to prompt template files.
+type Prompts struct {
+	Implementer      string `yaml:"implementer"`
+	ImplementerRetry string `yaml:"implementer_retry"`
+	Reviewer         string `yaml:"reviewer"`
+}
+
+// CLIFlags holds flag values passed on the command line.
+// Pointer fields distinguish "not set" (nil) from zero values.
+type CLIFlags struct {
+	Repo       *string
+	Milestone  *string
+	Issue      *int
+	MaxRetries *int
+	Config     string
+}
+
+// Load reads a YAML config file at path and merges CLI flag overrides.
+// A missing config file is not an error if all required values come from flags.
+func Load(path string, flags CLIFlags) (*Config, error) {
+	cfg := defaults()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("reading config file: %w", err)
+		}
+		// Missing file is OK — flags may supply required values.
+	} else {
+		if err := yaml.Unmarshal(data, cfg); err != nil {
+			return nil, fmt.Errorf("parsing config file: %w", err)
+		}
+	}
+
+	applyFlags(cfg, flags)
+
+	if err := validate(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func defaults() *Config {
+	return &Config{
+		MaxRetries:  2,
+		ScenarioDir: "tests/scenarios/",
+		ReviewDir:   "tests/review/",
+		LogDir:      "logs/",
+	}
+}
+
+func applyFlags(cfg *Config, flags CLIFlags) {
+	if flags.Repo != nil {
+		cfg.Repo = *flags.Repo
+	}
+	if flags.Milestone != nil {
+		cfg.Milestone = *flags.Milestone
+	}
+	if flags.Issue != nil {
+		cfg.Issue = *flags.Issue
+	}
+	if flags.MaxRetries != nil {
+		cfg.MaxRetries = *flags.MaxRetries
+	}
+}
+
+func validate(cfg *Config) error {
+	if cfg.Repo == "" {
+		return fmt.Errorf("repo is required (set in config file or pass --repo)")
+	}
+	if cfg.Milestone == "" && cfg.Issue == 0 {
+		return fmt.Errorf("milestone or issue is required (set in config file or pass --milestone / --issue)")
+	}
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,222 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+
+func writeYAML(t *testing.T, dir, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, "godark.yaml")
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestFullConfigParse(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+milestone: "Phase 1"
+max_retries: 3
+issue: 5
+claude_flags: ["-p", "--dangerously-skip-permissions"]
+build_command: "go build -o bin/ ./cmd/..."
+test_command: "go test ./..."
+cross_compile:
+  GOOS: linux
+  GOARCH: arm64
+protected_paths:
+  - tests/scenarios/
+  - CLAUDE.md
+scenario_dir: tests/scenarios/
+review_dir: tests/review/
+log_dir: logs/
+docker:
+  image: dark-factory-runner
+  dockerfile: Dockerfile.devloop
+  mount: /workspace
+  user: devloop
+prompts:
+  implementer: prompts/implementer.md
+  implementer_retry: prompts/implementer-retry.md
+  reviewer: prompts/reviewer.md
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Repo != "owner/repo" {
+		t.Errorf("Repo = %q, want %q", cfg.Repo, "owner/repo")
+	}
+	if cfg.Milestone != "Phase 1" {
+		t.Errorf("Milestone = %q, want %q", cfg.Milestone, "Phase 1")
+	}
+	if cfg.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want 3", cfg.MaxRetries)
+	}
+	if cfg.Issue != 5 {
+		t.Errorf("Issue = %d, want 5", cfg.Issue)
+	}
+	if len(cfg.ClaudeFlags) != 2 || cfg.ClaudeFlags[0] != "-p" {
+		t.Errorf("ClaudeFlags = %v, want [-p --dangerously-skip-permissions]", cfg.ClaudeFlags)
+	}
+	if cfg.BuildCommand != "go build -o bin/ ./cmd/..." {
+		t.Errorf("BuildCommand = %q", cfg.BuildCommand)
+	}
+	if cfg.TestCommand != "go test ./..." {
+		t.Errorf("TestCommand = %q", cfg.TestCommand)
+	}
+	if cfg.CrossCompile.GOOS != "linux" {
+		t.Errorf("CrossCompile.GOOS = %q, want linux", cfg.CrossCompile.GOOS)
+	}
+	if cfg.CrossCompile.GOARCH != "arm64" {
+		t.Errorf("CrossCompile.GOARCH = %q, want arm64", cfg.CrossCompile.GOARCH)
+	}
+	if len(cfg.ProtectedPaths) != 2 {
+		t.Errorf("ProtectedPaths = %v, want 2 entries", cfg.ProtectedPaths)
+	}
+	if cfg.Docker.Image != "dark-factory-runner" {
+		t.Errorf("Docker.Image = %q", cfg.Docker.Image)
+	}
+	if cfg.Docker.User != "devloop" {
+		t.Errorf("Docker.User = %q", cfg.Docker.User)
+	}
+	if cfg.Prompts.Implementer != "prompts/implementer.md" {
+		t.Errorf("Prompts.Implementer = %q", cfg.Prompts.Implementer)
+	}
+	if cfg.Prompts.Reviewer != "prompts/reviewer.md" {
+		t.Errorf("Prompts.Reviewer = %q", cfg.Prompts.Reviewer)
+	}
+}
+
+func TestFlagOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: original/repo
+milestone: "Phase 1"
+max_retries: 2
+`)
+
+	cfg, err := Load(path, CLIFlags{
+		Repo:       strPtr("override/repo"),
+		MaxRetries: intPtr(5),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Repo != "override/repo" {
+		t.Errorf("Repo = %q, want %q", cfg.Repo, "override/repo")
+	}
+	if cfg.Milestone != "Phase 1" {
+		t.Errorf("Milestone = %q, want %q (should be preserved from file)", cfg.Milestone, "Phase 1")
+	}
+	if cfg.MaxRetries != 5 {
+		t.Errorf("MaxRetries = %d, want 5", cfg.MaxRetries)
+	}
+}
+
+func TestMissingFileFlagsSufficient(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.yaml")
+
+	cfg, err := Load(path, CLIFlags{
+		Repo:      strPtr("owner/repo"),
+		Milestone: strPtr("Phase 1"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Repo != "owner/repo" {
+		t.Errorf("Repo = %q, want %q", cfg.Repo, "owner/repo")
+	}
+	if cfg.MaxRetries != 2 {
+		t.Errorf("MaxRetries = %d, want 2 (default)", cfg.MaxRetries)
+	}
+}
+
+func TestMissingFileFlagsInsufficient(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.yaml")
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for missing repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "repo") {
+		t.Errorf("error = %q, want mention of 'repo'", err.Error())
+	}
+}
+
+func TestMinimalConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+milestone: "Phase 1"
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.MaxRetries != 2 {
+		t.Errorf("MaxRetries = %d, want 2 (default)", cfg.MaxRetries)
+	}
+	if cfg.ScenarioDir != "tests/scenarios/" {
+		t.Errorf("ScenarioDir = %q, want default", cfg.ScenarioDir)
+	}
+	if cfg.ReviewDir != "tests/review/" {
+		t.Errorf("ReviewDir = %q, want default", cfg.ReviewDir)
+	}
+	if cfg.LogDir != "logs/" {
+		t.Errorf("LogDir = %q, want default", cfg.LogDir)
+	}
+}
+
+func TestInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `{{{not valid yaml`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "parsing config file") {
+		t.Errorf("error = %q, want mention of parsing", err.Error())
+	}
+}
+
+func TestMissingMilestoneAndIssue(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `repo: owner/repo`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for missing milestone/issue, got nil")
+	}
+	if !strings.Contains(err.Error(), "milestone") {
+		t.Errorf("error = %q, want mention of 'milestone'", err.Error())
+	}
+}
+
+func TestIssueAloneSuffices(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `repo: owner/repo`)
+
+	cfg, err := Load(path, CLIFlags{Issue: intPtr(42)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Issue != 42 {
+		t.Errorf("Issue = %d, want 42", cfg.Issue)
+	}
+}


### PR DESCRIPTION
Closes #2

## Summary

- Adds `internal/config/config.go` with `Load(path, flags)` that parses `godark.yaml` into a typed `Config` struct using `gopkg.in/yaml.v3`
- CLI flags (via `CLIFlags` struct with pointer fields) override config file values
- Missing config file is not an error when required values come from flags
- Validates that `repo` is present and that at least one of `milestone` or `issue` is set
- Sensible defaults for `max_retries` (2), `scenario_dir`, `review_dir`, `log_dir`

## Test plan

- [x] Full config parse — all YAML fields populate correctly
- [x] Flag override — `--repo` overrides YAML repo value
- [x] Missing file + sufficient flags — no error
- [x] Missing file + insufficient flags — descriptive error mentioning "repo"
- [x] Minimal config — defaults applied for optional fields
- [x] Invalid YAML — returns parse error
- [x] Missing milestone and issue — returns descriptive error
- [x] Issue alone suffices — no milestone needed if issue is set