### PR TITLE
refactor: code quality cleanup across the codebase

### DIFF
--- a/internal/agent/guardrails_test.go
+++ b/internal/agent/guardrails_test.go
@@ -8,13 +8,6 @@ import (
 	"testing"
 )
 
-func stubGuardRunner(t *testing.T, fn func(string, ...string) ([]byte, error)) {
-	t.Helper()
-	orig := GuardRunner
-	t.Cleanup(func() { GuardRunner = orig })
-	GuardRunner = fn
-}
-
 func TestParseReviewResult_Approved(t *testing.T) {
 	stdout := "some output\nREVIEW_RESULT=APPROVED\nmore output"
 	got := ParseReviewResult(stdout)
@@ -211,6 +204,96 @@ func TestWarnMissingScenario_PostsWarningWhenMissing(t *testing.T) {
 	}
 	if !commentPosted {
 		t.Error("expected warning comment when no scenario found")
+	}
+}
+
+func TestFindPR_MalformedJSON(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return []byte(`not json`), nil
+	})
+
+	_, err := FindPR("owner/repo")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "parsing PR JSON") {
+		t.Errorf("error = %v, want 'parsing PR JSON'", err)
+	}
+}
+
+func TestEnsureClosesRef_NoOpWhenFixesPresent(t *testing.T) {
+	var editCalled bool
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "pr" && args[1] == "view" {
+			return []byte(`{"body": "Some PR body\n\nFixes #5"}`), nil
+		}
+		if len(args) > 0 && args[0] == "pr" && args[1] == "edit" {
+			editCalled = true
+		}
+		return nil, nil
+	})
+
+	err := EnsureClosesRef("owner/repo", 10, 5)
+	if err != nil {
+		t.Fatalf("EnsureClosesRef() error = %v", err)
+	}
+	if editCalled {
+		t.Error("expected no edit when Fixes ref already present")
+	}
+}
+
+func TestEnsureClosesRef_MalformedJSON(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return []byte(`not json`), nil
+	})
+
+	err := EnsureClosesRef("owner/repo", 10, 5)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+	if !strings.Contains(err.Error(), "parsing PR body") {
+		t.Errorf("error = %v, want 'parsing PR body'", err)
+	}
+}
+
+func TestClosePR_ReturnsError(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("network error")
+	})
+
+	err := ClosePR("owner/repo", 10, "reason")
+	if err == nil {
+		t.Fatal("expected error from ClosePR")
+	}
+	if !strings.Contains(err.Error(), "closing PR #10") {
+		t.Errorf("error = %v, want 'closing PR #10'", err)
+	}
+}
+
+func TestParseReviewResult_FirstMatchWins(t *testing.T) {
+	stdout := "REVIEW_RESULT=APPROVED\nREVIEW_RESULT=CHANGES_REQUESTED\n"
+	got := ParseReviewResult(stdout)
+	if got != "APPROVED" {
+		t.Errorf("ParseReviewResult() = %q, want %q (first match should win)", got, "APPROVED")
+	}
+}
+
+func TestParseReviewResult_WhitespaceHandling(t *testing.T) {
+	stdout := "  REVIEW_RESULT=APPROVED  \n"
+	got := ParseReviewResult(stdout)
+	if got != "APPROVED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
+	}
+}
+
+func TestHasScenarioSpec_SkipsNonMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("Relates to: Issue #5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if HasScenarioSpec(dir, 5) {
+		t.Error("HasScenarioSpec() should skip non-.md files")
 	}
 }
 

--- a/internal/agent/helpers_test.go
+++ b/internal/agent/helpers_test.go
@@ -1,0 +1,83 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// testLogger returns a logger that only emits errors, suitable for tests.
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// stubRunner replaces Runner with a stub that returns "ok" and captures the
+// command-line arguments. Returns a pointer to the captured args slice.
+func stubRunner(t *testing.T) *[]string {
+	t.Helper()
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+
+	var captured []string
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		captured = append([]string{name}, args...)
+		return []byte("ok"), []byte(""), 0, nil
+	}
+	return &captured
+}
+
+// stubRunnerFunc replaces Runner with a custom function for tests that need
+// to control the return values.
+func stubRunnerFunc(t *testing.T, fn func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error)) {
+	t.Helper()
+	orig := Runner
+	t.Cleanup(func() { Runner = orig })
+	Runner = fn
+}
+
+// stubGuardRunner replaces GuardRunner with the given function for the
+// duration of the test.
+func stubGuardRunner(t *testing.T, fn func(string, ...string) ([]byte, error)) {
+	t.Helper()
+	orig := GuardRunner
+	t.Cleanup(func() { GuardRunner = orig })
+	GuardRunner = fn
+}
+
+// testIssue returns a sample issue for tests.
+func testIssue() github.Issue {
+	return github.Issue{
+		Number: 42,
+		Title:  "Add Widget Support",
+		Body:   "Implement widgets for the dashboard.",
+	}
+}
+
+// testConfig returns a standard config for agent tests.
+func testConfig() *config.Config {
+	return &config.Config{
+		Repo:           "owner/repo",
+		NoSandbox:      true,
+		AgentTimeout:   "10m",
+		BuildCommand:   "go build ./...",
+		TestCommand:    "go test ./...",
+		ProtectedPaths: []string{"CLAUDE.md", "tests/scenarios/"},
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+	}
+}
+
+// testPrompts returns minimal prompt templates for tests.
+func testPrompts(t *testing.T) *Prompts {
+	t.Helper()
+	return &Prompts{
+		Implementer:      "Implement #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} slug={{.Slug}}",
+		ImplementerRetry: "Retry PR #{{.PRNumber}} for #{{.IssueNumber}} repo={{.Repo}}",
+		Reviewer:         "Review PR #{{.PRNumber}} for #{{.IssueNumber}}",
+	}
+}

--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -18,7 +18,7 @@ func Implement(ctx context.Context, issue github.Issue, cfg *config.Config, prom
 	data := newPromptData(issue, cfg, slug)
 
 	// Check if the feature branch already exists on the remote.
-	branch := fmt.Sprintf("%d-%s", issue.Number, slug)
+	branch := BranchName(issue.Number, slug)
 	out, err := GuardRunner("git", "ls-remote", "--heads", "origin", branch)
 	if err == nil && strings.TrimSpace(string(out)) != "" {
 		data.BranchExists = true
@@ -29,26 +29,15 @@ func Implement(ctx context.Context, issue github.Issue, cfg *config.Config, prom
 		return nil, fmt.Errorf("rendering implementer prompt: %w", err)
 	}
 
-	timeout, err := parseTimeout(cfg.AgentTimeout)
+	opts, err := newRunOpts(rendered, cfg, authEnv)
 	if err != nil {
-		return nil, fmt.Errorf("parsing agent_timeout: %w", err)
-	}
-
-	opts := RunOpts{
-		Prompt:      rendered,
-		Env:         authEnv,
-		Image:       cfg.Docker.Image,
-		Repo:        cfg.Repo,
-		Branch:      "",
-		WorkDir:     "/workspace",
-		ClaudeFlags: cfg.ClaudeFlags,
-		Timeout:     timeout,
+		return nil, err
 	}
 
 	logger.Info("starting implementer agent",
 		"issue_number", issue.Number,
 		"issue_title", issue.Title,
-		"branch", fmt.Sprintf("%d-%s", issue.Number, slug),
+		"branch", branch,
 	)
 
 	return Run(ctx, opts, cfg.NoSandbox, logger)
@@ -66,20 +55,9 @@ func Retry(ctx context.Context, issue github.Issue, prNumber int, cfg *config.Co
 		return nil, fmt.Errorf("rendering implementer_retry prompt: %w", err)
 	}
 
-	timeout, err := parseTimeout(cfg.AgentTimeout)
+	opts, err := newRunOpts(rendered, cfg, authEnv)
 	if err != nil {
-		return nil, fmt.Errorf("parsing agent_timeout: %w", err)
-	}
-
-	opts := RunOpts{
-		Prompt:      rendered,
-		Env:         authEnv,
-		Image:       cfg.Docker.Image,
-		Repo:        cfg.Repo,
-		Branch:      "",
-		WorkDir:     "/workspace",
-		ClaudeFlags: cfg.ClaudeFlags,
-		Timeout:     timeout,
+		return nil, err
 	}
 
 	logger.Info("starting implementer retry agent",
@@ -88,6 +66,11 @@ func Retry(ctx context.Context, issue github.Issue, prNumber int, cfg *config.Co
 	)
 
 	return Run(ctx, opts, cfg.NoSandbox, logger)
+}
+
+// BranchName returns the conventional branch name for an issue.
+func BranchName(issueNumber int, slug string) string {
+	return fmt.Sprintf("%d-%s", issueNumber, slug)
 }
 
 func newPromptData(issue github.Issue, cfg *config.Config, slug string) PromptData {
@@ -103,6 +86,25 @@ func newPromptData(issue github.Issue, cfg *config.Config, slug string) PromptDa
 		ScenarioDir:    cfg.ScenarioDir,
 		ReviewDir:      cfg.ReviewDir,
 	}
+}
+
+// newRunOpts builds a RunOpts from a rendered prompt and config. This
+// consolidates the repeated timeout-parsing + opts-construction that every
+// agent function needs.
+func newRunOpts(rendered string, cfg *config.Config, authEnv map[string]string) (RunOpts, error) {
+	timeout, err := parseTimeout(cfg.AgentTimeout)
+	if err != nil {
+		return RunOpts{}, fmt.Errorf("parsing agent_timeout: %w", err)
+	}
+	return RunOpts{
+		Prompt:      rendered,
+		Env:         authEnv,
+		Image:       cfg.Docker.Image,
+		Repo:        cfg.Repo,
+		WorkDir:     "/workspace",
+		ClaudeFlags: cfg.ClaudeFlags,
+		Timeout:     timeout,
+	}, nil
 }
 
 func parseTimeout(s string) (time.Duration, error) {

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -4,58 +4,12 @@ import (
 	"context"
 	"strings"
 	"testing"
-
-	"github.com/phs/dark-factory/internal/config"
-	"github.com/phs/dark-factory/internal/github"
 )
-
-func stubRunner(t *testing.T) *[]string {
-	t.Helper()
-	orig := Runner
-	t.Cleanup(func() { Runner = orig })
-
-	var captured []string
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
-		captured = append([]string{name}, args...)
-		return []byte("ok"), []byte(""), 0, nil
-	}
-	return &captured
-}
-
-func testIssue() github.Issue {
-	return github.Issue{
-		Number: 42,
-		Title:  "Add Widget Support",
-		Body:   "Implement widgets for the dashboard.",
-	}
-}
-
-func testImplementerConfig() *config.Config {
-	return &config.Config{
-		Repo:           "owner/repo",
-		NoSandbox:      true,
-		AgentTimeout:   "10m",
-		BuildCommand:   "go build ./...",
-		TestCommand:    "go test ./...",
-		ProtectedPaths: []string{"CLAUDE.md", "tests/scenarios/"},
-		ScenarioDir:    "tests/scenarios/",
-		ReviewDir:      "tests/review/",
-	}
-}
-
-func testPrompts(t *testing.T) *Prompts {
-	t.Helper()
-	return &Prompts{
-		Implementer:      "Implement #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} slug={{.Slug}}",
-		ImplementerRetry: "Retry PR #{{.PRNumber}} for #{{.IssueNumber}} repo={{.Repo}}",
-		Reviewer:         "Review PR #{{.PRNumber}} for #{{.IssueNumber}}",
-	}
-}
 
 func TestImplement_RendersPromptAndCallsRun(t *testing.T) {
 	captured := stubRunner(t)
 
-	result, err := Implement(context.Background(), testIssue(), testImplementerConfig(), testPrompts(t), nil, testLogger(t))
+	result, err := Implement(context.Background(), testIssue(), testConfig(), testPrompts(t), nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("Implement() error = %v", err)
 	}
@@ -76,7 +30,7 @@ func TestImplement_RendersPromptAndCallsRun(t *testing.T) {
 func TestRetry_RendersRetryPromptWithPR(t *testing.T) {
 	captured := stubRunner(t)
 
-	result, err := Retry(context.Background(), testIssue(), 7, testImplementerConfig(), testPrompts(t), nil, testLogger(t))
+	result, err := Retry(context.Background(), testIssue(), 7, testConfig(), testPrompts(t), nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("Retry() error = %v", err)
 	}
@@ -96,7 +50,7 @@ func TestRetry_RendersRetryPromptWithPR(t *testing.T) {
 func TestImplement_AgentTimeoutParsed(t *testing.T) {
 	stubRunner(t)
 
-	cfg := testImplementerConfig()
+	cfg := testConfig()
 	cfg.AgentTimeout = "5m"
 
 	_, err := Implement(context.Background(), testIssue(), cfg, testPrompts(t), nil, testLogger(t))
@@ -108,7 +62,7 @@ func TestImplement_AgentTimeoutParsed(t *testing.T) {
 func TestImplement_InvalidTimeout(t *testing.T) {
 	stubRunner(t)
 
-	cfg := testImplementerConfig()
+	cfg := testConfig()
 	cfg.AgentTimeout = "invalid"
 
 	_, err := Implement(context.Background(), testIssue(), cfg, testPrompts(t), nil, testLogger(t))
@@ -117,15 +71,85 @@ func TestImplement_InvalidTimeout(t *testing.T) {
 	}
 }
 
-func TestImplement_NonZeroExitSurfacedInResult(t *testing.T) {
-	orig := Runner
-	t.Cleanup(func() { Runner = orig })
+func TestBranchName(t *testing.T) {
+	got := BranchName(42, "add-widget-support")
+	if got != "42-add-widget-support" {
+		t.Errorf("BranchName() = %q, want %q", got, "42-add-widget-support")
+	}
+}
 
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
-		return []byte("fail output"), []byte(""), 1, nil
+func TestNewRunOpts_SetsAllFields(t *testing.T) {
+	cfg := testConfig()
+	env := map[string]string{"FOO": "bar"}
+	opts, err := newRunOpts("prompt text", cfg, env)
+	if err != nil {
+		t.Fatalf("newRunOpts() error = %v", err)
+	}
+	if opts.Prompt != "prompt text" {
+		t.Errorf("Prompt = %q, want %q", opts.Prompt, "prompt text")
+	}
+	if opts.Image != cfg.Docker.Image {
+		t.Errorf("Image = %q, want %q", opts.Image, cfg.Docker.Image)
+	}
+	if opts.Repo != cfg.Repo {
+		t.Errorf("Repo = %q, want %q", opts.Repo, cfg.Repo)
+	}
+	if opts.WorkDir != "/workspace" {
+		t.Errorf("WorkDir = %q, want %q", opts.WorkDir, "/workspace")
+	}
+	if opts.Env["FOO"] != "bar" {
+		t.Errorf("Env missing FOO=bar")
+	}
+}
+
+func TestNewRunOpts_InvalidTimeout(t *testing.T) {
+	cfg := testConfig()
+	cfg.AgentTimeout = "bad"
+	_, err := newRunOpts("prompt", cfg, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid timeout")
+	}
+}
+
+func TestImplement_BranchExistsDetection(t *testing.T) {
+	// Stub Runner (agent call) and GuardRunner (git ls-remote).
+	var capturedPrompt string
+	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		// The prompt is the 3rd argument: claude -p --dangerously-skip-permissions <prompt>
+		if len(args) >= 3 {
+			capturedPrompt = args[2]
+		}
+		return []byte("ok"), []byte(""), 0, nil
+	})
+
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		// Simulate branch existing on remote.
+		if name == "git" && len(args) > 0 && args[0] == "ls-remote" {
+			return []byte("abc123\trefs/heads/42-add-widget-support\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	// Use a template that includes BranchExists.
+	prompts := &Prompts{
+		Implementer: "{{if .BranchExists}}EXISTING{{else}}NEW{{end}}",
 	}
 
-	result, err := Implement(context.Background(), testIssue(), testImplementerConfig(), testPrompts(t), nil, testLogger(t))
+	_, err := Implement(context.Background(), testIssue(), testConfig(), prompts, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() error = %v", err)
+	}
+	if !strings.Contains(capturedPrompt, "EXISTING") {
+		t.Errorf("expected BranchExists=true in prompt, got: %s", capturedPrompt)
+	}
+}
+
+func TestImplement_NonZeroExitSurfacedInResult(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		return []byte("fail output"), []byte(""), 1, nil
+	})
+
+	result, err := Implement(context.Background(), testIssue(), testConfig(), testPrompts(t), nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("Implement() should not return error for non-zero exit, got: %v", err)
 	}

--- a/internal/agent/launcher.go
+++ b/internal/agent/launcher.go
@@ -104,7 +104,7 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 
 	claudeArgs := fmt.Sprintf("claude -p --dangerously-skip-permissions %q", opts.Prompt)
 	for _, f := range opts.ClaudeFlags {
-		claudeArgs += " " + f
+		claudeArgs += " " + fmt.Sprintf("%q", f)
 	}
 
 	cloneScript := sandbox.CloneScript(opts.Repo, opts.Branch, workDir)

--- a/internal/agent/launcher_test.go
+++ b/internal/agent/launcher_test.go
@@ -2,26 +2,16 @@ package agent
 
 import (
 	"context"
-	"log/slog"
-	"os"
 	"strings"
 	"testing"
 )
 
-func testLogger(t *testing.T) *slog.Logger {
-	t.Helper()
-	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-}
-
 func TestRun_NoSandbox_DispatchesToRunner(t *testing.T) {
-	orig := Runner
-	t.Cleanup(func() { Runner = orig })
-
 	var capturedArgs []string
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedArgs = append([]string{name}, args...)
 		return []byte("out"), []byte("err"), 0, nil
-	}
+	})
 
 	opts := RunOpts{
 		Prompt:      "test prompt",
@@ -56,12 +46,9 @@ func TestRun_NoSandbox_DispatchesToRunner(t *testing.T) {
 }
 
 func TestRun_NoSandbox_NonZeroExit(t *testing.T) {
-	orig := Runner
-	t.Cleanup(func() { Runner = orig })
-
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
 		return []byte("out"), []byte("err"), 1, nil
-	}
+	})
 
 	result, err := Run(context.Background(), RunOpts{Prompt: "test"}, true, testLogger(t))
 	if err != nil {
@@ -73,13 +60,10 @@ func TestRun_NoSandbox_NonZeroExit(t *testing.T) {
 }
 
 func TestRun_NoSandbox_Timeout(t *testing.T) {
-	orig := Runner
-	t.Cleanup(func() { Runner = orig })
-
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
 		<-ctx.Done()
 		return []byte("partial"), []byte(""), 0, ctx.Err()
-	}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Immediately cancel

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -77,17 +77,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		logger.Warn("failed to ensure Closes ref", "error", err)
 	}
 
-	touched, err := CheckProtectedDrift(baseSHA, cfg.ProtectedPaths)
-	if err != nil {
-		logger.Warn("failed to check protected drift", "error", err)
-	}
-	if len(touched) > 0 {
-		reason := fmt.Sprintf("Closing: agent modified protected paths: %v", touched)
-		if closeErr := ClosePR(cfg.Repo, prNum, reason); closeErr != nil {
-			logger.Warn("failed to close PR", "error", closeErr)
-		}
+	if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
 		outcome.Status = "failed"
-		outcome.Err = fmt.Errorf("protected path drift: %v", touched)
+		outcome.Err = driftErr
 		return outcome
 	}
 
@@ -150,17 +142,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			}
 
 			// Re-check drift after retry.
-			touched, err := CheckProtectedDrift(baseSHA, cfg.ProtectedPaths)
-			if err != nil {
-				logger.Warn("failed to check protected drift after retry", "error", err)
-			}
-			if len(touched) > 0 {
-				reason := fmt.Sprintf("Closing: agent modified protected paths after retry: %v", touched)
-				if closeErr := ClosePR(cfg.Repo, prNum, reason); closeErr != nil {
-					logger.Warn("failed to close PR", "error", closeErr)
-				}
+			if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
 				outcome.Status = "failed"
-				outcome.Err = fmt.Errorf("protected path drift after retry: %v", touched)
+				outcome.Err = driftErr
 				return outcome
 			}
 
@@ -184,6 +168,24 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	outcome.Status = "needs-human-review"
 	outcome.Retries = maxAttempts - 1
 	return outcome
+}
+
+// checkDriftAndClose checks for protected path modifications and closes the
+// PR if any are found. Returns a non-nil error only when drift is detected.
+func checkDriftAndClose(baseSHA string, cfg *config.Config, prNum int, logger *slog.Logger) error {
+	touched, err := CheckProtectedDrift(baseSHA, cfg.ProtectedPaths)
+	if err != nil {
+		logger.Warn("failed to check protected drift", "error", err)
+		return nil
+	}
+	if len(touched) == 0 {
+		return nil
+	}
+	reason := fmt.Sprintf("Closing: agent modified protected paths: %v", touched)
+	if closeErr := ClosePR(cfg.Repo, prNum, reason); closeErr != nil {
+		logger.Warn("failed to close PR", "error", closeErr)
+	}
+	return fmt.Errorf("protected path drift: %v", touched)
 }
 
 func trimOutput(b []byte) string {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -313,3 +313,98 @@ func TestProcessIssue_MergeAndPullOnApproval(t *testing.T) {
 		t.Error("expected git pull --rebase to be called")
 	}
 }
+
+func TestCheckDriftAndClose_NoDrift(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return []byte("src/main.go\n"), nil
+	})
+
+	cfg := loopConfig()
+	err := checkDriftAndClose("abc123", cfg, 10, testLogger(t))
+	if err != nil {
+		t.Errorf("expected no error when no drift, got: %v", err)
+	}
+}
+
+func TestCheckDriftAndClose_Drift(t *testing.T) {
+	var closeCalled bool
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "diff --name-only") {
+			return []byte("CLAUDE.md\nsrc/main.go\n"), nil
+		}
+		if strings.Contains(joined, "pr close") {
+			closeCalled = true
+		}
+		return []byte(""), nil
+	})
+
+	cfg := loopConfig()
+	err := checkDriftAndClose("abc123", cfg, 10, testLogger(t))
+	if err == nil {
+		t.Fatal("expected error when drift detected")
+	}
+	if !strings.Contains(err.Error(), "protected path drift") {
+		t.Errorf("error = %v, want 'protected path drift'", err)
+	}
+	if !closeCalled {
+		t.Error("expected PR to be closed")
+	}
+}
+
+func TestCheckDriftAndClose_GitDiffError(t *testing.T) {
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("git error")
+	})
+
+	cfg := loopConfig()
+	err := checkDriftAndClose("abc123", cfg, 10, testLogger(t))
+	if err != nil {
+		t.Errorf("expected nil error on git diff failure (non-fatal), got: %v", err)
+	}
+}
+
+func TestProcessIssue_SkipsSpecGenWhenNoPrompt(t *testing.T) {
+	agentCallCount := 0
+	setupLoopTest(t, []string{
+		"implementer output",
+		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	// Override Runner to count agent calls.
+	origRunner := Runner
+	t.Cleanup(func() { Runner = origRunner })
+	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+		agentCallCount++
+		if agentCallCount == 2 {
+			return []byte("reviewer output\nREVIEW_RESULT=APPROVED\n"), []byte(""), 0, nil
+		}
+		return []byte("implementer output"), []byte(""), 0, nil
+	}
+
+	// No SpecGenerator prompt → should only have 2 agent calls (implement + review).
+	prompts := testPrompts(t)
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t))
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if agentCallCount != 2 {
+		t.Errorf("expected 2 agent calls (implement + review), got %d", agentCallCount)
+	}
+}

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -59,6 +59,100 @@ func TestLoadPrompts_MissingFile(t *testing.T) {
 	}
 }
 
+func TestLoadPrompts_SpecGeneratorOptional(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"impl.txt", "retry.txt", "rev.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("template"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		Prompts: config.Prompts{
+			Implementer:      filepath.Join(dir, "impl.txt"),
+			ImplementerRetry: filepath.Join(dir, "retry.txt"),
+			Reviewer:         filepath.Join(dir, "rev.txt"),
+			// SpecGenerator intentionally empty.
+		},
+	}
+
+	p, err := LoadPrompts(cfg)
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	if p.SpecGenerator != "" {
+		t.Errorf("SpecGenerator = %q, want empty", p.SpecGenerator)
+	}
+}
+
+func TestLoadPrompts_SpecGeneratorLoaded(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"impl.txt", "retry.txt", "rev.txt", "specgen.txt"} {
+		content := "template"
+		if name == "specgen.txt" {
+			content = "specgen template"
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		Prompts: config.Prompts{
+			Implementer:      filepath.Join(dir, "impl.txt"),
+			ImplementerRetry: filepath.Join(dir, "retry.txt"),
+			Reviewer:         filepath.Join(dir, "rev.txt"),
+			SpecGenerator:    filepath.Join(dir, "specgen.txt"),
+		},
+	}
+
+	p, err := LoadPrompts(cfg)
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	if p.SpecGenerator != "specgen template" {
+		t.Errorf("SpecGenerator = %q, want %q", p.SpecGenerator, "specgen template")
+	}
+}
+
+func TestLoadPrompts_SpecGeneratorMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"impl.txt", "retry.txt", "rev.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("template"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{
+		Prompts: config.Prompts{
+			Implementer:      filepath.Join(dir, "impl.txt"),
+			ImplementerRetry: filepath.Join(dir, "retry.txt"),
+			Reviewer:         filepath.Join(dir, "rev.txt"),
+			SpecGenerator:    filepath.Join(dir, "nonexistent.txt"),
+		},
+	}
+
+	p, err := LoadPrompts(cfg)
+	if err != nil {
+		t.Fatalf("LoadPrompts() should not error for missing spec_generator, got: %v", err)
+	}
+	if p.SpecGenerator != "" {
+		t.Errorf("SpecGenerator = %q, want empty for missing file", p.SpecGenerator)
+	}
+}
+
+func TestRenderPrompt_BranchExistsField(t *testing.T) {
+	tmpl := "{{if .BranchExists}}existing{{else}}new{{end}}"
+	data := PromptData{BranchExists: true}
+	result, err := RenderPrompt(tmpl, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if result != "existing" {
+		t.Errorf("RenderPrompt() = %q, want %q", result, "existing")
+	}
+}
+
 func TestRenderPrompt_SubstitutesAllFields(t *testing.T) {
 	tmpl := "Issue #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} PR={{.PRNumber}} build={{.BuildCommand}} test={{.TestCommand}} protected={{.ProtectedPaths}} scenario={{.ScenarioDir}} review={{.ReviewDir}} slug={{.Slug}}"
 

--- a/internal/agent/reviewer.go
+++ b/internal/agent/reviewer.go
@@ -25,19 +25,9 @@ func Review(ctx context.Context, issue github.Issue, prNum int, cfg *config.Conf
 		return nil, fmt.Errorf("rendering reviewer prompt: %w", err)
 	}
 
-	timeout, err := parseTimeout(cfg.AgentTimeout)
+	opts, err := newRunOpts(rendered, cfg, authEnv)
 	if err != nil {
-		return nil, fmt.Errorf("parsing agent_timeout: %w", err)
-	}
-
-	opts := RunOpts{
-		Prompt:      rendered,
-		Env:         authEnv,
-		Image:       cfg.Docker.Image,
-		Repo:        cfg.Repo,
-		WorkDir:     "/workspace",
-		ClaudeFlags: cfg.ClaudeFlags,
-		Timeout:     timeout,
+		return nil, err
 	}
 
 	logger.Info("starting reviewer agent",

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -6,18 +6,11 @@ import (
 )
 
 func TestReview_ReturnsVerdict(t *testing.T) {
-	orig := Runner
-	t.Cleanup(func() { Runner = orig })
-
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
 		return []byte("output\nREVIEW_RESULT=APPROVED\nmore output"), []byte(""), 0, nil
-	}
+	})
 
-	cfg := testImplementerConfig()
-	issue := testIssue()
-	prompts := testPrompts(t)
-
-	result, err := Review(context.Background(), issue, 10, cfg, prompts, nil, testLogger(t))
+	result, err := Review(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("Review() error = %v", err)
 	}
@@ -27,15 +20,11 @@ func TestReview_ReturnsVerdict(t *testing.T) {
 }
 
 func TestReview_ChangesRequested(t *testing.T) {
-	orig := Runner
-	t.Cleanup(func() { Runner = orig })
-
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
 		return []byte("REVIEW_RESULT=CHANGES_REQUESTED\n"), []byte(""), 0, nil
-	}
+	})
 
-	cfg := testImplementerConfig()
-	result, err := Review(context.Background(), testIssue(), 10, cfg, testPrompts(t), nil, testLogger(t))
+	result, err := Review(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("Review() error = %v", err)
 	}

--- a/internal/agent/specgen.go
+++ b/internal/agent/specgen.go
@@ -20,26 +20,15 @@ func GenerateSpec(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		return nil, fmt.Errorf("rendering spec_generator prompt: %w", err)
 	}
 
-	timeout, err := parseTimeout(cfg.AgentTimeout)
+	opts, err := newRunOpts(rendered, cfg, authEnv)
 	if err != nil {
-		return nil, fmt.Errorf("parsing agent_timeout: %w", err)
-	}
-
-	opts := RunOpts{
-		Prompt:      rendered,
-		Env:         authEnv,
-		Image:       cfg.Docker.Image,
-		Repo:        cfg.Repo,
-		Branch:      "",
-		WorkDir:     "/workspace",
-		ClaudeFlags: cfg.ClaudeFlags,
-		Timeout:     timeout,
+		return nil, err
 	}
 
 	logger.Info("starting spec generator agent",
 		"issue_number", issue.Number,
 		"issue_title", issue.Title,
-		"branch", fmt.Sprintf("%d-%s", issue.Number, slug),
+		"branch", BranchName(issue.Number, slug),
 	)
 
 	return Run(ctx, opts, cfg.NoSandbox, logger)

--- a/internal/agent/specgen_test.go
+++ b/internal/agent/specgen_test.go
@@ -13,7 +13,7 @@ func TestGenerateSpec_RendersPromptAndCallsRun(t *testing.T) {
 		SpecGenerator: "Generate spec for #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} slug={{.Slug}}",
 	}
 
-	result, err := GenerateSpec(context.Background(), testIssue(), testImplementerConfig(), prompts, nil, testLogger(t))
+	result, err := GenerateSpec(context.Background(), testIssue(), testConfig(), prompts, nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("GenerateSpec() error = %v", err)
 	}
@@ -33,7 +33,7 @@ func TestGenerateSpec_RendersPromptAndCallsRun(t *testing.T) {
 func TestGenerateSpec_InvalidTimeout(t *testing.T) {
 	stubRunner(t)
 
-	cfg := testImplementerConfig()
+	cfg := testConfig()
 	cfg.AgentTimeout = "invalid"
 
 	prompts := &Prompts{

--- a/internal/cmd/vet_helpers.go
+++ b/internal/cmd/vet_helpers.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"os"
-	"regexp"
 	"strings"
 
+	"github.com/phs/dark-factory/internal/patterns"
 	"github.com/phs/dark-factory/internal/vet"
 	"github.com/spf13/cobra"
 )
@@ -22,14 +22,11 @@ func printReport(cmd *cobra.Command, report *vet.Report, asJSON bool) {
 	}
 }
 
-// phasePattern matches "Phase N" at the start of a milestone title.
-var phasePattern = regexp.MustCompile(`(?i)^phase\s+(\d+)`)
-
 // milestoneToLabel extracts the phase label from a milestone title.
 // "Phase 2" and "Phase 2: Vault Reader + Foundation" both become "phase-2".
 // Falls back to full lowercase-hyphenated slug if no "Phase N" prefix is found.
 func milestoneToLabel(milestone string) string {
-	if m := phasePattern.FindStringSubmatch(milestone); m != nil {
+	if m := patterns.Phase.FindStringSubmatch(milestone); m != nil {
 		return "phase-" + m[1]
 	}
 	return strings.ReplaceAll(strings.ToLower(milestone), " ", "-")

--- a/internal/deps/resolver.go
+++ b/internal/deps/resolver.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/patterns"
 )
 
 // depPattern matches dependency declarations like:
@@ -14,14 +15,11 @@ import (
 //   - BLOCKED BY: #4
 var depPattern = regexp.MustCompile(`(?im)^\**(?:blocked by|depends on)\**:\s*(.+)$`)
 
-// issueRefPattern matches issue number references like #1, #42.
-var issueRefPattern = regexp.MustCompile(`#(\d+)`)
-
 // ParseDeps extracts dependency issue numbers from an issue body.
 func ParseDeps(body string) []int {
 	var deps []int
 	for _, match := range depPattern.FindAllStringSubmatch(body, -1) {
-		refs := issueRefPattern.FindAllStringSubmatch(match[1], -1)
+		refs := patterns.IssueRef.FindAllStringSubmatch(match[1], -1)
 		for _, ref := range refs {
 			n, err := strconv.Atoi(ref[1])
 			if err != nil {

--- a/internal/deps/resolver_test.go
+++ b/internal/deps/resolver_test.go
@@ -186,3 +186,66 @@ func TestParseDeps_MixedCase(t *testing.T) {
 		t.Errorf("ParseDeps = %v, want [4]", deps)
 	}
 }
+
+func TestParseDeps_EmptyBody(t *testing.T) {
+	deps := ParseDeps("")
+	if len(deps) != 0 {
+		t.Errorf("ParseDeps(\"\") = %v, want []", deps)
+	}
+}
+
+func TestParseDeps_IssueRefWithoutBlockerPrefix(t *testing.T) {
+	// #5 appearing in normal text should NOT be treated as a dependency.
+	body := "This relates to #5 but is not blocked by anything."
+	deps := ParseDeps(body)
+	if len(deps) != 0 {
+		t.Errorf("ParseDeps = %v, want [] (refs without blocker prefix should be ignored)", deps)
+	}
+}
+
+func TestParseDeps_LargeIssueNumber(t *testing.T) {
+	body := "Blocked by: #999999"
+	deps := ParseDeps(body)
+	if len(deps) != 1 || deps[0] != 999999 {
+		t.Errorf("ParseDeps = %v, want [999999]", deps)
+	}
+}
+
+func TestResolveWithDeps(t *testing.T) {
+	issues := []github.Issue{
+		{Number: 1, Body: ""},
+		{Number: 2, Body: "**Blocked by**: #1"},
+		{Number: 3, Body: "Depends on: #99"},
+	}
+	closed := ClosedSet([]int{1})
+	result := ResolveWithDeps(issues, closed)
+	if len(result) != 2 {
+		t.Fatalf("got %d issues, want 2", len(result))
+	}
+	if result[0].Issue.Number != 1 {
+		t.Errorf("first issue = #%d, want #1", result[0].Issue.Number)
+	}
+	if result[1].Issue.Number != 2 {
+		t.Errorf("second issue = #%d, want #2", result[1].Issue.Number)
+	}
+	if len(result[1].Deps) != 1 || result[1].Deps[0] != 1 {
+		t.Errorf("issue #2 deps = %v, want [1]", result[1].Deps)
+	}
+}
+
+func TestClosedSet(t *testing.T) {
+	s := ClosedSet([]int{1, 5, 10})
+	if !s[1] || !s[5] || !s[10] {
+		t.Error("expected all numbers in set")
+	}
+	if s[2] {
+		t.Error("expected 2 to not be in set")
+	}
+}
+
+func TestClosedSet_Empty(t *testing.T) {
+	s := ClosedSet(nil)
+	if len(s) != 0 {
+		t.Errorf("expected empty set, got %v", s)
+	}
+}

--- a/internal/patterns/patterns.go
+++ b/internal/patterns/patterns.go
@@ -1,0 +1,9 @@
+package patterns
+
+import "regexp"
+
+// IssueRef matches "#N" references (e.g., #1, #42).
+var IssueRef = regexp.MustCompile(`#(\d+)`)
+
+// Phase matches "Phase N" at the start of a milestone title (case-insensitive).
+var Phase = regexp.MustCompile(`(?i)^phase\s+(\d+)`)

--- a/internal/patterns/patterns_test.go
+++ b/internal/patterns/patterns_test.go
@@ -1,0 +1,49 @@
+package patterns
+
+import "testing"
+
+func TestIssueRef_MatchesRefs(t *testing.T) {
+	matches := IssueRef.FindAllStringSubmatch("See #1, #42, and #100", -1)
+	if len(matches) != 3 {
+		t.Fatalf("expected 3 matches, got %d", len(matches))
+	}
+	want := []string{"1", "42", "100"}
+	for i, m := range matches {
+		if m[1] != want[i] {
+			t.Errorf("match[%d] = %q, want %q", i, m[1], want[i])
+		}
+	}
+}
+
+func TestIssueRef_NoMatch(t *testing.T) {
+	matches := IssueRef.FindAllString("no issue refs here", -1)
+	if len(matches) != 0 {
+		t.Errorf("expected no matches, got %v", matches)
+	}
+}
+
+func TestPhase_MatchesPhaseN(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Phase 1", "1"},
+		{"phase 2: Something", "2"},
+		{"PHASE 10", "10"},
+	}
+	for _, tt := range tests {
+		m := Phase.FindStringSubmatch(tt.input)
+		if m == nil || m[1] != tt.want {
+			t.Errorf("Phase.FindStringSubmatch(%q) = %v, want [_, %q]", tt.input, m, tt.want)
+		}
+	}
+}
+
+func TestPhase_NoMatch(t *testing.T) {
+	inputs := []string{"not a phase", "Phased approach", "1 Phase"}
+	for _, s := range inputs {
+		if Phase.MatchString(s) {
+			t.Errorf("Phase should not match %q", s)
+		}
+	}
+}

--- a/internal/sandbox/auth.go
+++ b/internal/sandbox/auth.go
@@ -88,6 +88,10 @@ func GenerateClaudeConfig(workDir string) string {
 			},
 		},
 	}
-	data, _ := json.MarshalIndent(cfg, "", "  ")
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		// This should never happen with a simple struct, but handle it.
+		return "{}"
+	}
 	return string(data)
 }

--- a/internal/sandbox/container.go
+++ b/internal/sandbox/container.go
@@ -104,9 +104,10 @@ func RunContainer(ctx context.Context, opts RunOpts, logger *slog.Logger) (*RunR
 	} else if err != nil {
 		return nil, fmt.Errorf("docker wait: %w\noutput: %s", err, out)
 	} else {
-		code, parseErr := strconv.Atoi(strings.TrimSpace(string(out)))
+		trimmed := strings.TrimSpace(string(out))
+		code, parseErr := strconv.Atoi(trimmed)
 		if parseErr != nil {
-			return nil, fmt.Errorf("parsing exit code %q: %w", strings.TrimSpace(string(out)), parseErr)
+			return nil, fmt.Errorf("parsing exit code %q: %w", trimmed, parseErr)
 		}
 		result.ExitCode = code
 	}

--- a/internal/vet/issues.go
+++ b/internal/vet/issues.go
@@ -7,13 +7,11 @@ import (
 	"strings"
 
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/patterns"
 )
 
 // blockerPattern matches "Blocked by: #1, #2" or "Depends on: #3" lines.
 var blockerPattern = regexp.MustCompile(`(?i)^(?:blocked by|depends on)\s*:\s*(.+)$`)
-
-// issueRefPattern matches "#N" references.
-var issueRefPattern = regexp.MustCompile(`#(\d+)`)
 
 // ValidateIssues checks that each issue has the required structure for agent
 // consumption. It returns a report of findings.
@@ -57,7 +55,7 @@ func ValidateIssues(issues []github.Issue, allIssueNumbers map[int]bool, phaseLa
 			}
 
 			// Check each referenced issue exists
-			refs := issueRefPattern.FindAllStringSubmatch(m[1], -1)
+			refs := patterns.IssueRef.FindAllStringSubmatch(m[1], -1)
 			for _, ref := range refs {
 				num, _ := strconv.Atoi(ref[1])
 				if !allIssueNumbers[num] {

--- a/internal/vet/roadmap.go
+++ b/internal/vet/roadmap.go
@@ -9,10 +9,8 @@ import (
 	"strings"
 
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/patterns"
 )
-
-// phasePattern matches "Phase N" at the start of a milestone title.
-var phasePattern = regexp.MustCompile(`(?i)^phase\s+(\d+)`)
 
 // issueHeadingPattern matches "## Issue N:" or "## Issue #N:" headings.
 var issueHeadingPattern = regexp.MustCompile(`(?i)^##\s+issue\s+#?(\d+)\s*:`)
@@ -80,7 +78,7 @@ func ValidateRoadmap(planningDir string, milestoneIssues []github.Issue, milesto
 // pattern "phase-N" have one consistent with the milestone title.
 func checkLabelMismatch(r *Report, milestoneIssues []github.Issue, milestoneTitle string) {
 	var expectedLabel string
-	if m := phasePattern.FindStringSubmatch(milestoneTitle); m != nil {
+	if m := patterns.Phase.FindStringSubmatch(milestoneTitle); m != nil {
 		expectedLabel = "phase-" + m[1]
 	} else {
 		expectedLabel = strings.ReplaceAll(strings.ToLower(milestoneTitle), " ", "-")

--- a/internal/vet/scenarios.go
+++ b/internal/vet/scenarios.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/patterns"
 )
 
 // relatesToPattern matches "Relates to: Issue #N" lines, capturing all #N refs.
@@ -86,7 +87,7 @@ func validateScenarioFile(r *Report, path string, allIssueNumbers map[int]bool) 
 			continue
 		}
 		hasRelatesTo = true
-		refs := issueRefPattern.FindAllStringSubmatch(m[1], -1)
+		refs := patterns.IssueRef.FindAllStringSubmatch(m[1], -1)
 		if len(refs) == 0 {
 			r.Add(Finding{Severity: Error, Location: loc, Message: fmt.Sprintf("malformed Relates to line (no issue refs): %q", trimmed)})
 			continue


### PR DESCRIPTION
## Summary
- Deduplicate agent boilerplate: `newRunOpts`, `checkDriftAndClose`, `BranchName` helpers eliminate repeated code across 4+ agent functions
- Extract shared regex patterns (`issueRefPattern`, `phasePattern`) into `internal/patterns` package — were duplicated in deps, vet, and cmd packages
- Consolidate scattered test helpers into `helpers_test.go` with consistent `stubRunner`/`stubRunnerFunc`/`stubGuardRunner` patterns
- Fix minor bugs: unhandled `json.MarshalIndent` error, duplicate `TrimSpace`, unquoted `ClaudeFlags` in sandbox shell command
- Add ~30 new test cases covering edge cases, error paths, and previously untested helpers

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` — all 11 packages pass
- [x] `go build -o bin/godark ./cmd/godark` succeeds
- [x] Pre-push hooks (test + vet) pass
- [ ] Verify no behavior changes in existing agent execution paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)