### PR TITLE
feat: add spec generation agent to ProcessIssue lifecycle

### DIFF
--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -117,19 +117,14 @@ func ParseReviewResult(stdout string) string {
 	return ""
 }
 
-// WarnMissingScenario checks whether any scenario spec file in scenarioDir
-// references the given issue number. If not, it posts a warning comment on
-// the PR.
-func WarnMissingScenario(repo string, prNum, issueNum int, scenarioDir string, logger *slog.Logger) error {
+// HasScenarioSpec returns true if any .md file in scenarioDir contains a
+// reference to the given issue number (e.g. "#5").
+func HasScenarioSpec(scenarioDir string, issueNum int) bool {
 	ref := fmt.Sprintf("#%d", issueNum)
 
 	entries, err := os.ReadDir(scenarioDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			logger.Warn("scenario directory not found", "dir", scenarioDir)
-		} else {
-			return fmt.Errorf("reading scenario dir: %w", err)
-		}
+		return false
 	}
 
 	for _, e := range entries {
@@ -141,12 +136,26 @@ func WarnMissingScenario(repo string, prNum, issueNum int, scenarioDir string, l
 			continue
 		}
 		if strings.Contains(string(data), ref) {
-			return nil // found a scenario referencing this issue
+			return true
 		}
+	}
+	return false
+}
+
+// WarnMissingScenario checks whether any scenario spec file in scenarioDir
+// references the given issue number. If not, it posts a warning comment on
+// the PR.
+func WarnMissingScenario(repo string, prNum, issueNum int, scenarioDir string, logger *slog.Logger) error {
+	if HasScenarioSpec(scenarioDir, issueNum) {
+		return nil
+	}
+
+	if _, err := os.ReadDir(scenarioDir); err != nil && os.IsNotExist(err) {
+		logger.Warn("scenario directory not found", "dir", scenarioDir)
 	}
 
 	comment := fmt.Sprintf("Warning: no scenario spec found referencing issue #%d in %s. Consider creating one with `godark create-scenario %d`.", issueNum, scenarioDir, issueNum)
-	_, err = GuardRunner("gh", "pr", "comment", strconv.Itoa(prNum), "--repo", repo, "--body", comment)
+	_, err := GuardRunner("gh", "pr", "comment", strconv.Itoa(prNum), "--repo", repo, "--body", comment)
 	if err != nil {
 		return fmt.Errorf("posting scenario warning: %w", err)
 	}

--- a/internal/agent/guardrails_test.go
+++ b/internal/agent/guardrails_test.go
@@ -142,6 +142,34 @@ func TestCheckProtectedDrift_EmptyWhenClean(t *testing.T) {
 	}
 }
 
+func TestHasScenarioSpec_Found(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.md"), []byte("Relates to: Issue #5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !HasScenarioSpec(dir, 5) {
+		t.Error("HasScenarioSpec() = false, want true")
+	}
+}
+
+func TestHasScenarioSpec_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.md"), []byte("Relates to: Issue #99\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if HasScenarioSpec(dir, 5) {
+		t.Error("HasScenarioSpec() = true, want false")
+	}
+}
+
+func TestHasScenarioSpec_MissingDir(t *testing.T) {
+	if HasScenarioSpec("/nonexistent-dir-12345", 5) {
+		t.Error("HasScenarioSpec() = true, want false for missing dir")
+	}
+}
+
 func TestWarnMissingScenario_NoWarningWhenFound(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "spec.md"), []byte("Relates to: Issue #5\n"), 0o644); err != nil {

--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -17,6 +17,13 @@ func Implement(ctx context.Context, issue github.Issue, cfg *config.Config, prom
 	slug := Slugify(issue.Title)
 	data := newPromptData(issue, cfg, slug)
 
+	// Check if the feature branch already exists on the remote.
+	branch := fmt.Sprintf("%d-%s", issue.Number, slug)
+	out, err := GuardRunner("git", "ls-remote", "--heads", "origin", branch)
+	if err == nil && strings.TrimSpace(string(out)) != "" {
+		data.BranchExists = true
+	}
+
 	rendered, err := RenderPrompt(prompts.Implementer, data)
 	if err != nil {
 		return nil, fmt.Errorf("rendering implementer prompt: %w", err)

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -34,6 +34,17 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	}
 	baseSHA := trimOutput(baseSHAOut)
 
+	// Step 0: Generate scenario spec if missing.
+	if prompts.SpecGenerator != "" && !HasScenarioSpec(cfg.ScenarioDir, issue.Number) {
+		logger.Info("no scenario spec found, generating", "issue_number", issue.Number)
+		specResult, err := GenerateSpec(ctx, issue, cfg, prompts, authEnv, logger)
+		if err != nil {
+			logger.Warn("spec generation failed, continuing without spec", "error", err)
+		} else if specResult.TimedOut {
+			logger.Warn("spec generation timed out, continuing without spec")
+		}
+	}
+
 	// Step 1: Implement.
 	implResult, err := Implement(ctx, issue, cfg, prompts, authEnv, logger)
 	if err != nil {

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -16,6 +16,7 @@ type Prompts struct {
 	Implementer      string
 	ImplementerRetry string
 	Reviewer         string
+	SpecGenerator    string
 }
 
 // PromptData contains the values substituted into prompt templates.
@@ -31,6 +32,7 @@ type PromptData struct {
 	ProtectedPaths string
 	ScenarioDir    string
 	ReviewDir      string
+	BranchExists   bool
 }
 
 // LoadPrompts reads the three prompt template files specified in cfg.Prompts.
@@ -50,11 +52,26 @@ func LoadPrompts(cfg *config.Config) (*Prompts, error) {
 		return nil, fmt.Errorf("reading reviewer prompt %q: %w", cfg.Prompts.Reviewer, err)
 	}
 
-	return &Prompts{
+	p := &Prompts{
 		Implementer:      string(impl),
 		ImplementerRetry: string(retry),
 		Reviewer:         string(rev),
-	}, nil
+	}
+
+	// SpecGenerator is optional — skip if path is empty or file doesn't exist.
+	if cfg.Prompts.SpecGenerator != "" {
+		specGen, err := os.ReadFile(cfg.Prompts.SpecGenerator)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, fmt.Errorf("reading spec_generator prompt %q: %w", cfg.Prompts.SpecGenerator, err)
+			}
+			// File doesn't exist — leave SpecGenerator empty.
+		} else {
+			p.SpecGenerator = string(specGen)
+		}
+	}
+
+	return p, nil
 }
 
 // RenderPrompt executes a text/template against the given data and returns

--- a/internal/agent/specgen.go
+++ b/internal/agent/specgen.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// GenerateSpec runs the spec generator agent to create a scenario spec for
+// the given issue. It follows the same pattern as Implement and Review.
+func GenerateSpec(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*Result, error) {
+	slug := Slugify(issue.Title)
+	data := newPromptData(issue, cfg, slug)
+
+	rendered, err := RenderPrompt(prompts.SpecGenerator, data)
+	if err != nil {
+		return nil, fmt.Errorf("rendering spec_generator prompt: %w", err)
+	}
+
+	timeout, err := parseTimeout(cfg.AgentTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("parsing agent_timeout: %w", err)
+	}
+
+	opts := RunOpts{
+		Prompt:      rendered,
+		Env:         authEnv,
+		Image:       cfg.Docker.Image,
+		Repo:        cfg.Repo,
+		Branch:      "",
+		WorkDir:     "/workspace",
+		ClaudeFlags: cfg.ClaudeFlags,
+		Timeout:     timeout,
+	}
+
+	logger.Info("starting spec generator agent",
+		"issue_number", issue.Number,
+		"issue_title", issue.Title,
+		"branch", fmt.Sprintf("%d-%s", issue.Number, slug),
+	)
+
+	return Run(ctx, opts, cfg.NoSandbox, logger)
+}

--- a/internal/agent/specgen_test.go
+++ b/internal/agent/specgen_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestGenerateSpec_RendersPromptAndCallsRun(t *testing.T) {
+	captured := stubRunner(t)
+
+	prompts := &Prompts{
+		SpecGenerator: "Generate spec for #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} slug={{.Slug}}",
+	}
+
+	result, err := GenerateSpec(context.Background(), testIssue(), testImplementerConfig(), prompts, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("GenerateSpec() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
+	}
+
+	joined := strings.Join(*captured, " ")
+	if !strings.Contains(joined, "Generate spec for #42") {
+		t.Errorf("expected rendered prompt with issue number, got: %s", joined)
+	}
+	if !strings.Contains(joined, "add-widget-support") {
+		t.Errorf("expected slug in prompt, got: %s", joined)
+	}
+}
+
+func TestGenerateSpec_InvalidTimeout(t *testing.T) {
+	stubRunner(t)
+
+	cfg := testImplementerConfig()
+	cfg.AgentTimeout = "invalid"
+
+	prompts := &Prompts{
+		SpecGenerator: "test {{.IssueNumber}}",
+	}
+
+	_, err := GenerateSpec(context.Background(), testIssue(), cfg, prompts, nil, testLogger(t))
+	if err == nil {
+		t.Fatal("expected error for invalid timeout")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,7 @@ type Prompts struct {
 	Implementer      string `yaml:"implementer"`
 	ImplementerRetry string `yaml:"implementer_retry"`
 	Reviewer         string `yaml:"reviewer"`
+	SpecGenerator    string `yaml:"spec_generator"`
 }
 
 // CLIFlags holds flag values passed on the command line.

--- a/prompts/implementer.txt
+++ b/prompts/implementer.txt
@@ -11,7 +11,11 @@ Before writing any code:
 3. Post a brief implementation plan as a comment on the issue
 
 CRITICAL RULES:
+{{- if .BranchExists}}
+- Check out the existing feature branch: git fetch origin && git checkout {{.IssueNumber}}-{{.Slug}}
+{{- else}}
 - Create a feature branch: git checkout -b {{.IssueNumber}}-{{.Slug}}
+{{- end}}
 - Never commit directly to main
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
 - Do NOT modify files in {{.ScenarioDir}} or {{.ReviewDir}}

--- a/prompts/spec_generator.txt
+++ b/prompts/spec_generator.txt
@@ -1,0 +1,42 @@
+Read CLAUDE.md completely before doing anything else.
+Then generate a scenario spec for GitHub issue #{{.IssueNumber}} in the {{.Repo}} repository.
+
+Issue title: {{.IssueTitle}}
+Issue body:
+{{.IssueBody}}
+
+Before writing the spec:
+1. Read the full issue body carefully, including any acceptance criteria
+2. Explore the codebase to understand the architecture, patterns, and conventions
+3. Read existing scenario specs in {{.ScenarioDir}} to understand the expected format
+
+CRITICAL RULES:
+- Create a feature branch: git checkout -b {{.IssueNumber}}-{{.Slug}}
+- Never commit directly to main
+- Do NOT modify any protected paths: {{.ProtectedPaths}}
+- Do NOT modify existing files in {{.ScenarioDir}}
+
+Scenario spec format (follow this exactly):
+
+```markdown
+# Scenario: <descriptive feature name>
+
+Relates to: Issue #<number>
+
+## Setup
+- Description of test fixture state and prerequisites
+
+## Cases
+
+### <Case name>
+Description of what to do.
+- Expected outcome 1
+- Expected outcome 2
+```
+
+Steps:
+1. Choose a descriptive filename (e.g., {{.ScenarioDir}}<short-slug>.md)
+2. Write the scenario spec covering all cases from the issue
+3. Include edge cases and error scenarios where appropriate
+4. Commit with message: "test: add scenario spec for issue #{{.IssueNumber}}"
+5. Push the branch: git push -u origin {{.IssueNumber}}-{{.Slug}}


### PR DESCRIPTION
## Summary
- Adds an automatic scenario spec generation step that runs before the implementer agent in `ProcessIssue`
- When a matching spec doesn't already exist and a `spec_generator` prompt is configured, a Claude Code agent explores the codebase and issue body to write a scenario spec
- Spec gen failures are non-fatal — logged as warnings, implementation proceeds as before

## Changes
- Extract `HasScenarioSpec` from `WarnMissingScenario` for reuse
- Add `SpecGenerator` to config and agent prompt structs (optional field, backward-compatible)
- Add `BranchExists` to `PromptData`; implementer checks if remote branch exists and conditionally checks out vs creates
- New `GenerateSpec` function and `prompts/spec_generator.txt` template
- Wire spec gen step into `ProcessIssue` loop before the implementer

## Test plan
- [x] `HasScenarioSpec` tests: found, not found, missing directory
- [x] `GenerateSpec` tests: renders prompt and calls Run, invalid timeout
- [x] Existing tests continue to pass (no spec generator configured = skipped)
- [x] `go vet ./...` clean
- [x] `go build -o bin/godark ./cmd/godark` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)