### PR TITLE
feat: replace claude CLI invocation with Python agent_runner.py

### DIFF
--- a/internal/agent/helpers_test.go
+++ b/internal/agent/helpers_test.go
@@ -16,24 +16,26 @@ func testLogger(t *testing.T) *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
-// stubRunner replaces Runner with a stub that returns "ok" and captures the
-// command-line arguments. Returns a pointer to the captured args slice.
+// stubRunner replaces Runner with a stub that returns a minimal JSON result and
+// captures the command-line arguments. Returns a pointer to the captured args slice.
 func stubRunner(t *testing.T) *[]string {
 	t.Helper()
 	orig := Runner
 	t.Cleanup(func() { Runner = orig })
 
 	var captured []string
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		captured = append([]string{name}, args...)
-		return []byte("ok"), []byte(""), 0, nil
+		// Return a valid final JSON line so parseRunnerOutput succeeds.
+		out := env["GODARK_PROMPT"] + "\n" + `{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
 	}
 	return &captured
 }
 
 // stubRunnerFunc replaces Runner with a custom function for tests that need
 // to control the return values.
-func stubRunnerFunc(t *testing.T, fn func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error)) {
+func stubRunnerFunc(t *testing.T, fn func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error)) {
 	t.Helper()
 	orig := Runner
 	t.Cleanup(func() { Runner = orig })

--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -29,7 +29,7 @@ func Implement(ctx context.Context, issue github.Issue, cfg *config.Config, prom
 		return nil, fmt.Errorf("rendering implementer prompt: %w", err)
 	}
 
-	opts, err := newRunOpts(rendered, cfg, authEnv)
+	opts, err := newRunOpts(rendered, cfg, authEnv, "implementer")
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func Retry(ctx context.Context, issue github.Issue, prNumber int, cfg *config.Co
 		return nil, fmt.Errorf("rendering implementer_retry prompt: %w", err)
 	}
 
-	opts, err := newRunOpts(rendered, cfg, authEnv)
+	opts, err := newRunOpts(rendered, cfg, authEnv, "implementer")
 	if err != nil {
 		return nil, err
 	}
@@ -88,22 +88,22 @@ func newPromptData(issue github.Issue, cfg *config.Config, slug string) PromptDa
 	}
 }
 
-// newRunOpts builds a RunOpts from a rendered prompt and config. This
+// newRunOpts builds a RunOpts from a rendered prompt, config, and role. This
 // consolidates the repeated timeout-parsing + opts-construction that every
 // agent function needs.
-func newRunOpts(rendered string, cfg *config.Config, authEnv map[string]string) (RunOpts, error) {
+func newRunOpts(rendered string, cfg *config.Config, authEnv map[string]string, role string) (RunOpts, error) {
 	timeout, err := parseTimeout(cfg.AgentTimeout)
 	if err != nil {
 		return RunOpts{}, fmt.Errorf("parsing agent_timeout: %w", err)
 	}
 	return RunOpts{
-		Prompt:      rendered,
-		Env:         authEnv,
-		Image:       cfg.Docker.Image,
-		Repo:        cfg.Repo,
-		WorkDir:     "/workspace",
-		ClaudeFlags: cfg.ClaudeFlags,
-		Timeout:     timeout,
+		Prompt:  rendered,
+		Role:    role,
+		Env:     authEnv,
+		Image:   cfg.Docker.Image,
+		Repo:    cfg.Repo,
+		WorkDir: "/workspace",
+		Timeout: timeout,
 	}, nil
 }
 

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -17,18 +17,39 @@ func TestImplement_RendersPromptAndCallsRun(t *testing.T) {
 		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
 	}
 
-	// Verify the rendered prompt was passed to claude
+	// Verify the rendered prompt was set in GODARK_PROMPT (captured via stubRunner's output).
+	// stubRunner includes GODARK_PROMPT in its output for easy assertion.
 	joined := strings.Join(*captured, " ")
-	if !strings.Contains(joined, "Implement #42") {
-		t.Errorf("expected rendered prompt with issue number, got: %s", joined)
+	_ = joined // command is python3 <path>, prompt is in env not args
+}
+
+func TestImplement_PromptContainsIssueDetails(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Implement(context.Background(), testIssue(), testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() error = %v", err)
 	}
-	if !strings.Contains(joined, "add-widget-support") {
-		t.Errorf("expected slug in prompt, got: %s", joined)
+
+	prompt := capturedEnv["GODARK_PROMPT"]
+	if !strings.Contains(prompt, "Implement #42") {
+		t.Errorf("expected rendered prompt with issue number, got: %s", prompt)
+	}
+	if !strings.Contains(prompt, "add-widget-support") {
+		t.Errorf("expected slug in prompt, got: %s", prompt)
 	}
 }
 
 func TestRetry_RendersRetryPromptWithPR(t *testing.T) {
-	captured := stubRunner(t)
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
 
 	result, err := Retry(context.Background(), testIssue(), 7, testConfig(), testPrompts(t), nil, testLogger(t))
 	if err != nil {
@@ -38,12 +59,12 @@ func TestRetry_RendersRetryPromptWithPR(t *testing.T) {
 		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
 	}
 
-	joined := strings.Join(*captured, " ")
-	if !strings.Contains(joined, "Retry PR #7") {
-		t.Errorf("expected retry prompt with PR number, got: %s", joined)
+	prompt := capturedEnv["GODARK_PROMPT"]
+	if !strings.Contains(prompt, "Retry PR #7") {
+		t.Errorf("expected retry prompt with PR number, got: %s", prompt)
 	}
-	if !strings.Contains(joined, "#42") {
-		t.Errorf("expected issue number in retry prompt, got: %s", joined)
+	if !strings.Contains(prompt, "#42") {
+		t.Errorf("expected issue number in retry prompt, got: %s", prompt)
 	}
 }
 
@@ -81,12 +102,15 @@ func TestBranchName(t *testing.T) {
 func TestNewRunOpts_SetsAllFields(t *testing.T) {
 	cfg := testConfig()
 	env := map[string]string{"FOO": "bar"}
-	opts, err := newRunOpts("prompt text", cfg, env)
+	opts, err := newRunOpts("prompt text", cfg, env, "implementer")
 	if err != nil {
 		t.Fatalf("newRunOpts() error = %v", err)
 	}
 	if opts.Prompt != "prompt text" {
 		t.Errorf("Prompt = %q, want %q", opts.Prompt, "prompt text")
+	}
+	if opts.Role != "implementer" {
+		t.Errorf("Role = %q, want %q", opts.Role, "implementer")
 	}
 	if opts.Image != cfg.Docker.Image {
 		t.Errorf("Image = %q, want %q", opts.Image, cfg.Docker.Image)
@@ -105,7 +129,7 @@ func TestNewRunOpts_SetsAllFields(t *testing.T) {
 func TestNewRunOpts_InvalidTimeout(t *testing.T) {
 	cfg := testConfig()
 	cfg.AgentTimeout = "bad"
-	_, err := newRunOpts("prompt", cfg, nil)
+	_, err := newRunOpts("prompt", cfg, nil, "implementer")
 	if err == nil {
 		t.Fatal("expected error for invalid timeout")
 	}
@@ -113,13 +137,10 @@ func TestNewRunOpts_InvalidTimeout(t *testing.T) {
 
 func TestImplement_BranchExistsDetection(t *testing.T) {
 	// Stub Runner (agent call) and GuardRunner (git ls-remote).
-	var capturedPrompt string
-	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
-		// The prompt is the 3rd argument: claude -p --dangerously-skip-permissions <prompt>
-		if len(args) >= 3 {
-			capturedPrompt = args[2]
-		}
-		return []byte("ok"), []byte(""), 0, nil
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
 	})
 
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
@@ -139,13 +160,15 @@ func TestImplement_BranchExistsDetection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Implement() error = %v", err)
 	}
-	if !strings.Contains(capturedPrompt, "EXISTING") {
-		t.Errorf("expected BranchExists=true in prompt, got: %s", capturedPrompt)
+	// The prompt is passed via GODARK_PROMPT env var, not args.
+	prompt := capturedEnv["GODARK_PROMPT"]
+	if !strings.Contains(prompt, "EXISTING") {
+		t.Errorf("expected BranchExists=true in prompt, got: %s", prompt)
 	}
 }
 
 func TestImplement_NonZeroExitSurfacedInResult(t *testing.T) {
-	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		return []byte("fail output"), []byte(""), 1, nil
 	})
 

--- a/internal/agent/launcher.go
+++ b/internal/agent/launcher.go
@@ -2,37 +2,49 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"strings"
 	"time"
 
+	"github.com/phs/dark-factory/internal/agent/runner"
 	"github.com/phs/dark-factory/internal/sandbox"
 )
 
 // RunOpts configures an agent invocation.
 type RunOpts struct {
-	Prompt      string
-	Env         map[string]string
-	Image       string
-	Repo        string
-	Branch      string
-	WorkDir     string
-	ClaudeFlags []string
-	Timeout     time.Duration
+	Prompt  string
+	Role    string
+	Env     map[string]string
+	Image   string
+	Repo    string
+	Branch  string
+	WorkDir string
+	Timeout time.Duration
 }
 
 // Result holds the outcome of an agent run.
 type Result struct {
-	ExitCode int
-	Stdout   string
-	Stderr   string
-	TimedOut bool
+	ExitCode  int
+	Stdout    string
+	Stderr    string
+	TimedOut  bool
+	SessionID string
+	CostUSD   float64
 }
 
-// Runner executes a command on the host. Replaceable for testing.
-var Runner = func(ctx context.Context, name string, args ...string) (stdout, stderr []byte, exitCode int, err error) {
+// Runner executes a command on the host with the given environment. Replaceable for testing.
+var Runner = func(ctx context.Context, env map[string]string, name string, args ...string) (stdout, stderr []byte, exitCode int, err error) {
 	cmd := exec.CommandContext(ctx, name, args...)
+	if len(env) > 0 {
+		cmd.Env = os.Environ()
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
 	var outBuf, errBuf []byte
 	cmd.Stdout = &writerFunc{fn: func(p []byte) { outBuf = append(outBuf, p...) }}
 	cmd.Stderr = &writerFunc{fn: func(p []byte) { errBuf = append(errBuf, p...) }}
@@ -75,23 +87,60 @@ func runHost(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result, e
 		defer cancel()
 	}
 
-	args := []string{"-p", "--dangerously-skip-permissions", opts.Prompt}
-	args = append(args, opts.ClaudeFlags...)
+	// Write embedded agent_runner.py to a temp file.
+	pyContent, err := runner.FS.ReadFile("agent_runner.py")
+	if err != nil {
+		return nil, fmt.Errorf("reading embedded agent_runner.py: %w", err)
+	}
 
-	stdout, stderr, exitCode, err := Runner(ctx, "claude", args...)
+	tmpFile, err := os.CreateTemp("", "godark-agent-*.py")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp file for agent runner: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write(pyContent); err != nil {
+		tmpFile.Close()
+		return nil, fmt.Errorf("writing agent_runner.py to temp file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return nil, fmt.Errorf("closing temp agent runner file: %w", err)
+	}
+
+	// Build env vars: merge RunOpts.Env, then add GODARK_* vars.
+	env := make(map[string]string, len(opts.Env)+2)
+	for k, v := range opts.Env {
+		env[k] = v
+	}
+	env["GODARK_PROMPT"] = opts.Prompt
+	if opts.Role != "" {
+		env["GODARK_ROLE"] = opts.Role
+	}
+
+	stdout, stderr, exitCode, err := Runner(ctx, env, "python3", tmpFile.Name())
 	if ctx.Err() != nil {
 		return &Result{TimedOut: true, Stdout: string(stdout), Stderr: string(stderr)}, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("running claude on host: %w", err)
+		return nil, fmt.Errorf("running agent runner on host: %w", err)
 	}
 
-	logger.Info("host agent finished", "exit_code", exitCode)
-	return &Result{
+	res := &Result{
 		ExitCode: exitCode,
 		Stdout:   string(stdout),
 		Stderr:   string(stderr),
-	}, nil
+	}
+
+	if parsed := parseRunnerOutput(string(stdout)); parsed != nil {
+		res.SessionID = parsed.SessionID
+		res.CostUSD = parsed.CostUSD
+		if parsed.IsError && res.ExitCode == 0 {
+			res.ExitCode = 1
+		}
+	}
+
+	logger.Info("host agent finished", "exit_code", res.ExitCode)
+	return res, nil
 }
 
 func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result, error) {
@@ -102,20 +151,19 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 		workDir = "/workspace"
 	}
 
-	// Pass the prompt via environment variable to avoid shell quoting issues.
-	env := make(map[string]string, len(opts.Env)+1)
+	// Pass the prompt and role via environment variables to avoid shell quoting issues.
+	env := make(map[string]string, len(opts.Env)+2)
 	for k, v := range opts.Env {
 		env[k] = v
 	}
 	env["GODARK_PROMPT"] = opts.Prompt
-
-	claudeArgs := "claude -p --dangerously-skip-permissions \"$GODARK_PROMPT\""
-	for _, f := range opts.ClaudeFlags {
-		claudeArgs += " " + fmt.Sprintf("%q", f)
+	if opts.Role != "" {
+		env["GODARK_ROLE"] = opts.Role
 	}
 
+	agentCmd := "cd " + workDir + " && python3 /usr/local/bin/agent_runner.py"
 	cloneScript := sandbox.CloneScript(opts.Repo, opts.Branch, workDir)
-	entrypoint := sandbox.EntrypointScript(cloneScript, "cd "+workDir+" && "+claudeArgs)
+	entrypoint := sandbox.EntrypointScript(cloneScript, agentCmd)
 
 	sandboxOpts := sandbox.RunOpts{
 		Image:   opts.Image,
@@ -137,12 +185,48 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 		)
 	}
 
-	return &Result{
+	res := &Result{
 		ExitCode: result.ExitCode,
 		Stdout:   result.Stdout,
 		Stderr:   result.Stderr,
 		TimedOut: result.TimedOut,
-	}, nil
+	}
+
+	if parsed := parseRunnerOutput(result.Stdout); parsed != nil {
+		res.SessionID = parsed.SessionID
+		res.CostUSD = parsed.CostUSD
+		if parsed.IsError && res.ExitCode == 0 {
+			res.ExitCode = 1
+		}
+	}
+
+	return res, nil
+}
+
+// runnerFinalResult is the structured JSON output printed as the last line by agent_runner.py.
+type runnerFinalResult struct {
+	SessionID string  `json:"session_id"`
+	Result    string  `json:"result"`
+	CostUSD   float64 `json:"cost_usd"`
+	IsError   bool    `json:"is_error"`
+}
+
+// parseRunnerOutput extracts the structured final result from runner stdout.
+// The runner prints a final JSON line with session_id, result, cost_usd, and is_error.
+func parseRunnerOutput(stdout string) *runnerFinalResult {
+	lines := strings.Split(stdout, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		var r runnerFinalResult
+		if err := json.Unmarshal([]byte(line), &r); err == nil {
+			return &r
+		}
+		break
+	}
+	return nil
 }
 
 // truncate returns the last n bytes of s.

--- a/internal/agent/launcher_test.go
+++ b/internal/agent/launcher_test.go
@@ -6,47 +6,146 @@ import (
 	"testing"
 )
 
-func TestRun_NoSandbox_DispatchesToRunner(t *testing.T) {
-	var capturedArgs []string
-	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
-		capturedArgs = append([]string{name}, args...)
-		return []byte("out"), []byte("err"), 0, nil
+func TestRun_NoSandbox_InvokesPython3(t *testing.T) {
+	var capturedName string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedName = name
+		return []byte(`{"session_id":"","result":"done","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
 	})
 
-	opts := RunOpts{
-		Prompt:      "test prompt",
-		ClaudeFlags: []string{"--model", "opus"},
-	}
+	opts := RunOpts{Prompt: "test prompt"}
 	result, err := Run(context.Background(), opts, true, testLogger(t))
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 
+	if capturedName != "python3" {
+		t.Errorf("expected command 'python3', got %q", capturedName)
+	}
 	if result.ExitCode != 0 {
 		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
 	}
-	if result.Stdout != "out" {
-		t.Errorf("Stdout = %q, want %q", result.Stdout, "out")
+}
+
+func TestRun_NoSandbox_ScriptPathAsArg(t *testing.T) {
+	var capturedArgs []string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedArgs = args
+		return []byte(`{"session_id":"","result":"done","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Run(context.Background(), RunOpts{Prompt: "test"}, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
 	}
 
-	// Check claude was called with correct args
-	if capturedArgs[0] != "claude" {
-		t.Errorf("expected command 'claude', got %q", capturedArgs[0])
+	if len(capturedArgs) == 0 {
+		t.Fatal("expected at least one arg (script path)")
 	}
-	joined := strings.Join(capturedArgs, " ")
-	if !strings.Contains(joined, "test prompt") {
-		t.Error("expected prompt in args")
+	if !strings.HasSuffix(capturedArgs[0], ".py") {
+		t.Errorf("first arg should be .py file, got %q", capturedArgs[0])
 	}
-	if !strings.Contains(joined, "--model") {
-		t.Error("expected ClaudeFlags in args")
+}
+
+func TestRun_NoSandbox_PromptInEnv(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	opts := RunOpts{Prompt: "my special prompt"}
+	_, err := Run(context.Background(), opts, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
 	}
-	if !strings.Contains(joined, "--dangerously-skip-permissions") {
-		t.Error("expected --dangerously-skip-permissions in args")
+
+	if capturedEnv["GODARK_PROMPT"] != "my special prompt" {
+		t.Errorf("GODARK_PROMPT = %q, want %q", capturedEnv["GODARK_PROMPT"], "my special prompt")
+	}
+}
+
+func TestRun_NoSandbox_RoleInEnv(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	opts := RunOpts{Prompt: "test", Role: "implementer"}
+	_, err := Run(context.Background(), opts, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_ROLE"] != "implementer" {
+		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "implementer")
+	}
+}
+
+func TestRun_NoSandbox_AuthEnvForwarded(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	opts := RunOpts{
+		Prompt: "test",
+		Env:    map[string]string{"GH_TOKEN": "tok-abc"},
+	}
+	_, err := Run(context.Background(), opts, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if capturedEnv["GH_TOKEN"] != "tok-abc" {
+		t.Errorf("GH_TOKEN = %q, want %q", capturedEnv["GH_TOKEN"], "tok-abc")
+	}
+}
+
+func TestRun_NoSandbox_ParsesStructuredResult(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := "some message line\n" + `{"session_id":"sess-123","result":"Implementation complete","cost_usd":0.42,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	opts := RunOpts{Prompt: "test"}
+	result, err := Run(context.Background(), opts, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.SessionID != "sess-123" {
+		t.Errorf("SessionID = %q, want %q", result.SessionID, "sess-123")
+	}
+	if result.CostUSD != 0.42 {
+		t.Errorf("CostUSD = %v, want 0.42", result.CostUSD)
+	}
+}
+
+func TestRun_NoSandbox_ErrorResult(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"sess-456","result":"error","cost_usd":0,"is_error":true}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	opts := RunOpts{Prompt: "test"}
+	result, err := Run(context.Background(), opts, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.ExitCode != 1 {
+		t.Errorf("ExitCode = %d, want 1 for is_error=true", result.ExitCode)
+	}
+	if result.SessionID != "sess-456" {
+		t.Errorf("SessionID = %q, want %q", result.SessionID, "sess-456")
 	}
 }
 
 func TestRun_NoSandbox_NonZeroExit(t *testing.T) {
-	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		return []byte("out"), []byte("err"), 1, nil
 	})
 
@@ -60,7 +159,7 @@ func TestRun_NoSandbox_NonZeroExit(t *testing.T) {
 }
 
 func TestRun_NoSandbox_Timeout(t *testing.T) {
-	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		<-ctx.Done()
 		return []byte("partial"), []byte(""), 0, ctx.Err()
 	})
@@ -74,5 +173,42 @@ func TestRun_NoSandbox_Timeout(t *testing.T) {
 	}
 	if !result.TimedOut {
 		t.Error("expected TimedOut = true")
+	}
+}
+
+func TestRun_NoSandbox_NoDangerouslySkipPermissions(t *testing.T) {
+	var capturedArgs []string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedArgs = append([]string{name}, args...)
+		return []byte(`{"session_id":"","result":"","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Run(context.Background(), RunOpts{Prompt: "test"}, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	joined := strings.Join(capturedArgs, " ")
+	if strings.Contains(joined, "--dangerously-skip-permissions") {
+		t.Error("should not contain --dangerously-skip-permissions")
+	}
+}
+
+func TestRun_NoSandbox_PromptNotInArgs(t *testing.T) {
+	var capturedArgs []string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedArgs = append([]string{name}, args...)
+		return []byte(`{"session_id":"","result":"","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	const prompt = "my unique prompt text"
+	_, err := Run(context.Background(), RunOpts{Prompt: prompt}, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	joined := strings.Join(capturedArgs, " ")
+	if strings.Contains(joined, prompt) {
+		t.Error("prompt should not appear in CLI args (it is passed via env var)")
 	}
 }

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -42,7 +42,7 @@ func setupLoopTest(t *testing.T, agentOutputs []string, guardFn func(name string
 		GuardRunner = origGuard
 	})
 
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		out := stubs.nextAgentOutput()
 		return []byte(out), []byte(""), 0, nil
 	}
@@ -383,7 +383,7 @@ func TestProcessIssue_SkipsSpecGenWhenNoPrompt(t *testing.T) {
 	// Override Runner to count agent calls.
 	origRunner := Runner
 	t.Cleanup(func() { Runner = origRunner })
-	Runner = func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		agentCallCount++
 		if agentCallCount == 2 {
 			return []byte("reviewer output\nREVIEW_RESULT=APPROVED\n"), []byte(""), 0, nil

--- a/internal/agent/reviewer.go
+++ b/internal/agent/reviewer.go
@@ -25,7 +25,7 @@ func Review(ctx context.Context, issue github.Issue, prNum int, cfg *config.Conf
 		return nil, fmt.Errorf("rendering reviewer prompt: %w", err)
 	}
 
-	opts, err := newRunOpts(rendered, cfg, authEnv)
+	opts, err := newRunOpts(rendered, cfg, authEnv, "reviewer")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestReview_ReturnsVerdict(t *testing.T) {
-	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		return []byte("output\nREVIEW_RESULT=APPROVED\nmore output"), []byte(""), 0, nil
 	})
 
@@ -20,7 +20,7 @@ func TestReview_ReturnsVerdict(t *testing.T) {
 }
 
 func TestReview_ChangesRequested(t *testing.T) {
-	stubRunnerFunc(t, func(ctx context.Context, name string, args ...string) ([]byte, []byte, int, error) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		return []byte("REVIEW_RESULT=CHANGES_REQUESTED\n"), []byte(""), 0, nil
 	})
 

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Agent runner for dark-factory.
+
+Reads configuration from environment variables and invokes the Claude Agent SDK.
+Streams all messages to stdout as newline-delimited JSON and prints a final
+structured result line.
+
+Environment variables:
+  GODARK_PROMPT          The prompt text to send to the agent
+  GODARK_ROLE            Agent role: implementer, reviewer, or spec_generator
+  GODARK_SESSION_ID      Session ID for resuming a previous session
+  GODARK_WORKDIR         Working directory (default: /workspace)
+  GH_TOKEN               GitHub token forwarded to the agent environment
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+import claude_agent_sdk
+from claude_agent_sdk import ClaudeCodeOptions, ResultMessage
+
+
+async def main() -> None:
+    prompt = os.environ.get("GODARK_PROMPT", "")
+    session_id = os.environ.get("GODARK_SESSION_ID", "")
+    work_dir = os.environ.get("GODARK_WORKDIR", "/workspace")
+
+    env: dict = {}
+    for key in ("GH_TOKEN", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
+        if key in os.environ:
+            env[key] = os.environ[key]
+
+    options = ClaudeCodeOptions(
+        permission_mode="bypassPermissions",
+        setting_sources=["project"],
+        system_prompt={"type": "preset", "preset": "claude_code"},
+        cwd=work_dir,
+        env=env if env else None,
+    )
+
+    if session_id:
+        options.resume = session_id
+
+    result_session_id = ""
+    result_text = ""
+    cost_usd = 0.0
+    is_error = False
+
+    async for message in claude_agent_sdk.query(prompt=prompt, options=options):
+        try:
+            msg_dict = message.model_dump() if hasattr(message, "model_dump") else vars(message)
+        except Exception:
+            msg_dict = {"type": type(message).__name__, "raw": str(message)}
+        print(json.dumps(msg_dict), flush=True)
+
+        if isinstance(message, ResultMessage):
+            result_session_id = getattr(message, "session_id", "") or ""
+            result_text = getattr(message, "result", "") or ""
+            cost_usd = float(getattr(message, "cost_usd", 0.0) or 0.0)
+            is_error = bool(getattr(message, "is_error", False))
+
+    final = {
+        "session_id": result_session_id,
+        "result": result_text,
+        "cost_usd": cost_usd,
+        "is_error": is_error,
+    }
+    print(json.dumps(final), flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/internal/agent/runner/embed.go
+++ b/internal/agent/runner/embed.go
@@ -1,0 +1,9 @@
+// Package runner provides the embedded Python agent runner script.
+package runner
+
+import "embed"
+
+// FS holds the embedded agent_runner.py file.
+//
+//go:embed agent_runner.py
+var FS embed.FS

--- a/internal/agent/runner/embed_test.go
+++ b/internal/agent/runner/embed_test.go
@@ -1,0 +1,39 @@
+package runner_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/agent/runner"
+)
+
+func TestAgentRunnerPyIsEmbedded(t *testing.T) {
+	content, err := runner.FS.ReadFile("agent_runner.py")
+	if err != nil {
+		t.Fatalf("ReadFile(agent_runner.py): %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("agent_runner.py is empty")
+	}
+}
+
+func TestAgentRunnerPyImportsClaude(t *testing.T) {
+	content, err := runner.FS.ReadFile("agent_runner.py")
+	if err != nil {
+		t.Fatalf("ReadFile(agent_runner.py): %v", err)
+	}
+	s := string(content)
+	if !strings.Contains(s, "claude_agent_sdk") {
+		t.Error("agent_runner.py does not import claude_agent_sdk")
+	}
+}
+
+func TestAgentRunnerPyReadsGodarkPrompt(t *testing.T) {
+	content, err := runner.FS.ReadFile("agent_runner.py")
+	if err != nil {
+		t.Fatalf("ReadFile(agent_runner.py): %v", err)
+	}
+	if !strings.Contains(string(content), "GODARK_PROMPT") {
+		t.Error("agent_runner.py does not read GODARK_PROMPT from environment")
+	}
+}

--- a/internal/agent/specgen.go
+++ b/internal/agent/specgen.go
@@ -20,7 +20,7 @@ func GenerateSpec(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		return nil, fmt.Errorf("rendering spec_generator prompt: %w", err)
 	}
 
-	opts, err := newRunOpts(rendered, cfg, authEnv)
+	opts, err := newRunOpts(rendered, cfg, authEnv, "spec_generator")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/specgen_test.go
+++ b/internal/agent/specgen_test.go
@@ -7,7 +7,11 @@ import (
 )
 
 func TestGenerateSpec_RendersPromptAndCallsRun(t *testing.T) {
-	captured := stubRunner(t)
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
 
 	prompts := &Prompts{
 		SpecGenerator: "Generate spec for #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} slug={{.Slug}}",
@@ -21,12 +25,12 @@ func TestGenerateSpec_RendersPromptAndCallsRun(t *testing.T) {
 		t.Errorf("ExitCode = %d, want 0", result.ExitCode)
 	}
 
-	joined := strings.Join(*captured, " ")
-	if !strings.Contains(joined, "Generate spec for #42") {
-		t.Errorf("expected rendered prompt with issue number, got: %s", joined)
+	prompt := capturedEnv["GODARK_PROMPT"]
+	if !strings.Contains(prompt, "Generate spec for #42") {
+		t.Errorf("expected rendered prompt with issue number, got: %s", prompt)
 	}
-	if !strings.Contains(joined, "add-widget-support") {
-		t.Errorf("expected slug in prompt, got: %s", joined)
+	if !strings.Contains(prompt, "add-widget-support") {
+		t.Errorf("expected slug in prompt, got: %s", prompt)
 	}
 }
 

--- a/internal/sandbox/build.go
+++ b/internal/sandbox/build.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/phs/dark-factory/internal/agent/runner"
 )
 
 // CommandRunner executes a command and returns its combined output.
@@ -35,6 +37,17 @@ func BuildImage(ctx context.Context, cfg DockerConfig, logger *slog.Logger) (str
 	dfPath := filepath.Join(tmpDir, "Dockerfile")
 	if err := os.WriteFile(dfPath, []byte(content), 0o644); err != nil {
 		return "", fmt.Errorf("writing Dockerfile: %w", err)
+	}
+
+	// Write embedded agent_runner.py to the build context so the COPY
+	// directive in the Dockerfile can find it.
+	pyContent, err := runner.FS.ReadFile("agent_runner.py")
+	if err != nil {
+		return "", fmt.Errorf("reading embedded agent_runner.py: %w", err)
+	}
+	pyPath := filepath.Join(tmpDir, "agent_runner.py")
+	if err := os.WriteFile(pyPath, pyContent, 0o644); err != nil {
+		return "", fmt.Errorf("writing agent_runner.py to build context: %w", err)
 	}
 
 	out, err := CommandRunner("docker", "build", "-t", tag, "-f", dfPath, tmpDir)

--- a/internal/sandbox/dockerfile.go
+++ b/internal/sandbox/dockerfile.go
@@ -14,6 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     gnupg \
+    python3 \
+    python3-pip \
 {{- range .ExtraPackages}}
     {{.}} \
 {{- end}}
@@ -39,6 +41,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_{{.NodeVersion}}.x | bash - \
 
 # Install Claude Code
 RUN npm install -g @anthropic-ai/claude-code
+
+# Install Python agent runner dependencies
+RUN pip install claude-agent-sdk
+
+# Copy agent runner
+COPY agent_runner.py /usr/local/bin/agent_runner.py
 
 # Create non-root user
 RUN useradd -m -s /bin/bash {{.User}}

--- a/internal/sandbox/dockerfile_test.go
+++ b/internal/sandbox/dockerfile_test.go
@@ -3,6 +3,8 @@ package sandbox
 import (
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -85,6 +87,9 @@ func TestGenerateDockerfileDefault(t *testing.T) {
 		{"go install", "go1.26.0.linux-amd64.tar.gz"},
 		{"node install", "setup_20.x"},
 		{"useradd", "useradd -m -s /bin/bash devloop"},
+		{"python3 install", "python3"},
+		{"pip sdk install", "pip install claude-agent-sdk"},
+		{"copy agent runner", "COPY agent_runner.py /usr/local/bin/agent_runner.py"},
 	}
 	for _, c := range checks {
 		if !strings.Contains(df, c.contain) {
@@ -212,5 +217,63 @@ func TestBuildImageStubbedCommandRunner(t *testing.T) {
 	}
 	if !foundTag {
 		t.Errorf("docker build missing -t %s in args: %v", tag, capturedArgs)
+	}
+}
+
+func TestBuildImageWritesAgentRunner(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	var agentRunnerFound bool
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		// During docker build, check that agent_runner.py is present in the build context.
+		if name == "docker" && len(args) > 0 && args[0] == "build" {
+			// The build context dir is the last argument.
+			buildDir := args[len(args)-1]
+			pyPath := filepath.Join(buildDir, "agent_runner.py")
+			if _, err := os.Stat(pyPath); err == nil {
+				agentRunnerFound = true
+			}
+		}
+		return []byte("Successfully built"), nil
+	}
+
+	_, err := BuildImage(context.Background(), DefaultDockerConfig(), slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !agentRunnerFound {
+		t.Error("agent_runner.py was not written to the build context before docker build")
+	}
+}
+
+func TestGenerateDockerfileIncludesPython3(t *testing.T) {
+	df, err := GenerateDockerfile(DefaultDockerConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(df, "python3") {
+		t.Error("Dockerfile missing python3 in apt-get install")
+	}
+}
+
+func TestGenerateDockerfileIncludesPipInstall(t *testing.T) {
+	df, err := GenerateDockerfile(DefaultDockerConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(df, "pip install claude-agent-sdk") {
+		t.Error("Dockerfile missing 'pip install claude-agent-sdk'")
+	}
+}
+
+func TestGenerateDockerfileCopiesAgentRunner(t *testing.T) {
+	df, err := GenerateDockerfile(DefaultDockerConfig())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(df, "COPY agent_runner.py /usr/local/bin/agent_runner.py") {
+		t.Error("Dockerfile missing COPY agent_runner.py directive")
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces `claude -p --dangerously-skip-permissions` subprocess with a Python script (`agent_runner.py`) that uses the Claude Agent SDK's `query()` function
- Embeds `agent_runner.py` in the Go binary via `//go:embed` (new `internal/agent/runner` package)
- Updates `runHost()` to write the embedded script to a temp file and invoke `python3 <tempfile>` with env vars (`GODARK_PROMPT`, `GODARK_ROLE`)
- Updates `runSandbox()` entrypoint to call `python3 /usr/local/bin/agent_runner.py`
- Updates Dockerfile template to install `python3`, `python3-pip`, `pip install claude-agent-sdk`, and `COPY agent_runner.py`
- Updates `BuildImage()` to write embedded `agent_runner.py` to the temp build context before `docker build`
- Removes `ClaudeFlags` from `RunOpts`; adds `Role string`, `SessionID string`, `CostUSD float64`
- Runner now accepts `env map[string]string` for passing env vars to subprocesses

## Test plan

- [x] `go test ./internal/agent/runner/...` — embedded file tests pass
- [x] `go test ./internal/agent/...` — all agent tests pass (updated stubs to new Runner signature)
- [x] `go test ./internal/sandbox/...` — Dockerfile/BuildImage tests pass (new Python/pip/COPY assertions)
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — no issues

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)