### PR TITLE
feat: add Dockerfile generation and image build for sandbox

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,10 +39,13 @@ type CrossCompile struct {
 
 // Docker holds Docker sandbox configuration.
 type Docker struct {
-	Image      string `yaml:"image"`
-	Dockerfile string `yaml:"dockerfile"`
-	Mount      string `yaml:"mount"`
-	User       string `yaml:"user"`
+	Image         string   `yaml:"image"`
+	Dockerfile    string   `yaml:"dockerfile"`
+	Mount         string   `yaml:"mount"`
+	User          string   `yaml:"user"`
+	GoVersion     string   `yaml:"go_version"`
+	NodeVersion   string   `yaml:"node_version"`
+	ExtraPackages []string `yaml:"extra_packages"`
 }
 
 // Prompts holds paths to prompt template files.

--- a/internal/sandbox/build.go
+++ b/internal/sandbox/build.go
@@ -1,0 +1,47 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// CommandRunner executes a command and returns its combined output.
+// Replaceable for testing.
+var CommandRunner = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// BuildImage generates a Dockerfile from cfg, writes it to a temp directory,
+// and runs docker build. It returns the image tag on success.
+func BuildImage(ctx context.Context, cfg DockerConfig, logger *slog.Logger) (string, error) {
+	content, err := GenerateDockerfile(cfg)
+	if err != nil {
+		return "", fmt.Errorf("generating Dockerfile: %w", err)
+	}
+
+	tag := ImageTag(content)
+	logger.Info("building Docker image", "tag", tag)
+
+	tmpDir, err := os.MkdirTemp("", "godark-docker-*")
+	if err != nil {
+		return "", fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dfPath := filepath.Join(tmpDir, "Dockerfile")
+	if err := os.WriteFile(dfPath, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("writing Dockerfile: %w", err)
+	}
+
+	out, err := CommandRunner("docker", "build", "-t", tag, "-f", dfPath, tmpDir)
+	if err != nil {
+		return "", fmt.Errorf("docker build: %w\noutput: %s", err, out)
+	}
+
+	logger.Info("Docker image built", "tag", tag)
+	return tag, nil
+}

--- a/internal/sandbox/config.go
+++ b/internal/sandbox/config.go
@@ -1,0 +1,60 @@
+package sandbox
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/phs/dark-factory/internal/config"
+)
+
+// DockerConfig holds the resolved configuration for Dockerfile generation.
+type DockerConfig struct {
+	Image         string
+	GoVersion     string
+	NodeVersion   string
+	User          string
+	ExtraPackages []string
+	Mount         string
+}
+
+// DefaultDockerConfig returns a DockerConfig with sensible defaults.
+func DefaultDockerConfig() DockerConfig {
+	return DockerConfig{
+		Image:       "ubuntu:22.04",
+		GoVersion:   "1.23",
+		NodeVersion: "20",
+		User:        "devloop",
+	}
+}
+
+// DockerConfigFromConfig maps a config.Docker into a DockerConfig,
+// applying defaults for any zero-value fields.
+func DockerConfigFromConfig(cfg config.Docker) DockerConfig {
+	dc := DefaultDockerConfig()
+	if cfg.Image != "" {
+		dc.Image = cfg.Image
+	}
+	if cfg.GoVersion != "" {
+		dc.GoVersion = cfg.GoVersion
+	}
+	if cfg.NodeVersion != "" {
+		dc.NodeVersion = cfg.NodeVersion
+	}
+	if cfg.User != "" {
+		dc.User = cfg.User
+	}
+	if cfg.Mount != "" {
+		dc.Mount = cfg.Mount
+	}
+	if len(cfg.ExtraPackages) > 0 {
+		dc.ExtraPackages = cfg.ExtraPackages
+	}
+	return dc
+}
+
+// ImageTag returns a deterministic image tag derived from the Dockerfile content.
+// The tag format is "godark-runner:<first-12-chars-of-sha256>".
+func ImageTag(dockerfileContent string) string {
+	h := sha256.Sum256([]byte(dockerfileContent))
+	return fmt.Sprintf("godark-runner:%x", h[:6])
+}

--- a/internal/sandbox/dockerfile.go
+++ b/internal/sandbox/dockerfile.go
@@ -1,0 +1,71 @@
+package sandbox
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+var dockerfileTmpl = template.Must(template.New("Dockerfile").Parse(`FROM {{.Image}}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    curl \
+    ca-certificates \
+    gnupg \
+{{- range .ExtraPackages}}
+    {{.}} \
+{{- end}}
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go
+RUN curl -fsSL https://go.dev/dl/go{{.GoVersion}}.linux-amd64.tar.gz \
+      | tar -C /usr/local -xz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_{{.NodeVersion}}.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code
+RUN npm install -g @anthropic-ai/claude-code
+
+# Create non-root user
+RUN useradd -m -s /bin/bash {{.User}}
+USER {{.User}}
+WORKDIR /workspace
+`))
+
+// GenerateDockerfile renders a Dockerfile from the given DockerConfig.
+func GenerateDockerfile(cfg DockerConfig) (string, error) {
+	data := struct {
+		Image         string
+		GoVersion     string
+		NodeVersion   string
+		User          string
+		ExtraPackages []string
+	}{
+		Image:         cfg.Image,
+		GoVersion:     cfg.GoVersion,
+		NodeVersion:   cfg.NodeVersion,
+		User:          cfg.User,
+		ExtraPackages: cfg.ExtraPackages,
+	}
+
+	var buf bytes.Buffer
+	if err := dockerfileTmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("rendering Dockerfile template: %w", err)
+	}
+
+	return strings.TrimRight(buf.String(), "\n") + "\n", nil
+}

--- a/internal/sandbox/dockerfile_test.go
+++ b/internal/sandbox/dockerfile_test.go
@@ -1,0 +1,216 @@
+package sandbox
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/config"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	dc := DefaultDockerConfig()
+	if dc.Image != "ubuntu:22.04" {
+		t.Errorf("Image = %q, want ubuntu:22.04", dc.Image)
+	}
+	if dc.GoVersion != "1.23" {
+		t.Errorf("GoVersion = %q, want 1.23", dc.GoVersion)
+	}
+	if dc.NodeVersion != "20" {
+		t.Errorf("NodeVersion = %q, want 20", dc.NodeVersion)
+	}
+	if dc.User != "devloop" {
+		t.Errorf("User = %q, want devloop", dc.User)
+	}
+}
+
+func TestDockerConfigFromConfig(t *testing.T) {
+	cfg := config.Docker{
+		Image:         "debian:bookworm",
+		GoVersion:     "1.22",
+		NodeVersion:   "18",
+		User:          "runner",
+		Mount:         "/src",
+		ExtraPackages: []string{"vim", "jq"},
+	}
+	dc := DockerConfigFromConfig(cfg)
+
+	if dc.Image != "debian:bookworm" {
+		t.Errorf("Image = %q, want debian:bookworm", dc.Image)
+	}
+	if dc.GoVersion != "1.22" {
+		t.Errorf("GoVersion = %q, want 1.22", dc.GoVersion)
+	}
+	if dc.NodeVersion != "18" {
+		t.Errorf("NodeVersion = %q, want 18", dc.NodeVersion)
+	}
+	if dc.User != "runner" {
+		t.Errorf("User = %q, want runner", dc.User)
+	}
+	if dc.Mount != "/src" {
+		t.Errorf("Mount = %q, want /src", dc.Mount)
+	}
+	if len(dc.ExtraPackages) != 2 {
+		t.Fatalf("ExtraPackages len = %d, want 2", len(dc.ExtraPackages))
+	}
+}
+
+func TestDockerConfigFromConfigDefaults(t *testing.T) {
+	dc := DockerConfigFromConfig(config.Docker{})
+	def := DefaultDockerConfig()
+
+	if dc.Image != def.Image {
+		t.Errorf("Image = %q, want default %q", dc.Image, def.Image)
+	}
+	if dc.GoVersion != def.GoVersion {
+		t.Errorf("GoVersion = %q, want default %q", dc.GoVersion, def.GoVersion)
+	}
+}
+
+func TestGenerateDockerfileDefault(t *testing.T) {
+	df, err := GenerateDockerfile(DefaultDockerConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	checks := []struct {
+		name    string
+		contain string
+	}{
+		{"base image", "FROM ubuntu:22.04"},
+		{"claude-code", "npm install -g @anthropic-ai/claude-code"},
+		{"user directive", "USER devloop"},
+		{"workdir", "WORKDIR /workspace"},
+		{"go install", "go1.23.linux-amd64.tar.gz"},
+		{"node install", "setup_20.x"},
+		{"useradd", "useradd -m -s /bin/bash devloop"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(df, c.contain) {
+			t.Errorf("%s: Dockerfile missing %q", c.name, c.contain)
+		}
+	}
+}
+
+func TestGenerateDockerfileCustomImage(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.Image = "debian:bookworm"
+
+	df, err := GenerateDockerfile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(df, "FROM debian:bookworm") {
+		t.Error("Dockerfile missing custom base image")
+	}
+}
+
+func TestGenerateDockerfileCustomGoVersion(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.GoVersion = "1.22"
+
+	df, err := GenerateDockerfile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(df, "go1.22.linux-amd64.tar.gz") {
+		t.Error("Dockerfile missing custom Go version URL")
+	}
+}
+
+func TestGenerateDockerfileExtraPackages(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.ExtraPackages = []string{"vim", "jq"}
+
+	df, err := GenerateDockerfile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(df, "vim") || !strings.Contains(df, "jq") {
+		t.Error("Dockerfile missing extra packages")
+	}
+}
+
+func TestGenerateDockerfileNonRootUser(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.User = "myuser"
+
+	df, err := GenerateDockerfile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(df, "useradd -m -s /bin/bash myuser") {
+		t.Error("Dockerfile missing useradd for custom user")
+	}
+	if !strings.Contains(df, "USER myuser") {
+		t.Error("Dockerfile missing USER directive for custom user")
+	}
+}
+
+func TestImageTagDeterministic(t *testing.T) {
+	tag1 := ImageTag("FROM ubuntu:22.04\n")
+	tag2 := ImageTag("FROM ubuntu:22.04\n")
+	if tag1 != tag2 {
+		t.Errorf("tags differ for same content: %q vs %q", tag1, tag2)
+	}
+
+	if !strings.HasPrefix(tag1, "godark-runner:") {
+		t.Errorf("tag missing prefix: %q", tag1)
+	}
+}
+
+func TestImageTagChangesWithContent(t *testing.T) {
+	tag1 := ImageTag("FROM ubuntu:22.04\n")
+	tag2 := ImageTag("FROM debian:bookworm\n")
+	if tag1 == tag2 {
+		t.Error("tags should differ for different content")
+	}
+}
+
+func TestBuildImageStubbedCommandRunner(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	var capturedArgs []string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		capturedArgs = append([]string{name}, args...)
+		return []byte("Successfully built"), nil
+	}
+
+	logger := slog.Default()
+	tag, err := BuildImage(context.Background(), DefaultDockerConfig(), logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.HasPrefix(tag, "godark-runner:") {
+		t.Errorf("tag missing prefix: %q", tag)
+	}
+
+	if len(capturedArgs) == 0 {
+		t.Fatal("CommandRunner was not called")
+	}
+	if capturedArgs[0] != "docker" {
+		t.Errorf("expected docker command, got %q", capturedArgs[0])
+	}
+	if capturedArgs[1] != "build" {
+		t.Errorf("expected build subcommand, got %q", capturedArgs[1])
+	}
+
+	// Verify -t flag with tag
+	foundTag := false
+	for i, arg := range capturedArgs {
+		if arg == "-t" && i+1 < len(capturedArgs) && capturedArgs[i+1] == tag {
+			foundTag = true
+			break
+		}
+	}
+	if !foundTag {
+		t.Errorf("docker build missing -t %s in args: %v", tag, capturedArgs)
+	}
+}


### PR DESCRIPTION
Implement the internal/sandbox package with runtime Dockerfile generation from config, deterministic image tagging, and docker build invocation.

Closes #20