### PR TITLE
Phase 5 planning and pull-after-merge fix

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -178,3 +178,46 @@ making it easy for humans to spot-check agent work.
 - GitHub diff links for each PR (easy human spot-checking)
 - Manual test punchlist generation at end of each dev-loop run
 - Log viewer (parsed JSON structured logs with filtering)
+
+---
+
+## Phase 7: Review Quality & Code Quality Gates
+
+**Goal**: Ensure the reviewer agent is doing genuine, thorough work — not
+rubberstamping. Add automated quality gates that catch shallow reviews and
+improve overall code quality in the dev loop.
+
+**Milestone**: `Phase 7` | **Label**: `phase-7`
+
+### Review depth validation
+- Tool trace floor: reject reviews where the reviewer didn't read the PR diff,
+  run tests, or generate review tests in `tests/review/`
+- Token/cost floor: flag suspiciously cheap reviews (below a configurable
+  threshold) as likely rubberstamps
+- Review body quality check: verify the reviewer's PR review contains specific
+  file references and concrete observations (not generic "looks good")
+
+### Mandatory review test execution
+- Hard gate: reviewer must create and run ephemeral tests in `tests/review/`
+  for the review to count — no tests means automatic `CHANGES_REQUESTED`
+- Verify via PostToolUse audit trace: scan for Write to `tests/review/` and
+  Bash with `go test ./tests/review/`
+
+### Canary defect injection
+- Before review, inject a known trivial bug into the PR (e.g., a syntax error
+  or failing test assertion) via a guard rail step
+- If the reviewer approves despite the canary, the review is invalid
+- Remove the canary before merge if the reviewer catches it
+- Configurable: `canary_defects: true` in `godark.yaml` (default off)
+
+### Dual-reviewer sampling
+- Configurable percentage of PRs get a second independent review
+- If the two reviewers disagree, escalate to `needs-human-review`
+- Provides ground truth for calibrating other quality gates
+- `dual_review_sample_rate: 0.1` in `godark.yaml` (default 0, disabled)
+
+### Configurable lint gate
+- Run a configurable lint command (e.g., `golangci-lint run`) as an additional
+  quality gate after the implementer finishes, before review
+- Lint failures trigger a retry without consuming a review cycle
+- `lint_command` in `godark.yaml` (default empty, disabled)

--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -12,6 +12,7 @@ import (
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/logging"
+	"github.com/phs/dark-factory/internal/orchestrator"
 	"github.com/phs/dark-factory/internal/sandbox"
 	"github.com/spf13/cobra"
 )
@@ -101,6 +102,13 @@ loop directly, without milestone or dependency resolution.`,
 
 		fmt.Printf("Issue #%d: %s (PR #%d, %d retries)\n",
 			outcome.IssueNumber, outcome.Status, outcome.PRNumber, outcome.Retries)
+
+		if outcome.Status == "implemented" {
+			if err := orchestrator.PullAfterMerge(logger); err != nil {
+				logger.Warn("could not sync local repo after merge", "error", err)
+			}
+		}
+
 		return nil
 	},
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os/exec"
+	"strings"
 
 	"github.com/phs/dark-factory/internal/agent"
 	"github.com/phs/dark-factory/internal/config"
@@ -191,6 +193,10 @@ func processIssues(ctx context.Context, processable []github.Issue, blocked []bl
 		case "implemented":
 			stats.implemented++
 			fmt.Printf("  #%d %s — implemented (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
+			if err := PullAfterMerge(logger); err != nil {
+				logger.Warn("stopping loop: could not sync local repo after merge", "error", err)
+				break
+			}
 		case "needs-human-review":
 			stats.needsHumanReview++
 			fmt.Printf("  #%d %s — needs human review (PR #%d)\n", issue.Number, issue.Title, outcome.PRNumber)
@@ -222,6 +228,43 @@ func processIssues(ctx context.Context, processable []github.Issue, blocked []bl
 // printSummary outputs the final count line.
 func printSummary(total, blocked, processable int) {
 	fmt.Printf("Summary: %d total, %d blocked, %d processable\n", total, blocked, processable)
+}
+
+// CommandRunner executes a command and returns its combined output.
+// Replaceable for testing.
+var CommandRunner = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// PullAfterMerge syncs the local repo with the remote after a successful merge.
+// If the working tree is dirty, it logs an actionable message and returns an
+// error so the orchestration loop can stop gracefully.
+func PullAfterMerge(logger *slog.Logger) error {
+	_, err := CommandRunner("git", "pull", "--rebase", "origin", "main")
+	if err == nil {
+		logger.Info("pulled latest changes after merge")
+		return nil
+	}
+
+	// Check if the repo is dirty.
+	out, statusErr := CommandRunner("git", "status", "--porcelain")
+	if statusErr != nil {
+		logger.Warn("failed to pull after merge and could not check repo status",
+			"pull_error", err,
+			"status_error", statusErr,
+		)
+		return fmt.Errorf("pull after merge failed: %w", err)
+	}
+
+	if dirty := strings.TrimSpace(string(out)); dirty != "" {
+		logger.Warn("local repo has uncommitted changes — commit your changes then run: git pull --rebase origin main",
+			"dirty_files", dirty,
+		)
+		return fmt.Errorf("local repo is dirty, cannot pull after merge")
+	}
+
+	logger.Warn("failed to pull after merge", "error", err)
+	return fmt.Errorf("pull after merge failed: %w", err)
 }
 
 // formatIssueRefs formats a slice of issue numbers as "#1, #2, #3".


### PR DESCRIPTION
## Summary
- Update roadmap: mark Phases 2 and 3 as complete, add Phase 5 issue numbers (#36–#41), add Phase 7 (Review Quality)
- Fix pull-after-merge to detect dirty repos and log actionable instructions instead of cryptic `exit status 128`
- Add `PullAfterMerge` to both `godark run` loop and `godark implement` command

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `go build ./cmd/godark` succeeds
- [ ] Run `godark implement` with uncommitted local changes — verify warning message appears
- [ ] Run `godark implement` with clean repo — verify pull succeeds silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)