### PR TITLE
feat: add structured logging foundation

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,65 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// NewLogger creates a logger that writes structured JSON to a file in logDir
+// and human-readable text to stdout. The log file is named run-YYYYMMDD-HHMMSS.json.
+func NewLogger(logDir string) (*slog.Logger, error) {
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create log directory: %w", err)
+	}
+
+	filename := fmt.Sprintf("run-%s.json", timeNow().Format("20060102-150405"))
+	path := filepath.Join(logDir, filename)
+
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, fmt.Errorf("create log file: %w", err)
+	}
+
+	jsonHandler := slog.NewJSONHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug})
+	textHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	return slog.New(&multiHandler{json: jsonHandler, text: textHandler}), nil
+}
+
+// timeNow is a variable so tests can override it.
+var timeNow = time.Now
+
+// multiHandler fans out log records to multiple handlers.
+type multiHandler struct {
+	json slog.Handler
+	text slog.Handler
+}
+
+func (h *multiHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.json.Enabled(ctx, level) || h.text.Enabled(ctx, level)
+}
+
+func (h *multiHandler) Handle(ctx context.Context, r slog.Record) error {
+	if err := h.json.Handle(ctx, r); err != nil {
+		return err
+	}
+	return h.text.Handle(ctx, r)
+}
+
+func (h *multiHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &multiHandler{
+		json: h.json.WithAttrs(attrs),
+		text: h.text.WithAttrs(attrs),
+	}
+}
+
+func (h *multiHandler) WithGroup(name string) slog.Handler {
+	return &multiHandler{
+		json: h.json.WithGroup(name),
+		text: h.text.WithGroup(name),
+	}
+}

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,134 @@
+package logging
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewLogger_CreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "logs")
+	_, err := NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Fatal("expected log directory to be created")
+	}
+}
+
+func TestNewLogger_FileNaming(t *testing.T) {
+	dir := t.TempDir()
+	fixedTime := time.Date(2025, 6, 15, 14, 30, 45, 0, time.UTC)
+	timeNow = func() time.Time { return fixedTime }
+	t.Cleanup(func() { timeNow = time.Now })
+
+	_, err := NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+
+	expected := "run-20250615-143045.json"
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 || entries[0].Name() != expected {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Fatalf("expected file %q, got %v", expected, names)
+	}
+}
+
+func TestLogger_JSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+
+	logger.Info("test message")
+
+	entries, _ := os.ReadDir(dir)
+	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("log line is not valid JSON: %v\nraw: %s", err, data)
+	}
+
+	if _, ok := record["time"]; !ok {
+		t.Error("expected 'time' field in JSON output")
+	}
+	if _, ok := record["level"]; !ok {
+		t.Error("expected 'level' field in JSON output")
+	}
+	if _, ok := record["msg"]; !ok {
+		t.Error("expected 'msg' field in JSON output")
+	}
+	if record["msg"] != "test message" {
+		t.Errorf("expected msg 'test message', got %q", record["msg"])
+	}
+}
+
+func TestLogger_StructuredFields(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+
+	child := logger.With("component", "orchestrator", "issue_number", 5)
+	child.Info("processing issue")
+
+	entries, _ := os.ReadDir(dir)
+	data, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("log line is not valid JSON: %v\nraw: %s", err, data)
+	}
+
+	if record["component"] != "orchestrator" {
+		t.Errorf("expected component 'orchestrator', got %v", record["component"])
+	}
+	if record["issue_number"] != float64(5) {
+		t.Errorf("expected issue_number 5, got %v", record["issue_number"])
+	}
+}
+
+func TestLogger_StdoutOutput(t *testing.T) {
+	dir := t.TempDir()
+
+	// Capture stdout
+	origStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	logger, err := NewLogger(dir)
+	if err != nil {
+		w.Close()
+		os.Stdout = origStdout
+		t.Fatalf("NewLogger() error = %v", err)
+	}
+
+	logger.Info("hello stdout")
+	w.Close()
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	output := string(buf[:n])
+
+	if !strings.Contains(output, "hello stdout") {
+		t.Errorf("expected stdout to contain 'hello stdout', got: %s", output)
+	}
+}


### PR DESCRIPTION
Closes #5

## Summary

- Adds `internal/logging` package with `NewLogger(logDir string)` that creates a `*slog.Logger` with dual output: structured JSON lines to a timestamped file (`run-YYYYMMDD-HHMMSS.json`) and human-readable text to stdout
- Uses `log/slog` multi-handler pattern — supports `.With()` for structured fields like `component` and `issue_number`
- Creates log directory automatically if it doesn't exist

## Test plan

- [x] `go test ./internal/logging/` — 5 tests covering JSON output validity, stdout output, file naming, structured fields, and directory creation
- [x] `go test ./...` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)