### PR TITLE
Add `godark implement` subcommand

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -105,6 +105,7 @@ before implementation begins.
 - Baseline commit recording before each issue for rollback reference
 - `git pull --rebase origin main` after each merge
 - Single-issue mode (`--issue N`)
+- `godark implement <issue-number>` — direct single-issue command (no milestone/deps)
 - Summary stats at end (implemented, skipped, failed)
 
 ---

--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	"github.com/phs/dark-factory/internal/agent"
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/logging"
+	"github.com/phs/dark-factory/internal/sandbox"
+	"github.com/spf13/cobra"
+)
+
+var implementCmd = &cobra.Command{
+	Use:   "implement <issue-number>",
+	Short: "Implement a single GitHub issue",
+	Long: `Fetch a GitHub issue by number and run the implement → review → merge
+loop directly, without milestone or dependency resolution.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		issueNumber, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid issue number %q: %w", args[0], err)
+		}
+
+		configPath, _ := cmd.Flags().GetString("config")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		flags := config.CLIFlags{Config: configPath}
+
+		if cmd.Flags().Changed("repo") {
+			v, _ := cmd.Flags().GetString("repo")
+			flags.Repo = &v
+		}
+		if cmd.Flags().Changed("max-retries") {
+			v, _ := cmd.Flags().GetInt("max-retries")
+			flags.MaxRetries = &v
+		}
+		if cmd.Flags().Changed("no-sandbox") {
+			v, _ := cmd.Flags().GetBool("no-sandbox")
+			flags.NoSandbox = &v
+		}
+
+		cfg, err := config.Load(configPath, flags)
+		if err != nil {
+			return fmt.Errorf("loading config: %w", err)
+		}
+
+		issue, err := github.FetchIssue(cfg.Repo, issueNumber)
+		if err != nil {
+			return fmt.Errorf("fetching issue #%d: %w", issueNumber, err)
+		}
+
+		if dryRun {
+			fmt.Printf("Issue #%d: %s\n", issue.Number, issue.Title)
+			fmt.Printf("Labels: %v\n", issue.Labels)
+			fmt.Printf("Body:\n%s\n", issue.Body)
+			return nil
+		}
+
+		if cfg.NoSandbox {
+			fmt.Fprintln(os.Stderr, "WARNING: running without sandbox — agent execution is not containerized")
+		}
+
+		logger, err := logging.NewLogger(cfg.LogDir)
+		if err != nil {
+			return fmt.Errorf("creating logger: %w", err)
+		}
+
+		authEnv, err := sandbox.CollectAuthEnv(logger)
+		if err != nil {
+			return fmt.Errorf("collecting auth: %w", err)
+		}
+
+		prompts, err := agent.LoadPrompts(cfg)
+		if err != nil {
+			return fmt.Errorf("loading prompts: %w", err)
+		}
+
+		if !cfg.NoSandbox {
+			dc := sandbox.DockerConfigFromConfig(cfg.Docker)
+			tag, err := sandbox.BuildImage(cmd.Context(), dc, logger)
+			if err != nil {
+				return fmt.Errorf("building Docker image: %w", err)
+			}
+			cfg.Docker.Image = tag
+		}
+
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		outcome := agent.ProcessIssue(ctx, issue, cfg, prompts, authEnv, logger)
+		if outcome.Err != nil {
+			return fmt.Errorf("issue #%d failed: %w", issueNumber, outcome.Err)
+		}
+
+		fmt.Printf("Issue #%d: %s (PR #%d, %d retries)\n",
+			outcome.IssueNumber, outcome.Status, outcome.PRNumber, outcome.Retries)
+		return nil
+	},
+}
+
+func init() {
+	f := implementCmd.Flags()
+	f.String("repo", "", "GitHub repository (owner/repo)")
+	f.Int("max-retries", 2, "Maximum review/fix retry cycles")
+	f.Bool("dry-run", false, "Print issue details and exit")
+	f.Bool("no-sandbox", false, "Run agents on host instead of in Docker")
+	f.String("config", "godark.yaml", "Path to configuration file")
+
+	rootCmd.AddCommand(implementCmd)
+}

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -149,6 +149,36 @@ func fetchNumbersByState(repo, state string) ([]int, error) {
 	return numbers, nil
 }
 
+// FetchIssue returns a single GitHub issue by number.
+func FetchIssue(repo string, number int) (Issue, error) {
+	out, err := CommandRunner("gh", "issue", "view",
+		fmt.Sprintf("%d", number),
+		"--repo", repo,
+		"--json", "number,title,body,labels",
+	)
+	if err != nil {
+		return Issue{}, fmt.Errorf("gh issue view: %w", err)
+	}
+
+	var raw ghIssue
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return Issue{}, fmt.Errorf("parsing gh output: %w", err)
+	}
+
+	labels := make([]string, len(raw.Labels))
+	for i, l := range raw.Labels {
+		labels[i] = l.Name
+	}
+
+	return Issue{
+		Number:   raw.Number,
+		Title:    raw.Title,
+		Body:     raw.Body,
+		Labels:   labels,
+		Priority: extractPriority(labels),
+	}, nil
+}
+
 // sortIssues sorts by priority rank ascending, then by issue number ascending.
 func sortIssues(issues []Issue) {
 	sort.Slice(issues, func(i, j int) bool {

--- a/internal/github/issues_test.go
+++ b/internal/github/issues_test.go
@@ -138,6 +138,50 @@ func TestFetchAllIssueNumbers(t *testing.T) {
 	}
 }
 
+func TestFetchIssue(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(`{"number":42,"title":"Add widget","body":"Please add a widget.","labels":[{"name":"p2"},{"name":"enhancement"}]}`), nil
+	}
+
+	issue, err := FetchIssue("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if issue.Number != 42 {
+		t.Errorf("number: got %d, want 42", issue.Number)
+	}
+	if issue.Title != "Add widget" {
+		t.Errorf("title: got %q, want %q", issue.Title, "Add widget")
+	}
+	if issue.Body != "Please add a widget." {
+		t.Errorf("body: got %q", issue.Body)
+	}
+	if issue.Priority != "p2" {
+		t.Errorf("priority: got %q, want %q", issue.Priority, "p2")
+	}
+	if len(issue.Labels) != 2 {
+		t.Fatalf("labels: got %d, want 2", len(issue.Labels))
+	}
+}
+
+func TestFetchIssueError(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("not found")
+	}
+
+	_, err := FetchIssue("owner/repo", 999)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
 func TestEmptyMilestone(t *testing.T) {
 	orig := CommandRunner
 	CommandRunner = fakeGH([]ghIssue{})


### PR DESCRIPTION
## Summary

- Add `FetchIssue` to `internal/github/issues.go` for fetching a single issue by number via `gh issue view`
- Add `godark implement <issue-number>` subcommand that runs the implement → review → merge loop for a single issue, bypassing milestone and dependency resolution
- Update roadmap to document the new command

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build -o bin/godark ./cmd/godark` succeeds
- [x] `bin/godark implement --help` shows expected usage
- [ ] Manual: `godark implement <N> --dry-run` fetches and prints issue details

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)