### PR TITLE
feat: agent execution loop (Phase 4)

### DIFF
--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -1,0 +1,165 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// GuardRunner executes a command and returns its combined output.
+// Replaceable for testing.
+var GuardRunner = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// FindPR returns the PR number for the current branch in the given repo,
+// or 0 if no PR is found.
+func FindPR(repo string) (int, error) {
+	out, err := GuardRunner("gh", "pr", "view", "--repo", repo, "--json", "number")
+	if err != nil {
+		// gh pr view exits non-zero when no PR exists
+		return 0, nil
+	}
+
+	var result struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return 0, fmt.Errorf("parsing PR JSON: %w", err)
+	}
+	return result.Number, nil
+}
+
+// EnsureClosesRef checks whether the PR body contains "Closes #N".
+// If missing, it appends the reference via gh pr edit.
+func EnsureClosesRef(repo string, prNum, issueNum int) error {
+	out, err := GuardRunner("gh", "pr", "view", strconv.Itoa(prNum), "--repo", repo, "--json", "body")
+	if err != nil {
+		return fmt.Errorf("reading PR body: %w", err)
+	}
+
+	var pr struct {
+		Body string `json:"body"`
+	}
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return fmt.Errorf("parsing PR body: %w", err)
+	}
+
+	ref := fmt.Sprintf("Closes #%d", issueNum)
+	if strings.Contains(pr.Body, ref) {
+		return nil
+	}
+
+	// Also check for "Fixes #N" variant
+	fixRef := fmt.Sprintf("Fixes #%d", issueNum)
+	if strings.Contains(pr.Body, fixRef) {
+		return nil
+	}
+
+	newBody := pr.Body + "\n\n" + ref
+	_, err = GuardRunner("gh", "pr", "edit", strconv.Itoa(prNum), "--repo", repo, "--body", newBody)
+	if err != nil {
+		return fmt.Errorf("editing PR body: %w", err)
+	}
+	return nil
+}
+
+// CheckProtectedDrift returns the subset of protectedPaths that have been
+// modified between baseSHA and HEAD.
+func CheckProtectedDrift(baseSHA string, protectedPaths []string) ([]string, error) {
+	out, err := GuardRunner("git", "diff", "--name-only", baseSHA+"...HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("git diff: %w", err)
+	}
+
+	changed := make(map[string]bool)
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			changed[line] = true
+		}
+	}
+
+	var touched []string
+	for _, p := range protectedPaths {
+		if changed[p] {
+			touched = append(touched, p)
+		}
+	}
+	return touched, nil
+}
+
+// ClosePR closes the given PR with a comment explaining the reason.
+func ClosePR(repo string, prNum int, reason string) error {
+	_, err := GuardRunner("gh", "pr", "close", strconv.Itoa(prNum), "--repo", repo, "--comment", reason)
+	if err != nil {
+		return fmt.Errorf("closing PR #%d: %w", prNum, err)
+	}
+	return nil
+}
+
+// ParseReviewResult scans the agent stdout for a REVIEW_RESULT line and
+// returns "APPROVED", "CHANGES_REQUESTED", or "" if not found.
+func ParseReviewResult(stdout string) string {
+	for _, line := range strings.Split(stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "REVIEW_RESULT=APPROVED" {
+			return "APPROVED"
+		}
+		if line == "REVIEW_RESULT=CHANGES_REQUESTED" {
+			return "CHANGES_REQUESTED"
+		}
+	}
+	return ""
+}
+
+// WarnMissingScenario checks whether any scenario spec file in scenarioDir
+// references the given issue number. If not, it posts a warning comment on
+// the PR.
+func WarnMissingScenario(repo string, prNum, issueNum int, scenarioDir string, logger *slog.Logger) error {
+	ref := fmt.Sprintf("#%d", issueNum)
+
+	entries, err := os.ReadDir(scenarioDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Warn("scenario directory not found", "dir", scenarioDir)
+		} else {
+			return fmt.Errorf("reading scenario dir: %w", err)
+		}
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(scenarioDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if strings.Contains(string(data), ref) {
+			return nil // found a scenario referencing this issue
+		}
+	}
+
+	comment := fmt.Sprintf("Warning: no scenario spec found referencing issue #%d in %s. Consider creating one with `godark create-scenario %d`.", issueNum, scenarioDir, issueNum)
+	_, err = GuardRunner("gh", "pr", "comment", strconv.Itoa(prNum), "--repo", repo, "--body", comment)
+	if err != nil {
+		return fmt.Errorf("posting scenario warning: %w", err)
+	}
+
+	logger.Warn("no scenario spec found for issue", "issue_number", issueNum)
+	return nil
+}
+
+// LabelPR adds a label to the given PR.
+func LabelPR(repo string, prNum int, label string) error {
+	_, err := GuardRunner("gh", "pr", "edit", strconv.Itoa(prNum), "--repo", repo, "--add-label", label)
+	if err != nil {
+		return fmt.Errorf("labeling PR #%d with %q: %w", prNum, label, err)
+	}
+	return nil
+}

--- a/internal/agent/guardrails_test.go
+++ b/internal/agent/guardrails_test.go
@@ -1,0 +1,207 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func stubGuardRunner(t *testing.T, fn func(string, ...string) ([]byte, error)) {
+	t.Helper()
+	orig := GuardRunner
+	t.Cleanup(func() { GuardRunner = orig })
+	GuardRunner = fn
+}
+
+func TestParseReviewResult_Approved(t *testing.T) {
+	stdout := "some output\nREVIEW_RESULT=APPROVED\nmore output"
+	got := ParseReviewResult(stdout)
+	if got != "APPROVED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
+	}
+}
+
+func TestParseReviewResult_ChangesRequested(t *testing.T) {
+	stdout := "output\nREVIEW_RESULT=CHANGES_REQUESTED\n"
+	got := ParseReviewResult(stdout)
+	if got != "CHANGES_REQUESTED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "CHANGES_REQUESTED")
+	}
+}
+
+func TestParseReviewResult_NotFound(t *testing.T) {
+	stdout := "just some random output\nno result here"
+	got := ParseReviewResult(stdout)
+	if got != "" {
+		t.Errorf("ParseReviewResult() = %q, want empty", got)
+	}
+}
+
+func TestFindPR_ReturnsPRNumber(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return []byte(`{"number": 42}`), nil
+	})
+
+	num, err := FindPR("owner/repo")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if num != 42 {
+		t.Errorf("FindPR() = %d, want 42", num)
+	}
+}
+
+func TestFindPR_ReturnsZeroOnError(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("no PR found")
+	})
+
+	num, err := FindPR("owner/repo")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if num != 0 {
+		t.Errorf("FindPR() = %d, want 0", num)
+	}
+}
+
+func TestEnsureClosesRef_NoOpWhenPresent(t *testing.T) {
+	var editCalled bool
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "pr" && args[1] == "view" {
+			return []byte(`{"body": "Some PR body\n\nCloses #5"}`), nil
+		}
+		if len(args) > 0 && args[0] == "pr" && args[1] == "edit" {
+			editCalled = true
+		}
+		return nil, nil
+	})
+
+	err := EnsureClosesRef("owner/repo", 10, 5)
+	if err != nil {
+		t.Fatalf("EnsureClosesRef() error = %v", err)
+	}
+	if editCalled {
+		t.Error("expected no edit when Closes ref already present")
+	}
+}
+
+func TestEnsureClosesRef_EditsWhenMissing(t *testing.T) {
+	var editBody string
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		if len(args) > 2 && args[1] == "view" {
+			return []byte(`{"body": "PR body without issue ref"}`), nil
+		}
+		if len(args) > 2 && args[1] == "edit" {
+			for i, a := range args {
+				if a == "--body" && i+1 < len(args) {
+					editBody = args[i+1]
+				}
+			}
+			return nil, nil
+		}
+		return nil, nil
+	})
+
+	err := EnsureClosesRef("owner/repo", 10, 5)
+	if err != nil {
+		t.Fatalf("EnsureClosesRef() error = %v", err)
+	}
+	if !strings.Contains(editBody, "Closes #5") {
+		t.Errorf("expected edit body to contain 'Closes #5', got: %s", editBody)
+	}
+}
+
+func TestCheckProtectedDrift_ReturnsTouchedFiles(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return []byte("CLAUDE.md\nsrc/main.go\ntests/scenarios/spec.md\n"), nil
+	})
+
+	touched, err := CheckProtectedDrift("abc123", []string{"CLAUDE.md", "tests/scenarios/spec.md", "safe/file.go"})
+	if err != nil {
+		t.Fatalf("CheckProtectedDrift() error = %v", err)
+	}
+	if len(touched) != 2 {
+		t.Fatalf("expected 2 touched files, got %d: %v", len(touched), touched)
+	}
+}
+
+func TestCheckProtectedDrift_EmptyWhenClean(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return []byte("src/main.go\nREADME.md\n"), nil
+	})
+
+	touched, err := CheckProtectedDrift("abc123", []string{"CLAUDE.md", "tests/scenarios/"})
+	if err != nil {
+		t.Fatalf("CheckProtectedDrift() error = %v", err)
+	}
+	if len(touched) != 0 {
+		t.Errorf("expected no touched files, got %v", touched)
+	}
+}
+
+func TestWarnMissingScenario_NoWarningWhenFound(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.md"), []byte("Relates to: Issue #5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var commentPosted bool
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[1] == "comment" {
+			commentPosted = true
+		}
+		return nil, nil
+	})
+
+	err := WarnMissingScenario("owner/repo", 10, 5, dir, testLogger(t))
+	if err != nil {
+		t.Fatalf("WarnMissingScenario() error = %v", err)
+	}
+	if commentPosted {
+		t.Error("expected no comment when scenario found")
+	}
+}
+
+func TestWarnMissingScenario_PostsWarningWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	// No scenario files referencing issue #5
+
+	var commentPosted bool
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		if len(args) > 1 && args[1] == "comment" {
+			commentPosted = true
+		}
+		return nil, nil
+	})
+
+	err := WarnMissingScenario("owner/repo", 10, 5, dir, testLogger(t))
+	if err != nil {
+		t.Fatalf("WarnMissingScenario() error = %v", err)
+	}
+	if !commentPosted {
+		t.Error("expected warning comment when no scenario found")
+	}
+}
+
+func TestLabelPR(t *testing.T) {
+	var labelArg string
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		for i, a := range args {
+			if a == "--add-label" && i+1 < len(args) {
+				labelArg = args[i+1]
+			}
+		}
+		return nil, nil
+	})
+
+	err := LabelPR("owner/repo", 10, "needs-human-review")
+	if err != nil {
+		t.Fatalf("LabelPR() error = %v", err)
+	}
+	if labelArg != "needs-human-review" {
+		t.Errorf("expected label 'needs-human-review', got %q", labelArg)
+	}
+}

--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// Implement runs the implementer agent for a fresh issue implementation.
+// It renders the implementer prompt and invokes Run.
+func Implement(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*Result, error) {
+	slug := Slugify(issue.Title)
+	data := newPromptData(issue, cfg, slug)
+
+	rendered, err := RenderPrompt(prompts.Implementer, data)
+	if err != nil {
+		return nil, fmt.Errorf("rendering implementer prompt: %w", err)
+	}
+
+	timeout, err := parseTimeout(cfg.AgentTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("parsing agent_timeout: %w", err)
+	}
+
+	opts := RunOpts{
+		Prompt:      rendered,
+		Env:         authEnv,
+		Image:       cfg.Docker.Image,
+		Repo:        cfg.Repo,
+		Branch:      "",
+		WorkDir:     "/workspace",
+		ClaudeFlags: cfg.ClaudeFlags,
+		Timeout:     timeout,
+	}
+
+	logger.Info("starting implementer agent",
+		"issue_number", issue.Number,
+		"issue_title", issue.Title,
+		"branch", fmt.Sprintf("%d-%s", issue.Number, slug),
+	)
+
+	return Run(ctx, opts, cfg.NoSandbox, logger)
+}
+
+// Retry runs the implementer agent in retry mode for an existing PR.
+// It renders the retry prompt with the PR number and invokes Run.
+func Retry(ctx context.Context, issue github.Issue, prNumber int, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*Result, error) {
+	slug := Slugify(issue.Title)
+	data := newPromptData(issue, cfg, slug)
+	data.PRNumber = prNumber
+
+	rendered, err := RenderPrompt(prompts.ImplementerRetry, data)
+	if err != nil {
+		return nil, fmt.Errorf("rendering implementer_retry prompt: %w", err)
+	}
+
+	timeout, err := parseTimeout(cfg.AgentTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("parsing agent_timeout: %w", err)
+	}
+
+	opts := RunOpts{
+		Prompt:      rendered,
+		Env:         authEnv,
+		Image:       cfg.Docker.Image,
+		Repo:        cfg.Repo,
+		Branch:      "",
+		WorkDir:     "/workspace",
+		ClaudeFlags: cfg.ClaudeFlags,
+		Timeout:     timeout,
+	}
+
+	logger.Info("starting implementer retry agent",
+		"issue_number", issue.Number,
+		"pr_number", prNumber,
+	)
+
+	return Run(ctx, opts, cfg.NoSandbox, logger)
+}
+
+func newPromptData(issue github.Issue, cfg *config.Config, slug string) PromptData {
+	return PromptData{
+		IssueNumber:    issue.Number,
+		IssueTitle:     issue.Title,
+		IssueBody:      issue.Body,
+		Slug:           slug,
+		Repo:           cfg.Repo,
+		BuildCommand:   cfg.BuildCommand,
+		TestCommand:    cfg.TestCommand,
+		ProtectedPaths: strings.Join(cfg.ProtectedPaths, ", "),
+		ScenarioDir:    cfg.ScenarioDir,
+		ReviewDir:      cfg.ReviewDir,
+	}
+}
+
+func parseTimeout(s string) (time.Duration, error) {
+	if s == "" {
+		return 30 * time.Minute, nil
+	}
+	return time.ParseDuration(s)
+}

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+func stubRunner(t *testing.T) *[]string {
+	t.Helper()
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+
+	var captured []string
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		captured = append([]string{name}, args...)
+		return []byte("ok"), []byte(""), 0, nil
+	}
+	return &captured
+}
+
+func testIssue() github.Issue {
+	return github.Issue{
+		Number: 42,
+		Title:  "Add Widget Support",
+		Body:   "Implement widgets for the dashboard.",
+	}
+}
+
+func testImplementerConfig() *config.Config {
+	return &config.Config{
+		Repo:           "owner/repo",
+		NoSandbox:      true,
+		AgentTimeout:   "10m",
+		BuildCommand:   "go build ./...",
+		TestCommand:    "go test ./...",
+		ProtectedPaths: []string{"CLAUDE.md", "tests/scenarios/"},
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+	}
+}
+
+func testPrompts(t *testing.T) *Prompts {
+	t.Helper()
+	return &Prompts{
+		Implementer:      "Implement #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} slug={{.Slug}}",
+		ImplementerRetry: "Retry PR #{{.PRNumber}} for #{{.IssueNumber}} repo={{.Repo}}",
+		Reviewer:         "Review PR #{{.PRNumber}} for #{{.IssueNumber}}",
+	}
+}
+
+func TestImplement_RendersPromptAndCallsRun(t *testing.T) {
+	captured := stubRunner(t)
+
+	result, err := Implement(context.Background(), testIssue(), testImplementerConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+
+	// Verify the rendered prompt was passed to claude
+	joined := strings.Join(*captured, " ")
+	if !strings.Contains(joined, "Implement #42") {
+		t.Errorf("expected rendered prompt with issue number, got: %s", joined)
+	}
+	if !strings.Contains(joined, "add-widget-support") {
+		t.Errorf("expected slug in prompt, got: %s", joined)
+	}
+}
+
+func TestRetry_RendersRetryPromptWithPR(t *testing.T) {
+	captured := stubRunner(t)
+
+	result, err := Retry(context.Background(), testIssue(), 7, testImplementerConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Retry() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+
+	joined := strings.Join(*captured, " ")
+	if !strings.Contains(joined, "Retry PR #7") {
+		t.Errorf("expected retry prompt with PR number, got: %s", joined)
+	}
+	if !strings.Contains(joined, "#42") {
+		t.Errorf("expected issue number in retry prompt, got: %s", joined)
+	}
+}
+
+func TestImplement_AgentTimeoutParsed(t *testing.T) {
+	stubRunner(t)
+
+	cfg := testImplementerConfig()
+	cfg.AgentTimeout = "5m"
+
+	_, err := Implement(context.Background(), testIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() error = %v", err)
+	}
+}
+
+func TestImplement_InvalidTimeout(t *testing.T) {
+	stubRunner(t)
+
+	cfg := testImplementerConfig()
+	cfg.AgentTimeout = "invalid"
+
+	_, err := Implement(context.Background(), testIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	if err == nil {
+		t.Fatal("expected error for invalid timeout")
+	}
+}
+
+func TestImplement_NonZeroExitSurfacedInResult(t *testing.T) {
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		return []byte("fail output"), []byte(""), 1, nil
+	}
+
+	result, err := Implement(context.Background(), testIssue(), testImplementerConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() should not return error for non-zero exit, got: %v", err)
+	}
+	if result.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", result.ExitCode)
+	}
+}

--- a/internal/agent/launcher.go
+++ b/internal/agent/launcher.go
@@ -1,0 +1,131 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"time"
+
+	"github.com/phs/dark-factory/internal/sandbox"
+)
+
+// RunOpts configures an agent invocation.
+type RunOpts struct {
+	Prompt      string
+	Env         map[string]string
+	Image       string
+	Repo        string
+	Branch      string
+	WorkDir     string
+	ClaudeFlags []string
+	Timeout     time.Duration
+}
+
+// Result holds the outcome of an agent run.
+type Result struct {
+	ExitCode int
+	Stdout   string
+	Stderr   string
+	TimedOut bool
+}
+
+// Runner executes a command on the host. Replaceable for testing.
+var Runner = func(ctx context.Context, name string, args ...string) (stdout, stderr []byte, exitCode int, err error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var outBuf, errBuf []byte
+	cmd.Stdout = &writerFunc{fn: func(p []byte) { outBuf = append(outBuf, p...) }}
+	cmd.Stderr = &writerFunc{fn: func(p []byte) { errBuf = append(errBuf, p...) }}
+	err = cmd.Run()
+	code := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			code = exitErr.ExitCode()
+			err = nil // non-zero exit is not an error for us
+		}
+	}
+	return outBuf, errBuf, code, err
+}
+
+// writerFunc adapts a function to the io.Writer interface.
+type writerFunc struct {
+	fn func([]byte)
+}
+
+func (w *writerFunc) Write(p []byte) (int, error) {
+	w.fn(p)
+	return len(p), nil
+}
+
+// Run invokes a Claude Code agent with the given prompt, either inside a
+// Docker container (sandbox mode) or directly on the host (no-sandbox mode).
+func Run(ctx context.Context, opts RunOpts, noSandbox bool, logger *slog.Logger) (*Result, error) {
+	if noSandbox {
+		return runHost(ctx, opts, logger)
+	}
+	return runSandbox(ctx, opts, logger)
+}
+
+func runHost(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result, error) {
+	logger.Info("running agent on host", "timeout", opts.Timeout)
+
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
+	args := []string{"-p", "--dangerously-skip-permissions", opts.Prompt}
+	args = append(args, opts.ClaudeFlags...)
+
+	stdout, stderr, exitCode, err := Runner(ctx, "claude", args...)
+	if ctx.Err() != nil {
+		return &Result{TimedOut: true, Stdout: string(stdout), Stderr: string(stderr)}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("running claude on host: %w", err)
+	}
+
+	logger.Info("host agent finished", "exit_code", exitCode)
+	return &Result{
+		ExitCode: exitCode,
+		Stdout:   string(stdout),
+		Stderr:   string(stderr),
+	}, nil
+}
+
+func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result, error) {
+	logger.Info("running agent in sandbox", "image", opts.Image, "timeout", opts.Timeout)
+
+	workDir := opts.WorkDir
+	if workDir == "" {
+		workDir = "/workspace"
+	}
+
+	claudeArgs := fmt.Sprintf("claude -p --dangerously-skip-permissions %q", opts.Prompt)
+	for _, f := range opts.ClaudeFlags {
+		claudeArgs += " " + f
+	}
+
+	cloneScript := sandbox.CloneScript(opts.Repo, opts.Branch, workDir)
+	entrypoint := sandbox.EntrypointScript(cloneScript, "cd "+workDir+" && "+claudeArgs)
+
+	sandboxOpts := sandbox.RunOpts{
+		Image:   opts.Image,
+		Cmd:     []string{"sh", "-c", entrypoint},
+		Env:     opts.Env,
+		Timeout: opts.Timeout,
+	}
+
+	result, err := sandbox.RunContainer(ctx, sandboxOpts, logger)
+	if err != nil {
+		return nil, fmt.Errorf("running sandbox container: %w", err)
+	}
+
+	return &Result{
+		ExitCode: result.ExitCode,
+		Stdout:   result.Stdout,
+		Stderr:   result.Stderr,
+		TimedOut: result.TimedOut,
+	}, nil
+}

--- a/internal/agent/launcher_test.go
+++ b/internal/agent/launcher_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestRun_NoSandbox_DispatchesToRunner(t *testing.T) {
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+
+	var capturedArgs []string
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedArgs = append([]string{name}, args...)
+		return []byte("out"), []byte("err"), 0, nil
+	}
+
+	opts := RunOpts{
+		Prompt:      "test prompt",
+		ClaudeFlags: []string{"--model", "opus"},
+	}
+	result, err := Run(context.Background(), opts, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if result.Stdout != "out" {
+		t.Errorf("Stdout = %q, want %q", result.Stdout, "out")
+	}
+
+	// Check claude was called with correct args
+	if capturedArgs[0] != "claude" {
+		t.Errorf("expected command 'claude', got %q", capturedArgs[0])
+	}
+	joined := strings.Join(capturedArgs, " ")
+	if !strings.Contains(joined, "test prompt") {
+		t.Error("expected prompt in args")
+	}
+	if !strings.Contains(joined, "--model") {
+		t.Error("expected ClaudeFlags in args")
+	}
+	if !strings.Contains(joined, "--dangerously-skip-permissions") {
+		t.Error("expected --dangerously-skip-permissions in args")
+	}
+}
+
+func TestRun_NoSandbox_NonZeroExit(t *testing.T) {
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		return []byte("out"), []byte("err"), 1, nil
+	}
+
+	result, err := Run(context.Background(), RunOpts{Prompt: "test"}, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1", result.ExitCode)
+	}
+}
+
+func TestRun_NoSandbox_Timeout(t *testing.T) {
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		<-ctx.Done()
+		return []byte("partial"), []byte(""), 0, ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Immediately cancel
+
+	result, err := Run(ctx, RunOpts{Prompt: "test"}, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !result.TimedOut {
+		t.Error("expected TimedOut = true")
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -1,0 +1,184 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// IssueOutcome records the result of processing a single issue.
+type IssueOutcome struct {
+	IssueNumber int
+	Status      string // "implemented", "failed", "needs-human-review"
+	PRNumber    int
+	Retries     int
+	Err         error
+}
+
+// ProcessIssue runs the full per-issue lifecycle:
+// implement → find PR → guard rails → review/retry loop → merge or label.
+func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) IssueOutcome {
+	outcome := IssueOutcome{IssueNumber: issue.Number}
+
+	logger.Info("processing issue", "issue_number", issue.Number, "title", issue.Title)
+
+	// Record base SHA for drift detection.
+	baseSHAOut, err := GuardRunner("git", "rev-parse", "HEAD")
+	if err != nil {
+		outcome.Status = "failed"
+		outcome.Err = fmt.Errorf("getting base SHA: %w", err)
+		return outcome
+	}
+	baseSHA := trimOutput(baseSHAOut)
+
+	// Step 1: Implement.
+	implResult, err := Implement(ctx, issue, cfg, prompts, authEnv, logger)
+	if err != nil {
+		outcome.Status = "failed"
+		outcome.Err = fmt.Errorf("implementer agent: %w", err)
+		return outcome
+	}
+	if implResult.TimedOut {
+		outcome.Status = "failed"
+		outcome.Err = fmt.Errorf("implementer agent timed out")
+		return outcome
+	}
+
+	// Step 2: Find PR.
+	prNum, err := FindPR(cfg.Repo)
+	if err != nil {
+		outcome.Status = "failed"
+		outcome.Err = fmt.Errorf("finding PR: %w", err)
+		return outcome
+	}
+	if prNum == 0 {
+		outcome.Status = "failed"
+		outcome.Err = fmt.Errorf("implementer agent did not create a PR")
+		return outcome
+	}
+	outcome.PRNumber = prNum
+
+	// Step 3: Guard rails.
+	if err := EnsureClosesRef(cfg.Repo, prNum, issue.Number); err != nil {
+		logger.Warn("failed to ensure Closes ref", "error", err)
+	}
+
+	touched, err := CheckProtectedDrift(baseSHA, cfg.ProtectedPaths)
+	if err != nil {
+		logger.Warn("failed to check protected drift", "error", err)
+	}
+	if len(touched) > 0 {
+		reason := fmt.Sprintf("Closing: agent modified protected paths: %v", touched)
+		if closeErr := ClosePR(cfg.Repo, prNum, reason); closeErr != nil {
+			logger.Warn("failed to close PR", "error", closeErr)
+		}
+		outcome.Status = "failed"
+		outcome.Err = fmt.Errorf("protected path drift: %v", touched)
+		return outcome
+	}
+
+	_ = WarnMissingScenario(cfg.Repo, prNum, issue.Number, cfg.ScenarioDir, logger)
+
+	// Step 4: Review/retry loop.
+	maxAttempts := cfg.MaxRetries + 1
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if ctx.Err() != nil {
+			outcome.Status = "failed"
+			outcome.Err = ctx.Err()
+			return outcome
+		}
+
+		reviewResult, err := Review(ctx, issue, prNum, cfg, prompts, authEnv, logger)
+		if err != nil {
+			outcome.Status = "failed"
+			outcome.Err = fmt.Errorf("reviewer agent: %w", err)
+			return outcome
+		}
+
+		switch reviewResult.Verdict {
+		case "APPROVED":
+			// Merge the PR.
+			if _, err := GuardRunner("gh", "pr", "merge", fmt.Sprintf("%d", prNum), "--repo", cfg.Repo, "--squash", "--delete-branch"); err != nil {
+				outcome.Status = "failed"
+				outcome.Err = fmt.Errorf("merging PR: %w", err)
+				return outcome
+			}
+			// Pull latest main.
+			if _, err := GuardRunner("git", "pull", "--rebase", "origin", "main"); err != nil {
+				logger.Warn("failed to pull after merge", "error", err)
+			}
+			outcome.Status = "implemented"
+			outcome.Retries = attempt
+			return outcome
+
+		case "CHANGES_REQUESTED":
+			retriesLeft := maxAttempts - attempt - 1
+			if retriesLeft <= 0 {
+				break // exit loop, will label needs-human-review
+			}
+
+			logger.Info("retrying implementation",
+				"issue_number", issue.Number,
+				"attempt", attempt+1,
+				"retries_left", retriesLeft,
+			)
+
+			retryResult, err := Retry(ctx, issue, prNum, cfg, prompts, authEnv, logger)
+			if err != nil {
+				outcome.Status = "failed"
+				outcome.Err = fmt.Errorf("retry agent: %w", err)
+				return outcome
+			}
+			if retryResult.TimedOut {
+				outcome.Status = "failed"
+				outcome.Err = fmt.Errorf("retry agent timed out")
+				return outcome
+			}
+
+			// Re-check drift after retry.
+			touched, err := CheckProtectedDrift(baseSHA, cfg.ProtectedPaths)
+			if err != nil {
+				logger.Warn("failed to check protected drift after retry", "error", err)
+			}
+			if len(touched) > 0 {
+				reason := fmt.Sprintf("Closing: agent modified protected paths after retry: %v", touched)
+				if closeErr := ClosePR(cfg.Repo, prNum, reason); closeErr != nil {
+					logger.Warn("failed to close PR", "error", closeErr)
+				}
+				outcome.Status = "failed"
+				outcome.Err = fmt.Errorf("protected path drift after retry: %v", touched)
+				return outcome
+			}
+
+		default:
+			// No verdict found — treat as failure.
+			outcome.Status = "failed"
+			outcome.Err = fmt.Errorf("reviewer agent did not produce a verdict")
+			return outcome
+		}
+	}
+
+	// Exhausted retries.
+	if err := LabelPR(cfg.Repo, prNum, "needs-human-review"); err != nil {
+		logger.Warn("failed to label PR", "error", err)
+	}
+	comment := fmt.Sprintf("Exhausted %d review/retry cycles. Labeling for human review.", maxAttempts)
+	if _, err := GuardRunner("gh", "pr", "comment", fmt.Sprintf("%d", prNum), "--repo", cfg.Repo, "--body", comment); err != nil {
+		logger.Warn("failed to comment on PR", "error", err)
+	}
+
+	outcome.Status = "needs-human-review"
+	outcome.Retries = maxAttempts - 1
+	return outcome
+}
+
+func trimOutput(b []byte) string {
+	s := string(b)
+	if idx := len(s) - 1; idx >= 0 && s[idx] == '\n' {
+		return s[:idx]
+	}
+	return s
+}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1,0 +1,315 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// loopTestSetup stubs both Runner (for agent invocations) and GuardRunner
+// (for git/gh commands) and returns the config. The caller configures
+// specific behavior via the provided function maps.
+type loopStubs struct {
+	// agentOutputs maps call index to stdout (simulating agent runs)
+	agentCalls   int
+	agentOutputs []string
+
+	// guardCalls records all GuardRunner invocations
+	guardCalls [][]string
+}
+
+func (s *loopStubs) nextAgentOutput() string {
+	idx := s.agentCalls
+	s.agentCalls++
+	if idx < len(s.agentOutputs) {
+		return s.agentOutputs[idx]
+	}
+	return ""
+}
+
+func setupLoopTest(t *testing.T, agentOutputs []string, guardFn func(name string, args ...string) ([]byte, error)) *loopStubs {
+	t.Helper()
+	stubs := &loopStubs{agentOutputs: agentOutputs}
+
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		out := stubs.nextAgentOutput()
+		return []byte(out), []byte(""), 0, nil
+	}
+
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		stubs.guardCalls = append(stubs.guardCalls, append([]string{name}, args...))
+		if guardFn != nil {
+			return guardFn(name, args...)
+		}
+		return []byte(""), nil
+	}
+
+	return stubs
+}
+
+func loopConfig() *config.Config {
+	return &config.Config{
+		Repo:           "owner/repo",
+		NoSandbox:      true,
+		MaxRetries:     2,
+		AgentTimeout:   "10m",
+		ProtectedPaths: []string{"CLAUDE.md"},
+		ScenarioDir:    "/nonexistent-scenario-dir",
+		ReviewDir:      "tests/review/",
+	}
+}
+
+func loopIssue() github.Issue {
+	return github.Issue{Number: 5, Title: "Test Issue", Body: "body"}
+}
+
+func TestProcessIssue_ImplementedOnFirstApproval(t *testing.T) {
+	// Agent outputs: 1=implementer, 2=reviewer(APPROVED)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if outcome.PRNumber != 10 {
+		t.Errorf("PRNumber = %d, want 10", outcome.PRNumber)
+	}
+	if outcome.Retries != 0 {
+		t.Errorf("Retries = %d, want 0", outcome.Retries)
+	}
+}
+
+func TestProcessIssue_RetriesOnChangesRequested(t *testing.T) {
+	// Agent outputs: implementer, reviewer(CHANGES), retry, reviewer(APPROVED)
+	callIdx := 0
+	setupLoopTest(t, []string{
+		"implementer output",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output",
+		"REVIEW_RESULT=APPROVED",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		callIdx++
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if outcome.Retries != 1 {
+		t.Errorf("Retries = %d, want 1", outcome.Retries)
+	}
+}
+
+func TestProcessIssue_NeedsHumanReviewAfterMaxRetries(t *testing.T) {
+	cfg := loopConfig()
+	cfg.MaxRetries = 1
+
+	// Agent outputs: implementer, reviewer(CHANGES), retry, reviewer(CHANGES)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t))
+
+	if outcome.Status != "needs-human-review" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "needs-human-review", outcome.Err)
+	}
+}
+
+func TestProcessIssue_FailedWhenNoPRFound(t *testing.T) {
+	setupLoopTest(t, []string{"implementer output"}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") {
+			return nil, fmt.Errorf("no PR found")
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if outcome.Status != "failed" {
+		t.Errorf("Status = %q, want %q", outcome.Status, "failed")
+	}
+	if !strings.Contains(outcome.Err.Error(), "did not create a PR") {
+		t.Errorf("Err = %v, want 'did not create a PR'", outcome.Err)
+	}
+}
+
+func TestProcessIssue_FailedOnProtectedDrift(t *testing.T) {
+	setupLoopTest(t, []string{"implementer output"}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("CLAUDE.md\nsrc/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if outcome.Status != "failed" {
+		t.Errorf("Status = %q, want %q", outcome.Status, "failed")
+	}
+	if !strings.Contains(outcome.Err.Error(), "protected path drift") {
+		t.Errorf("Err = %v, want 'protected path drift'", outcome.Err)
+	}
+}
+
+func TestProcessIssue_RechecksProtectedDriftAfterRetry(t *testing.T) {
+	driftCheckCount := 0
+	setupLoopTest(t, []string{
+		"implementer output",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			driftCheckCount++
+			if driftCheckCount == 2 {
+				// Second drift check (after retry) shows protected file modified
+				return []byte("CLAUDE.md\n"), nil
+			}
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if outcome.Status != "failed" {
+		t.Errorf("Status = %q, want %q", outcome.Status, "failed")
+	}
+	if driftCheckCount < 2 {
+		t.Errorf("expected at least 2 drift checks, got %d", driftCheckCount)
+	}
+}
+
+func TestProcessIssue_MergeAndPullOnApproval(t *testing.T) {
+	var mergedCalled, pullCalled bool
+	setupLoopTest(t, []string{
+		"implementer output",
+		"REVIEW_RESULT=APPROVED",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr merge") {
+			mergedCalled = true
+			if !strings.Contains(joined, "--squash") {
+				t.Error("expected --squash flag")
+			}
+			if !strings.Contains(joined, "--delete-branch") {
+				t.Error("expected --delete-branch flag")
+			}
+		}
+		if name == "git" && strings.Contains(joined, "pull --rebase") {
+			pullCalled = true
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if !mergedCalled {
+		t.Error("expected gh pr merge to be called")
+	}
+	if !pullCalled {
+		t.Error("expected git pull --rebase to be called")
+	}
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/phs/dark-factory/internal/config"
+)
+
+// Prompts holds the loaded template text for each agent prompt.
+type Prompts struct {
+	Implementer      string
+	ImplementerRetry string
+	Reviewer         string
+}
+
+// PromptData contains the values substituted into prompt templates.
+type PromptData struct {
+	IssueNumber    int
+	IssueTitle     string
+	IssueBody      string
+	Slug           string
+	Repo           string
+	PRNumber       int
+	BuildCommand   string
+	TestCommand    string
+	ProtectedPaths string
+	ScenarioDir    string
+	ReviewDir      string
+}
+
+// LoadPrompts reads the three prompt template files specified in cfg.Prompts.
+func LoadPrompts(cfg *config.Config) (*Prompts, error) {
+	impl, err := os.ReadFile(cfg.Prompts.Implementer)
+	if err != nil {
+		return nil, fmt.Errorf("reading implementer prompt %q: %w", cfg.Prompts.Implementer, err)
+	}
+
+	retry, err := os.ReadFile(cfg.Prompts.ImplementerRetry)
+	if err != nil {
+		return nil, fmt.Errorf("reading implementer_retry prompt %q: %w", cfg.Prompts.ImplementerRetry, err)
+	}
+
+	rev, err := os.ReadFile(cfg.Prompts.Reviewer)
+	if err != nil {
+		return nil, fmt.Errorf("reading reviewer prompt %q: %w", cfg.Prompts.Reviewer, err)
+	}
+
+	return &Prompts{
+		Implementer:      string(impl),
+		ImplementerRetry: string(retry),
+		Reviewer:         string(rev),
+	}, nil
+}
+
+// RenderPrompt executes a text/template against the given data and returns
+// the rendered string.
+func RenderPrompt(tmplText string, data PromptData) (string, error) {
+	t, err := template.New("prompt").Parse(tmplText)
+	if err != nil {
+		return "", fmt.Errorf("parsing prompt template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("executing prompt template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// slugRe matches characters that are not alphanumeric or hyphens.
+var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// Slugify converts a string into a branch-name-safe slug.
+// It lowercases, replaces non-alphanumeric runs with hyphens, and trims.
+func Slugify(s string) string {
+	s = strings.ToLower(s)
+	s = slugRe.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	return s
+}

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/config"
+)
+
+func TestLoadPrompts_Success(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"impl.txt":  "implement {{.IssueNumber}}",
+		"retry.txt": "retry {{.PRNumber}}",
+		"rev.txt":   "review {{.PRNumber}}",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		Prompts: config.Prompts{
+			Implementer:      filepath.Join(dir, "impl.txt"),
+			ImplementerRetry: filepath.Join(dir, "retry.txt"),
+			Reviewer:         filepath.Join(dir, "rev.txt"),
+		},
+	}
+
+	p, err := LoadPrompts(cfg)
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	if p.Implementer != files["impl.txt"] {
+		t.Errorf("Implementer = %q, want %q", p.Implementer, files["impl.txt"])
+	}
+	if p.ImplementerRetry != files["retry.txt"] {
+		t.Errorf("ImplementerRetry = %q, want %q", p.ImplementerRetry, files["retry.txt"])
+	}
+	if p.Reviewer != files["rev.txt"] {
+		t.Errorf("Reviewer = %q, want %q", p.Reviewer, files["rev.txt"])
+	}
+}
+
+func TestLoadPrompts_MissingFile(t *testing.T) {
+	cfg := &config.Config{
+		Prompts: config.Prompts{
+			Implementer:      "/nonexistent/implementer.txt",
+			ImplementerRetry: "/nonexistent/retry.txt",
+			Reviewer:         "/nonexistent/reviewer.txt",
+		},
+	}
+
+	_, err := LoadPrompts(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestRenderPrompt_SubstitutesAllFields(t *testing.T) {
+	tmpl := "Issue #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} PR={{.PRNumber}} build={{.BuildCommand}} test={{.TestCommand}} protected={{.ProtectedPaths}} scenario={{.ScenarioDir}} review={{.ReviewDir}} slug={{.Slug}}"
+
+	data := PromptData{
+		IssueNumber:    42,
+		IssueTitle:     "Add feature",
+		Repo:           "owner/repo",
+		PRNumber:       7,
+		BuildCommand:   "go build",
+		TestCommand:    "go test ./...",
+		ProtectedPaths: "CLAUDE.md, tests/scenarios/",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "add-feature",
+	}
+
+	result, err := RenderPrompt(tmpl, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+
+	expected := "Issue #42 Add feature repo=owner/repo PR=7 build=go build test=go test ./... protected=CLAUDE.md, tests/scenarios/ scenario=tests/scenarios/ review=tests/review/ slug=add-feature"
+	if result != expected {
+		t.Errorf("RenderPrompt() = %q, want %q", result, expected)
+	}
+}
+
+func TestRenderPrompt_InvalidTemplate(t *testing.T) {
+	_, err := RenderPrompt("{{.Invalid", PromptData{})
+	if err == nil {
+		t.Fatal("expected error for invalid template")
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Add feature", "add-feature"},
+		{"Fix bug #42", "fix-bug-42"},
+		{"Hello World!", "hello-world"},
+		{"  spaces  ", "spaces"},
+		{"UPPERCASE", "uppercase"},
+		{"multi---dashes", "multi-dashes"},
+		{"special@chars&here", "special-chars-here"},
+	}
+
+	for _, tt := range tests {
+		got := Slugify(tt.input)
+		if got != tt.want {
+			t.Errorf("Slugify(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/agent/reviewer.go
+++ b/internal/agent/reviewer.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// ReviewResult holds the outcome of a reviewer agent run.
+type ReviewResult struct {
+	Verdict     string // "APPROVED", "CHANGES_REQUESTED", or ""
+	AgentResult *Result
+}
+
+// Review runs the reviewer agent for the given PR and returns the verdict.
+func Review(ctx context.Context, issue github.Issue, prNum int, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*ReviewResult, error) {
+	data := newPromptData(issue, cfg, Slugify(issue.Title))
+	data.PRNumber = prNum
+
+	rendered, err := RenderPrompt(prompts.Reviewer, data)
+	if err != nil {
+		return nil, fmt.Errorf("rendering reviewer prompt: %w", err)
+	}
+
+	timeout, err := parseTimeout(cfg.AgentTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("parsing agent_timeout: %w", err)
+	}
+
+	opts := RunOpts{
+		Prompt:      rendered,
+		Env:         authEnv,
+		Image:       cfg.Docker.Image,
+		Repo:        cfg.Repo,
+		WorkDir:     "/workspace",
+		ClaudeFlags: cfg.ClaudeFlags,
+		Timeout:     timeout,
+	}
+
+	logger.Info("starting reviewer agent",
+		"issue_number", issue.Number,
+		"pr_number", prNum,
+	)
+
+	result, err := Run(ctx, opts, cfg.NoSandbox, logger)
+	if err != nil {
+		return nil, fmt.Errorf("running reviewer agent: %w", err)
+	}
+
+	verdict := ParseReviewResult(result.Stdout)
+	logger.Info("reviewer finished",
+		"issue_number", issue.Number,
+		"pr_number", prNum,
+		"verdict", verdict,
+	)
+
+	return &ReviewResult{
+		Verdict:     verdict,
+		AgentResult: result,
+	}, nil
+}

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestReview_ReturnsVerdict(t *testing.T) {
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		return []byte("output\nREVIEW_RESULT=APPROVED\nmore output"), []byte(""), 0, nil
+	}
+
+	cfg := testImplementerConfig()
+	issue := testIssue()
+	prompts := testPrompts(t)
+
+	result, err := Review(context.Background(), issue, 10, cfg, prompts, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Review() error = %v", err)
+	}
+	if result.Verdict != "APPROVED" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "APPROVED")
+	}
+}
+
+func TestReview_ChangesRequested(t *testing.T) {
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		return []byte("REVIEW_RESULT=CHANGES_REQUESTED\n"), []byte(""), 0, nil
+	}
+
+	cfg := testImplementerConfig()
+	result, err := Review(context.Background(), testIssue(), 10, cfg, testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Review() error = %v", err)
+	}
+	if result.Verdict != "CHANGES_REQUESTED" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "CHANGES_REQUESTED")
+	}
+}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -17,6 +17,15 @@ repo: ""              # GitHub repository (owner/repo)
 # roadmap_path: docs/ROADMAP.md
 # planning_dir: docs/planning/
 # scenario_dir: tests/scenarios/
+
+# Prompt templates
+prompts:
+  implementer: prompts/implementer.txt
+  implementer_retry: prompts/implementer_retry.txt
+  reviewer: prompts/reviewer.txt
+
+# Agent timeout (Go duration format: "30m", "1h", etc.)
+# agent_timeout: "30m"
 `
 
 var initCmd = &cobra.Command{

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/logging"
@@ -56,7 +59,10 @@ each unblocked issue through the implement → review → merge loop.`,
 			return fmt.Errorf("creating logger: %w", err)
 		}
 
-		return orchestrator.Run(cfg, logger, dryRun)
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		return orchestrator.Run(ctx, cfg, logger, dryRun)
 	},
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Issue      int    `yaml:"issue"`
 	MaxRetries int    `yaml:"max_retries"`
 
+	AgentTimeout string       `yaml:"agent_timeout"`
 	ClaudeFlags  []string     `yaml:"claude_flags"`
 	BuildCommand string       `yaml:"build_command"`
 	TestCommand  string       `yaml:"test_command"`

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1,18 +1,21 @@
 package orchestrator
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
+	"github.com/phs/dark-factory/internal/agent"
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/deps"
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/sandbox"
 )
 
 // Run is the main entry point for the orchestration loop.
 // It fetches issues, resolves dependencies, and either prints the execution
 // plan (dry-run) or iterates through processable issues.
-func Run(cfg *config.Config, logger *slog.Logger, dryRun bool) error {
+func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, dryRun bool) error {
 	logger.Info("starting orchestration",
 		"repo", cfg.Repo,
 		"milestone", cfg.Milestone,
@@ -54,6 +57,14 @@ func Run(cfg *config.Config, logger *slog.Logger, dryRun bool) error {
 		}
 	}
 
+	// Single-issue mode: filter processable to the requested issue.
+	if cfg.Issue != 0 {
+		processable, err = filterSingleIssue(processable, blocked, cfg.Issue)
+		if err != nil {
+			return err
+		}
+	}
+
 	logger.Info("dependency resolution complete",
 		"total", len(issues),
 		"blocked", len(blocked),
@@ -63,11 +74,26 @@ func Run(cfg *config.Config, logger *slog.Logger, dryRun bool) error {
 	// Step 4: Print or process.
 	if dryRun {
 		printDryRun(processable, blocked, len(issues))
-	} else {
-		processIssues(processable, blocked, len(issues), logger)
+		return nil
 	}
 
-	return nil
+	return processIssues(ctx, processable, blocked, len(issues), cfg, logger)
+}
+
+// filterSingleIssue extracts a single issue from processable, returning an
+// error if it's not found or is blocked.
+func filterSingleIssue(processable []github.Issue, blocked []blockedIssue, issueNum int) ([]github.Issue, error) {
+	for _, issue := range processable {
+		if issue.Number == issueNum {
+			return []github.Issue{issue}, nil
+		}
+	}
+	for _, bi := range blocked {
+		if bi.Issue.Number == issueNum {
+			return nil, fmt.Errorf("issue #%d is blocked by %s", issueNum, formatIssueRefs(bi.BlockedBy))
+		}
+	}
+	return nil, fmt.Errorf("issue #%d not found in milestone", issueNum)
 }
 
 // blockedIssue pairs an issue with its open (unresolved) dependency numbers.
@@ -115,25 +141,82 @@ func printDryRun(processable []github.Issue, blocked []blockedIssue, total int) 
 	printSummary(total, len(blocked), len(processable))
 }
 
-// processIssues iterates processable issues and logs placeholder messages.
-func processIssues(processable []github.Issue, blocked []blockedIssue, total int, logger *slog.Logger) {
+// processIssues runs each processable issue through the agent loop and prints
+// summary stats.
+func processIssues(ctx context.Context, processable []github.Issue, blocked []blockedIssue, total int, cfg *config.Config, logger *slog.Logger) error {
 	if len(processable) == 0 {
 		fmt.Println("All issues are blocked — nothing to process.")
 		printSummary(total, len(blocked), 0)
-		return
+		return nil
+	}
+
+	// Collect auth tokens once at the start.
+	authEnv, err := sandbox.CollectAuthEnv(logger)
+	if err != nil {
+		return fmt.Errorf("collecting auth: %w", err)
+	}
+
+	// Load prompt templates once.
+	prompts, err := agent.LoadPrompts(cfg)
+	if err != nil {
+		return fmt.Errorf("loading prompts: %w", err)
+	}
+
+	// Build Docker image once if using sandbox mode.
+	if !cfg.NoSandbox {
+		dc := sandbox.DockerConfigFromConfig(cfg.Docker)
+		tag, err := sandbox.BuildImage(ctx, dc, logger)
+		if err != nil {
+			return fmt.Errorf("building Docker image: %w", err)
+		}
+		cfg.Docker.Image = tag
+	}
+
+	// Process each issue.
+	var stats struct {
+		implemented      int
+		needsHumanReview int
+		failed           int
 	}
 
 	for _, issue := range processable {
-		logger.Info("would process issue (agent execution not implemented yet)",
-			"issue_number", issue.Number,
-			"title", issue.Title,
-			"priority", issue.Priority,
-		)
-		fmt.Printf("Processing #%d %s — not implemented yet (Phase 2)\n", issue.Number, issue.Title)
-	}
-	fmt.Println()
+		if ctx.Err() != nil {
+			logger.Warn("context cancelled, stopping", "error", ctx.Err())
+			break
+		}
 
-	printSummary(total, len(blocked), len(processable))
+		outcome := agent.ProcessIssue(ctx, issue, cfg, prompts, authEnv, logger)
+
+		switch outcome.Status {
+		case "implemented":
+			stats.implemented++
+			fmt.Printf("  #%d %s — implemented (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
+		case "needs-human-review":
+			stats.needsHumanReview++
+			fmt.Printf("  #%d %s — needs human review (PR #%d)\n", issue.Number, issue.Title, outcome.PRNumber)
+		default:
+			stats.failed++
+			errMsg := ""
+			if outcome.Err != nil {
+				errMsg = outcome.Err.Error()
+			}
+			fmt.Printf("  #%d %s — failed: %s\n", issue.Number, issue.Title, errMsg)
+		}
+
+		logger.Info("issue outcome",
+			"issue_number", outcome.IssueNumber,
+			"status", outcome.Status,
+			"pr_number", outcome.PRNumber,
+			"retries", outcome.Retries,
+			"error", outcome.Err,
+		)
+	}
+
+	fmt.Println()
+	fmt.Printf("Results: %d implemented, %d needs-human-review, %d failed, %d skipped (blocked)\n",
+		stats.implemented, stats.needsHumanReview, stats.failed, len(blocked))
+
+	return nil
 }
 
 // printSummary outputs the final count line.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -96,7 +97,7 @@ func TestDryRun_ListsIssuesInOrder(t *testing.T) {
 	setupFakeGH(t, openIssues, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(testConfig(), testLogger(t), true)
+		err := Run(context.Background(), testConfig(), testLogger(t), true)
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -122,7 +123,7 @@ func TestDryRun_BlockedIssuesShownSeparately(t *testing.T) {
 	setupFakeGH(t, openIssues, nil) // #99 not closed
 
 	output := captureStdout(t, func() {
-		err := Run(testConfig(), testLogger(t), true)
+		err := Run(context.Background(), testConfig(), testLogger(t), true)
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -148,7 +149,7 @@ func TestDryRun_SummaryCounts(t *testing.T) {
 	setupFakeGH(t, openIssues, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(testConfig(), testLogger(t), true)
+		err := Run(context.Background(), testConfig(), testLogger(t), true)
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -172,7 +173,7 @@ func TestDryRun_LogFileCreated(t *testing.T) {
 	}
 
 	captureStdout(t, func() {
-		if err := Run(testConfig(), logger, true); err != nil {
+		if err := Run(context.Background(), testConfig(), logger, true); err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
 	})
@@ -190,7 +191,7 @@ func TestEmptyMilestone(t *testing.T) {
 	setupFakeGH(t, []ghIssue{}, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(testConfig(), testLogger(t), true)
+		err := Run(context.Background(), testConfig(), testLogger(t), true)
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -209,7 +210,7 @@ func TestAllBlocked(t *testing.T) {
 	setupFakeGH(t, openIssues, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(testConfig(), testLogger(t), false)
+		err := Run(context.Background(), testConfig(), testLogger(t), false)
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -223,31 +224,6 @@ func TestAllBlocked(t *testing.T) {
 	}
 }
 
-func TestNormalMode_PlaceholderMessages(t *testing.T) {
-	openIssues := []ghIssue{
-		{Number: 1, Title: "first task", Labels: []ghLabel{{Name: "p1"}}},
-		{Number: 2, Title: "second task", Labels: []ghLabel{{Name: "p2"}}},
-	}
-	setupFakeGH(t, openIssues, nil)
-
-	output := captureStdout(t, func() {
-		err := Run(testConfig(), testLogger(t), false)
-		if err != nil {
-			t.Fatalf("Run() error = %v", err)
-		}
-	})
-
-	if !strings.Contains(output, "#1 first task") {
-		t.Error("expected issue #1 in output")
-	}
-	if !strings.Contains(output, "#2 second task") {
-		t.Error("expected issue #2 in output")
-	}
-	if !strings.Contains(output, "not implemented yet") {
-		t.Error("expected 'not implemented yet' placeholder")
-	}
-}
-
 func TestDryRun_ClosedDepsUnblock(t *testing.T) {
 	openIssues := []ghIssue{
 		{Number: 5, Title: "depends on closed", Body: "**Blocked by**: #3", Labels: []ghLabel{}},
@@ -255,7 +231,7 @@ func TestDryRun_ClosedDepsUnblock(t *testing.T) {
 	setupFakeGH(t, openIssues, []int{3}) // #3 is closed
 
 	output := captureStdout(t, func() {
-		err := Run(testConfig(), testLogger(t), true)
+		err := Run(context.Background(), testConfig(), testLogger(t), true)
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -301,7 +277,7 @@ func TestDryRun_PriorityDisplayed(t *testing.T) {
 	setupFakeGH(t, openIssues, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(testConfig(), testLogger(t), true)
+		err := Run(context.Background(), testConfig(), testLogger(t), true)
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -313,6 +289,73 @@ func TestDryRun_PriorityDisplayed(t *testing.T) {
 	if !strings.Contains(output, "[priority: none]") {
 		t.Error("expected priority 'none' for unlabeled issues")
 	}
+}
+
+func TestSingleIssueMode_FiltersCorrectly(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "first", Labels: []ghLabel{}},
+		{Number: 2, Title: "second", Labels: []ghLabel{}},
+		{Number: 3, Title: "third", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	cfg := testConfig()
+	cfg.Issue = 2
+
+	output := captureStdout(t, func() {
+		err := Run(context.Background(), cfg, testLogger(t), true)
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "#2 second") {
+		t.Errorf("expected issue #2 in output, got:\n%s", output)
+	}
+	// Should not contain the other issues in processable section
+	if strings.Contains(output, "#1 first") {
+		t.Errorf("expected issue #1 filtered out, got:\n%s", output)
+	}
+}
+
+func TestSingleIssueMode_ErrorWhenBlocked(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "blocked", Body: "**Blocked by**: #99", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	cfg := testConfig()
+	cfg.Issue = 1
+
+	captureStdout(t, func() {
+		err := Run(context.Background(), cfg, testLogger(t), true)
+		if err == nil {
+			t.Fatal("expected error for blocked single issue")
+		}
+		if !strings.Contains(err.Error(), "blocked by") {
+			t.Errorf("expected 'blocked by' in error, got: %v", err)
+		}
+	})
+}
+
+func TestSingleIssueMode_ErrorWhenNotFound(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "first", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	cfg := testConfig()
+	cfg.Issue = 999
+
+	captureStdout(t, func() {
+		err := Run(context.Background(), cfg, testLogger(t), true)
+		if err == nil {
+			t.Fatal("expected error for missing single issue")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("expected 'not found' in error, got: %v", err)
+		}
+	})
 }
 
 // Suppress unused import warnings.

--- a/prompts/implementer.txt
+++ b/prompts/implementer.txt
@@ -1,0 +1,29 @@
+Read CLAUDE.md completely before doing anything else.
+Then implement GitHub issue #{{.IssueNumber}} in the {{.Repo}} repository.
+
+Issue title: {{.IssueTitle}}
+Issue body:
+{{.IssueBody}}
+
+Before writing any code:
+1. Read the full issue body carefully, including any ## Test cases section
+2. Identify every file you expect to create or modify
+3. Post a brief implementation plan as a comment on the issue
+
+CRITICAL RULES:
+- Create a feature branch: git checkout -b {{.IssueNumber}}-{{.Slug}}
+- Never commit directly to main
+- Do NOT modify any protected paths: {{.ProtectedPaths}}
+- Do NOT modify files in {{.ScenarioDir}} or {{.ReviewDir}}
+
+Implementation steps:
+1. Write the implementation code
+2. Write unit tests (foo_test.go next to foo.go)
+{{- if .BuildCommand}}
+3. Run build: {{.BuildCommand}}
+{{- end}}
+{{- if .TestCommand}}
+4. Run tests: {{.TestCommand}}
+{{- end}}
+5. Commit with message including "Closes #{{.IssueNumber}}"
+6. Push the branch and open a pull request

--- a/prompts/implementer_retry.txt
+++ b/prompts/implementer_retry.txt
@@ -1,0 +1,25 @@
+You are fixing review failures on PR #{{.PRNumber}} for issue #{{.IssueNumber}} in the {{.Repo}} repository.
+
+Issue title: {{.IssueTitle}}
+Issue body:
+{{.IssueBody}}
+
+Steps:
+1. Check out the PR branch: gh pr checkout {{.PRNumber}} --repo {{.Repo}}
+2. Read review comments: gh pr view {{.PRNumber}} --repo {{.Repo}} --comments
+3. Read the issue body for original requirements
+4. Fix the issues described in the review comments
+
+CRITICAL RULES:
+- Do NOT modify any protected paths: {{.ProtectedPaths}}
+- Do NOT modify files in {{.ScenarioDir}} or {{.ReviewDir}}
+
+After fixing:
+{{- if .TestCommand}}
+1. Run tests: {{.TestCommand}}
+{{- end}}
+{{- if .BuildCommand}}
+2. Run build: {{.BuildCommand}}
+{{- end}}
+3. Commit your fixes
+4. Push to the PR branch

--- a/prompts/reviewer.txt
+++ b/prompts/reviewer.txt
@@ -1,0 +1,29 @@
+You are a code reviewer. Validate PR #{{.PRNumber}} against the scenario specs and acceptance criteria for issue #{{.IssueNumber}} in the {{.Repo}} repository.
+
+Issue title: {{.IssueTitle}}
+Issue body:
+{{.IssueBody}}
+
+Steps:
+1. Check out the PR: gh pr checkout {{.PRNumber}} --repo {{.Repo}}
+2. Read scenario spec files in {{.ScenarioDir}} that relate to issue #{{.IssueNumber}}
+3. Read the issue body for acceptance criteria
+4. Review the code changes: gh pr diff {{.PRNumber}} --repo {{.Repo}}
+{{- if .TestCommand}}
+5. Run unit tests: {{.TestCommand}}
+{{- end}}
+{{- if .BuildCommand}}
+6. Verify build: {{.BuildCommand}}
+{{- end}}
+7. Generate Go integration tests in {{.ReviewDir}} that validate the behaviors described in the scenario spec
+8. Run your integration tests: go test ./{{.ReviewDir}} -v
+
+Based on your findings:
+- If ALL tests pass and the implementation meets acceptance criteria:
+  Delete the {{.ReviewDir}} directory, approve the PR, and print REVIEW_RESULT=APPROVED
+- If ANY tests fail or acceptance criteria are not met:
+  Delete the {{.ReviewDir}} directory, request changes on the PR with specific feedback, and print REVIEW_RESULT=CHANGES_REQUESTED
+
+CRITICAL: You MUST print exactly one of these lines:
+  REVIEW_RESULT=APPROVED
+  REVIEW_RESULT=CHANGES_REQUESTED


### PR DESCRIPTION
## Summary

- Adds `internal/agent/` package with the full implement → review → retry → merge lifecycle
- Prompt template loading (`LoadPrompts`, `RenderPrompt`) with generalized templates in `prompts/`
- Agent launcher dispatching to sandbox (Docker) or host (`--no-sandbox`) execution
- Implementer agent (fresh + retry modes) and reviewer agent with verdict parsing
- PR guard rails: `FindPR`, `EnsureClosesRef`, `CheckProtectedDrift`, `ClosePR`, `LabelPR`, `WarnMissingScenario`, `ParseReviewResult`
- `ProcessIssue` loop: implement → find PR → guard rails → review/retry → squash-merge or label `needs-human-review`
- Orchestrator wired with `context.Context`, `signal.NotifyContext` for graceful shutdown, auth/prompt loading, Docker image build, single-issue mode, and stats summary
- `AgentTimeout` config field; prompt template defaults in `godark init`

## Test plan

- [x] `go test ./internal/agent/...` — 33 tests covering prompts, launcher, implementer, guardrails, reviewer, and loop
- [x] `go test ./internal/orchestrator/...` — 13 tests including 3 new single-issue mode tests
- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `go build -o bin/godark ./cmd/godark` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)