### PR TITLE
Phase 2 planning breakdown and scenario specs

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,120 @@
+# Dark Factory — Roadmap
+
+> A Go CLI that orchestrates autonomous AI agents to implement GitHub issues,
+> review their own work, and merge — without human intervention.
+
+---
+
+## Phase 1: Skeleton + Orchestration ✅
+
+**Goal**: `godark run --milestone "Phase 1" --repo owner/repo --dry-run` works
+end-to-end. Fetches issues, resolves dependencies, sorts by priority, and
+prints the execution plan. No agent execution in this phase.
+
+**Milestone**: `Phase 1` | **Label**: `phase-1`
+
+- Project scaffold and CLI skeleton (Cobra, subcommand stubs)
+- YAML config parsing with CLI flag overrides
+- GitHub issue fetching with priority sorting (p1 → p2 → p3 → unlabeled)
+- Dependency resolution from issue bodies (`Blocked by`, `Depends on`)
+- Structured logging (JSON file + human-readable stdout)
+- Orchestration loop with dry-run mode
+- CLAUDE.md and scenario specs for Phase 2 validation
+
+**Issues**: #1–#7 (all closed)
+
+---
+
+## Phase 2: Quality & Vetting
+
+**Goal**: The `godark vet` subcommand validates that roadmap docs and GitHub
+issues are clear, unambiguous, and fully actionable by agents. Built early so
+it can be used to validate issues for all subsequent phases.
+
+**Milestone**: `Phase 2` | **Label**: `phase-2`
+
+- Vet command scaffold and validation framework (Finding types, report format)
+- Issue structure validation (`godark vet issues`)
+- Scenario spec validation (`godark vet scenarios`)
+- Roadmap validation (`godark vet roadmap`)
+
+**Issues**: #14–#17
+
+---
+
+## Phase 3: Docker Sandbox
+
+**Goal**: Run agents in isolated containers for safety. The user's working
+directory is never touched — all agent work happens in a container. Required
+before agent execution so that `--dangerously-skip-permissions` runs in a
+confined environment.
+
+**Milestone**: `Phase 3` | **Label**: `phase-3`
+
+- Dockerfile generation and image management
+- Container lifecycle: build image, run agent, capture output, cleanup
+- Auth forwarding: `ANTHROPIC_API_KEY`, `GH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`
+- Pre-configured `.claude.json` for headless operation (skip onboarding, trust dialogs)
+- Non-root user (Claude Code refuses `--dangerously-skip-permissions` as root)
+- Repo cloning or worktree inside container (not host volume mount)
+- `--no-sandbox` flag to run agents directly on the host
+
+---
+
+## Phase 4: Agent Execution
+
+**Goal**: `godark run --milestone "M" --repo owner/repo` autonomously implements,
+reviews, and merges GitHub issues using Claude Code agents inside Docker
+containers. This is the first phase whose issues are vetted by `godark vet`
+before implementation begins.
+
+**Milestone**: `Phase 4` | **Label**: `phase-4`
+
+### Agent launcher
+- Invoke `claude -p --dangerously-skip-permissions` with prompt templates
+- Load prompt templates from config-specified file paths
+- Capture agent stdout/stderr for log parsing
+- Execute agents inside Docker sandbox (from Phase 3)
+
+### Implementer agent (Agent 1)
+- **Fresh mode**: create feature branch, implement issue, write unit tests, open PR
+- **Retry mode**: check out existing PR, read review comments, fix issues, push
+
+### Reviewer agent (Agent 2)
+- Check out PR, read matching scenario specs
+- Generate ephemeral integration tests in `tests/review/`
+- Run all tests, approve or request changes
+- Clean up `tests/review/` before finishing
+- Output `REVIEW_RESULT=APPROVED` or `REVIEW_RESULT=CHANGES_REQUESTED`
+
+### Guard rails (script-level, not prompt-level)
+- PR existence check after implementer finishes
+- `Closes #N` auto-append if missing from PR body
+- Protected path drift detection (reject PRs touching protected files)
+- Scenario spec presence warning (comment on PR if no spec exists)
+- `REVIEW_RESULT` sentinel parsing from reviewer output
+- golangci-lint as additional quality gate (configurable lint command in `godark.yaml`)
+
+### Orchestration
+- Review/retry loop (max N retries from config)
+- Merge approved PRs (squash + delete branch) or escalate (label `needs-human-review`)
+- Baseline commit recording before each issue for rollback reference
+- `git pull --rebase origin main` after each merge
+- Single-issue mode (`--issue N`)
+- Summary stats at end (implemented, skipped, failed)
+
+---
+
+## Phase 5: Run Review Dashboard
+
+**Goal**: `godark status` serves a local web UI for reviewing dev-loop runs,
+making it easy for humans to spot-check agent work.
+
+**Milestone**: `Phase 5` | **Label**: `phase-5`
+
+- Local web server serving a review dashboard
+- Homepage: list of dev-loop runs with summary stats (issues processed, pass/fail counts)
+- Run detail view: per-issue outcomes (implemented, skipped, failed, retry count)
+- GitHub diff links for each PR (easy human spot-checking)
+- Manual test punchlist generation at end of each dev-loop run
+- Log viewer (parsed JSON structured logs with filtering)

--- a/docs/planning/phase-2-quality-and-vetting.md
+++ b/docs/planning/phase-2-quality-and-vetting.md
@@ -1,0 +1,200 @@
+# Phase 2: Quality & Vetting
+
+> **Goal:** `godark vet issues`, `godark vet scenarios`, and `godark vet roadmap`
+> validate that GitHub issues, scenario specs, and planning docs are clear,
+> unambiguous, and fully actionable by agents.
+>
+> Built early so it can vet issues for all subsequent phases.
+
+## Milestone
+
+`Phase 2`
+
+---
+
+## Issue 14: Vet command scaffold and validation framework
+
+### Description
+
+Replace the existing `vet` stub with a real command that dispatches to
+subcommands: `godark vet issues`, `godark vet scenarios`, `godark vet roadmap`.
+Define the shared types that all vet subcommands will use: validation findings
+(severity, message, location) and a report output format.
+
+### Key constraints
+
+- Replace the stub in `internal/cmd/vet.go` — do not create a separate file for
+  the parent command
+- Subcommand files: `internal/cmd/vet_issues.go`, `internal/cmd/vet_scenarios.go`,
+  `internal/cmd/vet_roadmap.go`
+- Shared types in a new package: `internal/vet/findings.go`
+- Finding struct: `Severity` (error, warning, info), `Message`, `Location` (file
+  path or issue number)
+- Report: list of findings, summary counts by severity, exit code 1 if any errors
+- Reuse `internal/github/` for issue fetching (same `CommandRunner` pattern)
+- `--repo` and `--milestone` flags (inherited from root or passed explicitly)
+- Human-readable table output to stdout, optional `--json` flag for machine output
+
+### Acceptance criteria
+
+- [ ] `godark vet --help` shows subcommands: issues, scenarios, roadmap
+- [ ] `godark vet issues --help` shows flags with descriptions
+- [ ] `godark vet scenarios --help` shows flags with descriptions
+- [ ] `godark vet roadmap --help` shows flags with descriptions
+- [ ] `Finding` struct exists with Severity, Message, Location fields
+- [ ] Report output includes summary counts (errors, warnings, info)
+- [ ] Exit code is 1 when any finding has error severity, 0 otherwise
+- [ ] `go test ./internal/vet/` passes
+- [ ] `go test ./internal/cmd/` passes
+
+### Test cases
+
+- **Help output**: `godark vet --help` lists issues, scenarios, roadmap subcommands
+- **Finding struct**: Creating a Finding with error severity, message, and location populates all fields
+- **Report with errors**: A report containing error findings returns exit code 1
+- **Report without errors**: A report with only warnings returns exit code 0
+- **Empty report**: No findings returns exit code 0 with "no issues found" message
+- **JSON output**: `--json` flag produces valid JSON with findings array and summary
+
+---
+
+## Issue 15: Issue structure validation (`vet issues`)
+
+**Blocked by**: #14 (Vet command scaffold)
+
+### Description
+
+Implement the `godark vet issues` subcommand. It fetches issues from a GitHub
+milestone and validates that each issue has the required structure for agent
+consumption: description, acceptance criteria, test cases, and well-formed
+dependency notation.
+
+### Key constraints
+
+- Package: `internal/vet/issues.go`
+- Fetch issues using `internal/github/` (same `CommandRunner` pattern)
+- Required sections in issue body: `## Description`, `## Acceptance criteria`,
+  `## Test cases`
+- Acceptance criteria must contain at least one `- [ ]` checkbox item
+- Test cases must contain at least one `- **Name**:` entry
+- Validate `Blocked by` / `Depends on` notation: referenced issues must exist,
+  format must match `**Blocked by**: #N` or `Depends on: #N, #M`
+- Check every issue has the milestone's phase label (e.g., `phase-2`)
+- Each violation produces a Finding (error or warning depending on severity)
+
+### Acceptance criteria
+
+- [ ] Issues missing `## Acceptance criteria` section produce an error finding
+- [ ] Issues missing `## Test cases` section produce an error finding
+- [ ] Issues with empty acceptance criteria (no checkboxes) produce an error finding
+- [ ] Issues with empty test cases (no entries) produce an error finding
+- [ ] Malformed `Blocked by` notation produces a warning finding
+- [ ] References to non-existent issues produce a warning finding
+- [ ] Issues missing the phase label produce a warning finding
+- [ ] All findings include the issue number as location
+- [ ] `go test ./internal/vet/` passes
+
+### Test cases
+
+- **Complete issue passes**: Issue with all required sections and valid notation produces no error findings
+- **Missing acceptance criteria**: Issue body without `## Acceptance criteria` → error finding
+- **Missing test cases**: Issue body without `## Test cases` → error finding
+- **Empty acceptance criteria**: Section exists but contains no `- [ ]` items → error finding
+- **Empty test cases**: Section exists but contains no `- **Name**:` entries → error finding
+- **Malformed blocker**: `Blocked by #1` (missing colon) → warning finding
+- **Non-existent blocker reference**: `**Blocked by**: #999` where #999 does not exist → warning finding
+- **Missing phase label**: Issue in Phase 2 milestone without `phase-2` label → warning finding
+- **Multiple issues**: Validates all issues in milestone, not just the first one
+
+---
+
+## Issue 16: Scenario spec validation (`vet scenarios`)
+
+**Blocked by**: #14 (Vet command scaffold)
+
+### Description
+
+Implement the `godark vet scenarios` subcommand. It reads scenario spec files
+from `tests/scenarios/`, validates their format, and cross-references them with
+GitHub issues to ensure every issue has spec coverage.
+
+### Key constraints
+
+- Package: `internal/vet/scenarios.go`
+- Read `*.md` files from the scenario directory (config `scenario_dir`, default
+  `tests/scenarios/`)
+- Required format: `# Scenario:` title, `Relates to: Issue #N`, `## Setup`
+  section, `## Cases` section
+- Each case (level-3 heading under `## Cases`) must have at least one bullet
+  point (expected outcome)
+- Cross-reference: fetch milestone issues from GitHub, verify every issue has at
+  least one spec with `Relates to: Issue #N`
+- Verify `Relates to:` references point to real GitHub issues
+- Flag issues with no scenario spec coverage as warnings
+
+### Acceptance criteria
+
+- [ ] Spec files missing `## Setup` section produce an error finding
+- [ ] Spec files missing `## Cases` section produce an error finding
+- [ ] Cases with no expected outcomes (no bullet points) produce an error finding
+- [ ] Specs with missing or malformed `Relates to:` line produce an error finding
+- [ ] `Relates to:` references to non-existent issues produce a warning finding
+- [ ] Issues in milestone with no matching scenario spec produce a warning finding
+- [ ] Valid spec files produce no findings
+- [ ] All findings include the file path as location
+- [ ] `go test ./internal/vet/` passes
+
+### Test cases
+
+- **Valid spec passes**: A correctly formatted spec with valid `Relates to:` produces no findings
+- **Missing Setup section**: Spec without `## Setup` → error finding with file path
+- **Missing Cases section**: Spec without `## Cases` → error finding with file path
+- **Case without outcomes**: A `### Case` heading followed by no bullet points → error finding
+- **Missing Relates to**: Spec with no `Relates to:` line → error finding
+- **Malformed Relates to**: `Relates to: 5` (missing `Issue #` prefix) → error finding
+- **Non-existent issue reference**: `Relates to: Issue #999` where #999 does not exist → warning finding
+- **Issue without spec coverage**: Issue in milestone has no matching `Relates to: Issue #N` → warning finding
+- **Multiple relates-to lines**: Spec with `Relates to: Issue #14` and `Relates to: Issue #15` covers both issues
+
+---
+
+## Issue 17: Roadmap validation (`vet roadmap`)
+
+**Blocked by**: #14 (Vet command scaffold)
+
+### Description
+
+Implement the `godark vet roadmap` subcommand. It parses planning docs in
+`docs/planning/` and cross-references them with GitHub to verify that issue
+references are valid, phase labels match milestone names, and no issues are
+orphaned.
+
+### Key constraints
+
+- Package: `internal/vet/roadmap.go`
+- Scan `docs/planning/*.md` for issue references (patterns like `## Issue N:`,
+  `#N`, `Blocked by: #N`)
+- Cross-reference with GitHub: every issue mentioned must exist, every issue in
+  the milestone must appear in a planning doc
+- Validate phase labels match milestone names (e.g., issues with `phase-2` label
+  must be in `Phase 2` milestone)
+- Flag orphaned issues: in milestone but not mentioned in any planning doc
+- Flag phantom issues: referenced in planning doc but do not exist on GitHub
+
+### Acceptance criteria
+
+- [ ] Planning docs referencing non-existent issues produce a warning finding
+- [ ] Issues in milestone but not in any planning doc produce a warning finding
+- [ ] Issues with phase label not matching their milestone produce an error finding
+- [ ] Valid planning docs with correct cross-references produce no findings
+- [ ] All findings include the file path or issue number as location
+- [ ] `go test ./internal/vet/` passes
+
+### Test cases
+
+- **Valid planning doc passes**: Doc with correct issue references that all exist → no findings
+- **Phantom issue reference**: Planning doc mentions `## Issue 99:` but #99 does not exist → warning finding
+- **Orphaned issue**: Issue #5 is in Phase 2 milestone but not mentioned in any planning doc → warning finding
+- **Label-milestone mismatch**: Issue has `phase-1` label but is in `Phase 2` milestone → error finding
+- **Multiple planning docs**: Issues can be referenced across different planning docs
+- **No planning docs**: Empty `docs/planning/` directory → warning finding

--- a/tests/scenarios/vet-command-scaffold.md
+++ b/tests/scenarios/vet-command-scaffold.md
@@ -1,0 +1,50 @@
+# Scenario: Vet command scaffold and validation framework
+
+Relates to: Issue #14
+
+## Setup
+- The CLI binary is built or the `cmd` package is imported directly
+- The vet package (`internal/vet`) is imported for findings types
+- No external services or network access required
+
+## Cases
+
+### Vet help shows subcommands
+Run `godark vet --help`.
+- Output lists `issues` subcommand with description
+- Output lists `scenarios` subcommand with description
+- Output lists `roadmap` subcommand with description
+
+### Vet subcommand help shows flags
+Run `godark vet issues --help`.
+- Output includes `--repo` flag with description
+- Output includes `--milestone` flag with description
+- Output includes `--json` flag with description
+
+### Create a finding with error severity
+Construct a `Finding` with severity `Error`, a message, and a location.
+- `Severity` field is `Error`
+- `Message` field contains the provided text
+- `Location` field contains the provided file path or issue number
+
+### Report with error findings exits non-zero
+Build a report containing one error finding and one warning finding.
+- Report summary shows 1 error and 1 warning
+- Report indicates exit code 1
+
+### Report with only warnings exits zero
+Build a report containing two warning findings and no error findings.
+- Report summary shows 0 errors and 2 warnings
+- Report indicates exit code 0
+
+### Empty report exits zero
+Build a report with no findings.
+- Report summary shows 0 errors, 0 warnings, 0 info
+- Output contains a message indicating no issues found
+- Report indicates exit code 0
+
+### JSON output format
+Build a report with findings and render with JSON flag.
+- Output is valid JSON
+- JSON contains a `findings` array with severity, message, and location fields
+- JSON contains a `summary` object with error, warning, and info counts

--- a/tests/scenarios/vet-issues.md
+++ b/tests/scenarios/vet-issues.md
@@ -1,0 +1,58 @@
+# Scenario: Issue structure validation
+
+Relates to: Issue #15
+
+## Setup
+- The vet issues package (`internal/vet`) is imported directly
+- The `github.CommandRunner` variable is stubbed to return controlled JSON responses (no real GitHub API calls)
+- Stub responses include issue bodies with various combinations of required sections
+- No external services or network access required
+
+## Cases
+
+### Complete issue produces no error findings
+Stub a single issue with `## Description`, `## Acceptance criteria` (with checkboxes), `## Test cases` (with entries), valid `**Blocked by**: #1` notation, and the correct phase label.
+- No error findings are produced
+- No warning findings are produced
+
+### Missing acceptance criteria section
+Stub an issue body that has `## Description` and `## Test cases` but no `## Acceptance criteria` section.
+- An error finding is produced
+- The finding message mentions "acceptance criteria"
+- The finding location identifies the issue number
+
+### Missing test cases section
+Stub an issue body that has `## Description` and `## Acceptance criteria` but no `## Test cases` section.
+- An error finding is produced
+- The finding message mentions "test cases"
+- The finding location identifies the issue number
+
+### Empty acceptance criteria section
+Stub an issue body with `## Acceptance criteria` heading but no `- [ ]` checkbox items beneath it.
+- An error finding is produced
+- The finding message mentions "acceptance criteria" and "empty" or "no checkboxes"
+
+### Empty test cases section
+Stub an issue body with `## Test cases` heading but no `- **Name**:` entries beneath it.
+- An error finding is produced
+- The finding message mentions "test cases" and "empty" or "no entries"
+
+### Malformed blocker notation
+Stub an issue body containing `Blocked by #1` (missing colon after "Blocked by").
+- A warning finding is produced
+- The finding message mentions malformed dependency notation
+
+### Non-existent blocker reference
+Stub an issue body with `**Blocked by**: #999` and stub GitHub to indicate #999 does not exist.
+- A warning finding is produced
+- The finding message mentions the non-existent issue number
+
+### Missing phase label
+Stub an issue in the Phase 2 milestone that has no `phase-2` label.
+- A warning finding is produced
+- The finding message mentions the missing phase label
+
+### Multiple issues are all validated
+Stub three issues: one valid, one missing acceptance criteria, one missing test cases.
+- Two error findings are produced (one per invalid issue)
+- The valid issue produces no error findings

--- a/tests/scenarios/vet-roadmap.md
+++ b/tests/scenarios/vet-roadmap.md
@@ -1,0 +1,43 @@
+# Scenario: Roadmap validation
+
+Relates to: Issue #17
+
+## Setup
+- The vet roadmap package (`internal/vet`) is imported directly
+- A temporary directory containing planning doc markdown files
+- The `github.CommandRunner` variable is stubbed to return controlled issue and milestone data
+- No external services or network access required
+
+## Cases
+
+### Valid planning doc produces no findings
+A planning doc that references issues `## Issue 14:` through `## Issue 17:`, all of which exist on GitHub and are in the correct milestone with matching phase labels.
+- No error findings are produced
+- No warning findings are produced
+
+### Phantom issue reference
+A planning doc contains `## Issue 99:` but issue #99 does not exist on GitHub.
+- A warning finding is produced
+- The finding message mentions issue #99
+- The finding location is the planning doc file path
+
+### Orphaned issue in milestone
+Issue #5 is in the Phase 2 milestone on GitHub but is not mentioned in any planning doc in `docs/planning/`.
+- A warning finding is produced
+- The finding message mentions issue #5 and "not referenced in any planning doc"
+
+### Phase label does not match milestone
+An issue has label `phase-1` but is assigned to the `Phase 2` milestone.
+- An error finding is produced
+- The finding message mentions the label-milestone mismatch
+- The finding location identifies the issue number
+
+### Issues referenced across multiple planning docs
+Issue #14 is mentioned in `phase-2-quality-and-vetting.md` and also referenced in another planning doc.
+- Issue #14 is considered covered
+- No orphan warning is produced for issue #14
+
+### No planning docs found
+The `docs/planning/` directory is empty (or does not exist).
+- A warning finding is produced
+- The finding message mentions that no planning docs were found

--- a/tests/scenarios/vet-scenarios.md
+++ b/tests/scenarios/vet-scenarios.md
@@ -1,0 +1,58 @@
+# Scenario: Scenario spec validation
+
+Relates to: Issue #16
+
+## Setup
+- The vet scenarios package (`internal/vet`) is imported directly
+- A temporary directory containing scenario spec markdown files with various formats
+- The `github.CommandRunner` variable is stubbed to return controlled issue lists (for cross-referencing)
+- No external services or network access required
+
+## Cases
+
+### Valid scenario spec produces no findings
+A spec file with `# Scenario:` title, `Relates to: Issue #14`, `## Setup` section, `## Cases` section with cases that have bullet-point outcomes.
+- No error findings are produced
+- No warning findings are produced
+
+### Missing Setup section
+A spec file with `# Scenario:` title and `## Cases` but no `## Setup` section.
+- An error finding is produced
+- The finding message mentions "Setup"
+- The finding location is the file path
+
+### Missing Cases section
+A spec file with `# Scenario:` title and `## Setup` but no `## Cases` section.
+- An error finding is produced
+- The finding message mentions "Cases"
+- The finding location is the file path
+
+### Case without expected outcomes
+A spec file where a `### Case name` heading is followed by descriptive text but no bullet points (lines starting with `- `).
+- An error finding is produced
+- The finding message mentions the case name or "expected outcomes"
+
+### Missing Relates to line
+A spec file with valid format but no `Relates to:` line.
+- An error finding is produced
+- The finding message mentions "Relates to"
+
+### Malformed Relates to line
+A spec file with `Relates to: 5` instead of `Relates to: Issue #5`.
+- An error finding is produced
+- The finding message mentions the malformed format
+
+### Non-existent issue reference
+A spec file with `Relates to: Issue #999` where issue #999 does not exist on GitHub.
+- A warning finding is produced
+- The finding message mentions the non-existent issue
+
+### Issue in milestone with no scenario spec coverage
+Stub GitHub to return issue #14 in the milestone, but no spec file contains `Relates to: Issue #14`.
+- A warning finding is produced
+- The finding message mentions issue #14 and "no scenario spec"
+
+### Multiple Relates to lines cover multiple issues
+A spec file with both `Relates to: Issue #14` and `Relates to: Issue #15`.
+- Both issue #8 and issue #9 are considered covered by this spec
+- No "missing coverage" warnings are produced for either issue


### PR DESCRIPTION
## Summary
- Add planning doc `docs/planning/phase-2-quality-and-vetting.md` with full specs for issues #14–#17
- Add 4 scenario specs in `tests/scenarios/` (one per issue: vet-command-scaffold, vet-issues, vet-scenarios, vet-roadmap)
- Update `docs/ROADMAP.md` Phase 2 section with issue numbers and streamlined format

## Test plan
- [ ] `gh issue list --milestone "Phase 2"` shows 4 issues (#14–#17)
- [ ] Each issue has `phase-2` label, acceptance criteria, test cases, and correct blocker notation
- [ ] Each issue has a matching scenario spec with `Relates to: Issue #N`
- [ ] Planning doc follows Phase 1 format
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)