### PR TITLE
feat: add GitHub issue fetching by milestone

### DIFF
--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Issue represents a GitHub issue with the fields needed for orchestration.
+type Issue struct {
+	Number   int
+	Title    string
+	Body     string
+	Labels   []string
+	Priority string // "p1", "p2", "p3", or "" for unlabeled
+}
+
+// ghIssue maps the JSON fields returned by gh issue list.
+type ghIssue struct {
+	Number int      `json:"number"`
+	Title  string   `json:"title"`
+	Body   string   `json:"body"`
+	Labels []label  `json:"labels"`
+}
+
+type label struct {
+	Name string `json:"name"`
+}
+
+// priorityRank returns a sort key for priority labels.
+// Lower rank = higher priority. Unlabeled issues sort last.
+var priorityRank = map[string]int{
+	"p1": 0,
+	"p2": 1,
+	"p3": 2,
+	"":   3,
+}
+
+// CommandRunner executes a command and returns its combined output.
+// Replaceable for testing.
+var CommandRunner = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// FetchMilestoneIssues returns open issues for the given milestone in the
+// given repo, sorted by priority label (p1 → p2 → p3 → unlabeled) then by
+// issue number ascending within each tier.
+func FetchMilestoneIssues(repo, milestone string) ([]Issue, error) {
+	out, err := CommandRunner("gh", "issue", "list",
+		"--repo", repo,
+		"--milestone", milestone,
+		"--state", "open",
+		"--json", "number,title,body,labels",
+		"--limit", "200",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh issue list: %w", err)
+	}
+
+	var raw []ghIssue
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parsing gh output: %w", err)
+	}
+
+	issues := make([]Issue, len(raw))
+	for i, r := range raw {
+		labels := make([]string, len(r.Labels))
+		for j, l := range r.Labels {
+			labels[j] = l.Name
+		}
+		issues[i] = Issue{
+			Number:   r.Number,
+			Title:    r.Title,
+			Body:     r.Body,
+			Labels:   labels,
+			Priority: extractPriority(labels),
+		}
+	}
+
+	sortIssues(issues)
+	return issues, nil
+}
+
+// extractPriority finds the first p1/p2/p3 label and returns it.
+// Returns "" if no priority label is found.
+func extractPriority(labels []string) string {
+	for _, l := range labels {
+		lower := strings.ToLower(l)
+		if lower == "p1" || lower == "p2" || lower == "p3" {
+			return lower
+		}
+	}
+	return ""
+}
+
+// sortIssues sorts by priority rank ascending, then by issue number ascending.
+func sortIssues(issues []Issue) {
+	sort.Slice(issues, func(i, j int) bool {
+		ri := priorityRank[issues[i].Priority]
+		rj := priorityRank[issues[j].Priority]
+		if ri != rj {
+			return ri < rj
+		}
+		return issues[i].Number < issues[j].Number
+	})
+}

--- a/internal/github/issues_test.go
+++ b/internal/github/issues_test.go
@@ -1,0 +1,126 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// fakeGH returns a CommandRunner that produces canned JSON output.
+func fakeGH(issues []ghIssue) func(string, ...string) ([]byte, error) {
+	return func(name string, args ...string) ([]byte, error) {
+		out, err := json.Marshal(issues)
+		if err != nil {
+			return nil, fmt.Errorf("test marshal: %w", err)
+		}
+		return out, nil
+	}
+}
+
+func TestPrioritySorting(t *testing.T) {
+	raw := []ghIssue{
+		{Number: 4, Title: "unlabeled", Labels: []label{}},
+		{Number: 3, Title: "p3", Labels: []label{{Name: "p3"}}},
+		{Number: 1, Title: "p1", Labels: []label{{Name: "p1"}}},
+		{Number: 2, Title: "p2", Labels: []label{{Name: "p2"}}},
+	}
+
+	orig := CommandRunner
+	CommandRunner = fakeGH(raw)
+	defer func() { CommandRunner = orig }()
+
+	issues, err := FetchMilestoneIssues("owner/repo", "v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"p1", "p2", "p3", ""}
+	for i, iss := range issues {
+		if iss.Priority != want[i] {
+			t.Errorf("index %d: got priority %q, want %q", i, iss.Priority, want[i])
+		}
+	}
+}
+
+func TestNumberSortingWithinTier(t *testing.T) {
+	raw := []ghIssue{
+		{Number: 10, Title: "second p1", Labels: []label{{Name: "p1"}}},
+		{Number: 5, Title: "first p1", Labels: []label{{Name: "p1"}}},
+		{Number: 20, Title: "p2", Labels: []label{{Name: "p2"}}},
+	}
+
+	orig := CommandRunner
+	CommandRunner = fakeGH(raw)
+	defer func() { CommandRunner = orig }()
+
+	issues, err := FetchMilestoneIssues("owner/repo", "v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if issues[0].Number != 5 || issues[1].Number != 10 {
+		t.Errorf("p1 issues not sorted by number: got %d, %d", issues[0].Number, issues[1].Number)
+	}
+	if issues[2].Number != 20 {
+		t.Errorf("expected p2 issue last, got number %d", issues[2].Number)
+	}
+}
+
+func TestBodyIncluded(t *testing.T) {
+	raw := []ghIssue{
+		{Number: 1, Title: "has body", Body: "This is the full body text.", Labels: []label{}},
+	}
+
+	orig := CommandRunner
+	CommandRunner = fakeGH(raw)
+	defer func() { CommandRunner = orig }()
+
+	issues, err := FetchMilestoneIssues("owner/repo", "v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if issues[0].Body != "This is the full body text." {
+		t.Errorf("body not preserved: got %q", issues[0].Body)
+	}
+}
+
+func TestLabelParsing(t *testing.T) {
+	raw := []ghIssue{
+		{Number: 1, Title: "multi-label", Labels: []label{{Name: "p1"}, {Name: "bug"}, {Name: "phase-1"}}},
+	}
+
+	orig := CommandRunner
+	CommandRunner = fakeGH(raw)
+	defer func() { CommandRunner = orig }()
+
+	issues, err := FetchMilestoneIssues("owner/repo", "v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(issues[0].Labels) != 3 {
+		t.Fatalf("expected 3 labels, got %d", len(issues[0].Labels))
+	}
+	want := []string{"p1", "bug", "phase-1"}
+	for i, l := range issues[0].Labels {
+		if l != want[i] {
+			t.Errorf("label %d: got %q, want %q", i, l, want[i])
+		}
+	}
+}
+
+func TestEmptyMilestone(t *testing.T) {
+	orig := CommandRunner
+	CommandRunner = fakeGH([]ghIssue{})
+	defer func() { CommandRunner = orig }()
+
+	issues, err := FetchMilestoneIssues("owner/repo", "empty-milestone")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(issues) != 0 {
+		t.Errorf("expected empty slice, got %d issues", len(issues))
+	}
+}


### PR DESCRIPTION
Closes #3

## Summary

- Adds `internal/github` package with `FetchMilestoneIssues(repo, milestone)` function
- Shells out to `gh issue list` with JSON output, parses into typed `Issue` structs
- Sorts results by priority label (p1 → p2 → p3 → unlabeled), then by issue number ascending
- Uses a replaceable `CommandRunner` var for testability without hitting the real `gh` CLI

## Test plan

- [x] `go test ./internal/github/` passes (5 tests)
- [x] Priority sorting: mixed p1/p2/p3/unlabeled labels sort correctly
- [x] Number sorting within tier: two p1 issues sort by number ascending
- [x] Body included: returned Issue structs include full body text
- [x] Label parsing: labels returned as string slices
- [x] Empty milestone: returns empty slice, no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)