### PR TITLE
feat: add orchestration loop and dry-run mode

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/logging"
+	"github.com/phs/dark-factory/internal/orchestrator"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +15,39 @@ var runCmd = &cobra.Command{
 	Long: `Fetch issues from a GitHub milestone, resolve dependencies, and process
 each unblocked issue through the implement → review → merge loop.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("run: not implemented yet (Phase 2)")
-		return nil
+		configPath, _ := cmd.Flags().GetString("config")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		flags := config.CLIFlags{Config: configPath}
+
+		if cmd.Flags().Changed("repo") {
+			v, _ := cmd.Flags().GetString("repo")
+			flags.Repo = &v
+		}
+		if cmd.Flags().Changed("milestone") {
+			v, _ := cmd.Flags().GetString("milestone")
+			flags.Milestone = &v
+		}
+		if cmd.Flags().Changed("issue") {
+			v, _ := cmd.Flags().GetInt("issue")
+			flags.Issue = &v
+		}
+		if cmd.Flags().Changed("max-retries") {
+			v, _ := cmd.Flags().GetInt("max-retries")
+			flags.MaxRetries = &v
+		}
+
+		cfg, err := config.Load(configPath, flags)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+
+		logger, err := logging.NewLogger(cfg.LogDir)
+		if err != nil {
+			return fmt.Errorf("creating logger: %w", err)
+		}
+
+		return orchestrator.Run(cfg, logger, dryRun)
 	},
 }
 

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -95,6 +95,33 @@ func extractPriority(labels []string) string {
 	return ""
 }
 
+// FetchClosedIssueNumbers returns the issue numbers of all closed issues in
+// the given repo. This is used to build the closed-set for dependency resolution.
+func FetchClosedIssueNumbers(repo string) ([]int, error) {
+	out, err := CommandRunner("gh", "issue", "list",
+		"--repo", repo,
+		"--state", "closed",
+		"--json", "number",
+		"--limit", "500",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh issue list (closed): %w", err)
+	}
+
+	var raw []struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parsing gh output: %w", err)
+	}
+
+	numbers := make([]int, len(raw))
+	for i, r := range raw {
+		numbers[i] = r.Number
+	}
+	return numbers, nil
+}
+
 // sortIssues sorts by priority rank ascending, then by issue number ascending.
 func sortIssues(issues []Issue) {
 	sort.Slice(issues, func(i, j int) bool {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1,0 +1,154 @@
+package orchestrator
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/deps"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// Run is the main entry point for the orchestration loop.
+// It fetches issues, resolves dependencies, and either prints the execution
+// plan (dry-run) or iterates through processable issues.
+func Run(cfg *config.Config, logger *slog.Logger, dryRun bool) error {
+	logger.Info("starting orchestration",
+		"repo", cfg.Repo,
+		"milestone", cfg.Milestone,
+		"dry_run", dryRun,
+	)
+
+	// Step 1: Fetch open issues for the milestone.
+	issues, err := github.FetchMilestoneIssues(cfg.Repo, cfg.Milestone)
+	if err != nil {
+		return fmt.Errorf("fetching milestone issues: %w", err)
+	}
+
+	if len(issues) == 0 {
+		logger.Info("no issues found", "milestone", cfg.Milestone)
+		fmt.Println("No issues found in milestone.")
+		return nil
+	}
+
+	logger.Info("fetched issues", "count", len(issues))
+
+	// Step 2: Fetch closed issues for dependency resolution.
+	closedNumbers, err := github.FetchClosedIssueNumbers(cfg.Repo)
+	if err != nil {
+		return fmt.Errorf("fetching closed issues: %w", err)
+	}
+	closedSet := deps.ClosedSet(closedNumbers)
+
+	// Step 3: Categorize issues into blocked and processable.
+	var blocked []blockedIssue
+	var processable []github.Issue
+
+	for _, issue := range issues {
+		issueDeps := deps.ParseDeps(issue.Body)
+		openDeps := openDependencies(issueDeps, closedSet)
+		if len(openDeps) > 0 {
+			blocked = append(blocked, blockedIssue{Issue: issue, BlockedBy: openDeps})
+		} else {
+			processable = append(processable, issue)
+		}
+	}
+
+	logger.Info("dependency resolution complete",
+		"total", len(issues),
+		"blocked", len(blocked),
+		"processable", len(processable),
+	)
+
+	// Step 4: Print or process.
+	if dryRun {
+		printDryRun(processable, blocked, len(issues))
+	} else {
+		processIssues(processable, blocked, len(issues), logger)
+	}
+
+	return nil
+}
+
+// blockedIssue pairs an issue with its open (unresolved) dependency numbers.
+type blockedIssue struct {
+	Issue     github.Issue
+	BlockedBy []int
+}
+
+// openDependencies returns the subset of dep numbers that are not in closedSet.
+func openDependencies(depNumbers []int, closedSet map[int]bool) []int {
+	var open []int
+	for _, d := range depNumbers {
+		if !closedSet[d] {
+			open = append(open, d)
+		}
+	}
+	return open
+}
+
+// printDryRun outputs the execution plan without taking any action.
+func printDryRun(processable []github.Issue, blocked []blockedIssue, total int) {
+	fmt.Println("=== Execution Plan (dry-run) ===")
+	fmt.Println()
+
+	if len(processable) > 0 {
+		fmt.Println("Processable issues:")
+		for _, issue := range processable {
+			pri := issue.Priority
+			if pri == "" {
+				pri = "none"
+			}
+			fmt.Printf("  #%d %s [priority: %s]\n", issue.Number, issue.Title, pri)
+		}
+		fmt.Println()
+	}
+
+	if len(blocked) > 0 {
+		fmt.Println("Blocked issues:")
+		for _, bi := range blocked {
+			fmt.Printf("  #%d %s (blocked by: %s)\n", bi.Issue.Number, bi.Issue.Title, formatIssueRefs(bi.BlockedBy))
+		}
+		fmt.Println()
+	}
+
+	printSummary(total, len(blocked), len(processable))
+}
+
+// processIssues iterates processable issues and logs placeholder messages.
+func processIssues(processable []github.Issue, blocked []blockedIssue, total int, logger *slog.Logger) {
+	if len(processable) == 0 {
+		fmt.Println("All issues are blocked — nothing to process.")
+		printSummary(total, len(blocked), 0)
+		return
+	}
+
+	for _, issue := range processable {
+		logger.Info("would process issue (agent execution not implemented yet)",
+			"issue_number", issue.Number,
+			"title", issue.Title,
+			"priority", issue.Priority,
+		)
+		fmt.Printf("Processing #%d %s — not implemented yet (Phase 2)\n", issue.Number, issue.Title)
+	}
+	fmt.Println()
+
+	printSummary(total, len(blocked), len(processable))
+}
+
+// printSummary outputs the final count line.
+func printSummary(total, blocked, processable int) {
+	fmt.Printf("Summary: %d total, %d blocked, %d processable\n", total, blocked, processable)
+}
+
+// formatIssueRefs formats a slice of issue numbers as "#1, #2, #3".
+func formatIssueRefs(numbers []int) string {
+	s := ""
+	for i, n := range numbers {
+		if i > 0 {
+			s += ", "
+		}
+		s += fmt.Sprintf("#%d", n)
+	}
+	return s
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,0 +1,319 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/logging"
+)
+
+// ghIssue mirrors the JSON shape for test fixtures.
+type ghIssue struct {
+	Number int       `json:"number"`
+	Title  string    `json:"title"`
+	Body   string    `json:"body"`
+	Labels []ghLabel `json:"labels"`
+}
+
+type ghLabel struct {
+	Name string `json:"name"`
+}
+
+type ghClosedIssue struct {
+	Number int `json:"number"`
+}
+
+// setupFakeGH installs a fake CommandRunner that returns different JSON
+// depending on whether the caller asks for open or closed issues.
+func setupFakeGH(t *testing.T, openIssues []ghIssue, closedNumbers []int) {
+	t.Helper()
+
+	closedIssues := make([]ghClosedIssue, len(closedNumbers))
+	for i, n := range closedNumbers {
+		closedIssues[i] = ghClosedIssue{Number: n}
+	}
+
+	orig := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = orig })
+
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		// Determine if this is a closed-issue query.
+		for i, a := range args {
+			if a == "--state" && i+1 < len(args) && args[i+1] == "closed" {
+				return json.Marshal(closedIssues)
+			}
+		}
+		return json.Marshal(openIssues)
+	}
+}
+
+func testConfig() *config.Config {
+	return &config.Config{
+		Repo:      "owner/repo",
+		Milestone: "Phase 1",
+		LogDir:    "",
+	}
+}
+
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	dir := t.TempDir()
+	logger, err := logging.NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	return logger
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	origStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = origStdout
+
+	buf := make([]byte, 65536)
+	n, _ := r.Read(buf)
+	return string(buf[:n])
+}
+
+func TestDryRun_ListsIssuesInOrder(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 3, Title: "third", Labels: []ghLabel{{Name: "p2"}}},
+		{Number: 1, Title: "first", Labels: []ghLabel{{Name: "p1"}}},
+		{Number: 2, Title: "second", Labels: []ghLabel{{Name: "p1"}}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	output := captureStdout(t, func() {
+		err := Run(testConfig(), testLogger(t), true)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	// Verify all issues appear and in priority order (p1 first).
+	idx1 := strings.Index(output, "#1 first")
+	idx2 := strings.Index(output, "#2 second")
+	idx3 := strings.Index(output, "#3 third")
+	if idx1 == -1 || idx2 == -1 || idx3 == -1 {
+		t.Fatalf("expected all issues in output, got:\n%s", output)
+	}
+	if idx1 > idx2 || idx2 > idx3 {
+		t.Errorf("issues not in priority/number order:\n%s", output)
+	}
+}
+
+func TestDryRun_BlockedIssuesShownSeparately(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "unblocked", Labels: []ghLabel{}},
+		{Number: 2, Title: "blocked one", Body: "**Blocked by**: #99", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil) // #99 not closed
+
+	output := captureStdout(t, func() {
+		err := Run(testConfig(), testLogger(t), true)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "Processable issues:") {
+		t.Error("expected 'Processable issues:' section")
+	}
+	if !strings.Contains(output, "Blocked issues:") {
+		t.Error("expected 'Blocked issues:' section")
+	}
+	if !strings.Contains(output, "#2 blocked one (blocked by: #99)") {
+		t.Errorf("expected blocked issue with reason, got:\n%s", output)
+	}
+}
+
+func TestDryRun_SummaryCounts(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "processable", Labels: []ghLabel{}},
+		{Number: 2, Title: "blocked", Body: "**Blocked by**: #99", Labels: []ghLabel{}},
+		{Number: 3, Title: "also processable", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	output := captureStdout(t, func() {
+		err := Run(testConfig(), testLogger(t), true)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	expected := "Summary: 3 total, 1 blocked, 2 processable"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected summary %q, got:\n%s", expected, output)
+	}
+}
+
+func TestDryRun_LogFileCreated(t *testing.T) {
+	dir := t.TempDir()
+	setupFakeGH(t, []ghIssue{
+		{Number: 1, Title: "test", Labels: []ghLabel{}},
+	}, nil)
+
+	logger, err := logging.NewLogger(dir)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+
+	captureStdout(t, func() {
+		if err := Run(testConfig(), logger, true); err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	entries, _ := os.ReadDir(dir)
+	if len(entries) == 0 {
+		t.Fatal("expected log file to be created")
+	}
+	if !strings.HasSuffix(entries[0].Name(), ".json") {
+		t.Errorf("expected JSON log file, got %s", entries[0].Name())
+	}
+}
+
+func TestEmptyMilestone(t *testing.T) {
+	setupFakeGH(t, []ghIssue{}, nil)
+
+	output := captureStdout(t, func() {
+		err := Run(testConfig(), testLogger(t), true)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "No issues found") {
+		t.Errorf("expected 'No issues found' message, got:\n%s", output)
+	}
+}
+
+func TestAllBlocked(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "blocked a", Body: "**Blocked by**: #90", Labels: []ghLabel{}},
+		{Number: 2, Title: "blocked b", Body: "**Blocked by**: #91", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	output := captureStdout(t, func() {
+		err := Run(testConfig(), testLogger(t), false)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "All issues are blocked") {
+		t.Errorf("expected 'All issues are blocked' message, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Summary: 2 total, 2 blocked, 0 processable") {
+		t.Errorf("expected correct summary, got:\n%s", output)
+	}
+}
+
+func TestNormalMode_PlaceholderMessages(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "first task", Labels: []ghLabel{{Name: "p1"}}},
+		{Number: 2, Title: "second task", Labels: []ghLabel{{Name: "p2"}}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	output := captureStdout(t, func() {
+		err := Run(testConfig(), testLogger(t), false)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "#1 first task") {
+		t.Error("expected issue #1 in output")
+	}
+	if !strings.Contains(output, "#2 second task") {
+		t.Error("expected issue #2 in output")
+	}
+	if !strings.Contains(output, "not implemented yet") {
+		t.Error("expected 'not implemented yet' placeholder")
+	}
+}
+
+func TestDryRun_ClosedDepsUnblock(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 5, Title: "depends on closed", Body: "**Blocked by**: #3", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, []int{3}) // #3 is closed
+
+	output := captureStdout(t, func() {
+		err := Run(testConfig(), testLogger(t), true)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	if strings.Contains(output, "Blocked issues:") {
+		t.Error("expected no blocked issues when deps are closed")
+	}
+	if !strings.Contains(output, "Summary: 1 total, 0 blocked, 1 processable") {
+		t.Errorf("expected all issues processable, got:\n%s", output)
+	}
+}
+
+func TestFormatIssueRefs(t *testing.T) {
+	tests := []struct {
+		input []int
+		want  string
+	}{
+		{[]int{1}, "#1"},
+		{[]int{1, 2, 3}, "#1, #2, #3"},
+	}
+	for _, tt := range tests {
+		got := formatIssueRefs(tt.input)
+		if got != tt.want {
+			t.Errorf("formatIssueRefs(%v) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestOpenDependencies(t *testing.T) {
+	closed := map[int]bool{1: true, 3: true}
+	open := openDependencies([]int{1, 2, 3, 4}, closed)
+	if len(open) != 2 || open[0] != 2 || open[1] != 4 {
+		t.Errorf("openDependencies = %v, want [2 4]", open)
+	}
+}
+
+func TestDryRun_PriorityDisplayed(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "high pri", Labels: []ghLabel{{Name: "p1"}}},
+		{Number: 2, Title: "no pri", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	output := captureStdout(t, func() {
+		err := Run(testConfig(), testLogger(t), true)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "[priority: p1]") {
+		t.Error("expected priority p1 to be displayed")
+	}
+	if !strings.Contains(output, "[priority: none]") {
+		t.Error("expected priority 'none' for unlabeled issues")
+	}
+}
+
+// Suppress unused import warnings.
+var _ = fmt.Sprintf


### PR DESCRIPTION
Closes #6

## Summary
- Add `internal/orchestrator` package with `Run()` entry point that wires together issue fetching, dependency resolution, and structured logging
- Wire the `run` subcommand to load config, create a logger, and invoke the orchestrator
- Add `FetchClosedIssueNumbers()` to the github package for dependency resolution
- Dry-run mode prints execution plan with processable/blocked issues and summary counts
- Normal mode iterates processable issues with placeholder messages (agent execution in Phase 2)

## Test plan
- [x] `go test ./internal/orchestrator/` — 11 tests covering:
  - Dry-run output with correct priority/number ordering
  - Blocked issues shown separately with blocking reasons
  - Summary counts match actual issue counts
  - Log file creation verified
  - Empty milestone prints "no issues found" and exits cleanly
  - All-blocked scenario prints warning and correct summary
  - Normal mode placeholder messages
  - Closed dependencies correctly unblock issues
  - Priority labels displayed in output
- [x] `go test ./...` — all existing tests still pass
- [x] `go build ./...` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)