### PR TITLE
fix: update agent_runner.py for claude-agent-sdk v0.1 rename

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -216,6 +216,12 @@ improve overall code quality in the dev loop.
 - Provides ground truth for calibrating other quality gates
 - `dual_review_sample_rate: 0.1` in `godark.yaml` (default 0, disabled)
 
+### SDK version check
+- On startup, check PyPI for the latest `claude-agent-sdk` version and warn if
+  it exceeds the pinned range (`>=0.1.0,<0.2.0`) in the generated Dockerfile
+- Gives early notice that a new major/minor SDK version is available and may
+  require migration work before the pin can be bumped
+
 ### Configurable lint gate
 - Run a configurable lint command (e.g., `golangci-lint run`) as an additional
   quality gate after the implementer finishes, before review

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -19,7 +19,7 @@ import os
 import sys
 
 import claude_agent_sdk
-from claude_agent_sdk import ClaudeCodeOptions, ResultMessage
+from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
 
 
 async def main() -> None:
@@ -32,7 +32,7 @@ async def main() -> None:
         if key in os.environ:
             env[key] = os.environ[key]
 
-    options = ClaudeCodeOptions(
+    options = ClaudeAgentOptions(
         permission_mode="bypassPermissions",
         setting_sources=["project"],
         system_prompt={"type": "preset", "preset": "claude_code"},
@@ -58,7 +58,7 @@ async def main() -> None:
         if isinstance(message, ResultMessage):
             result_session_id = getattr(message, "session_id", "") or ""
             result_text = getattr(message, "result", "") or ""
-            cost_usd = float(getattr(message, "cost_usd", 0.0) or 0.0)
+            cost_usd = float(getattr(message, "total_cost_usd", 0.0) or 0.0)
             is_error = bool(getattr(message, "is_error", False))
 
     final = {

--- a/internal/sandbox/dockerfile.go
+++ b/internal/sandbox/dockerfile.go
@@ -43,7 +43,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_{{.NodeVersion}}.x | bash - \
 RUN npm install -g @anthropic-ai/claude-code
 
 # Install Python agent runner dependencies
-RUN pip install claude-agent-sdk
+RUN pip install 'claude-agent-sdk>=0.1.0,<0.2.0'
 
 # Copy agent runner
 COPY agent_runner.py /usr/local/bin/agent_runner.py

--- a/internal/sandbox/dockerfile_test.go
+++ b/internal/sandbox/dockerfile_test.go
@@ -88,7 +88,7 @@ func TestGenerateDockerfileDefault(t *testing.T) {
 		{"node install", "setup_20.x"},
 		{"useradd", "useradd -m -s /bin/bash devloop"},
 		{"python3 install", "python3"},
-		{"pip sdk install", "pip install claude-agent-sdk"},
+		{"pip sdk install", "pip install 'claude-agent-sdk>=0.1.0,<0.2.0'"},
 		{"copy agent runner", "COPY agent_runner.py /usr/local/bin/agent_runner.py"},
 	}
 	for _, c := range checks {
@@ -263,8 +263,8 @@ func TestGenerateDockerfileIncludesPipInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(df, "pip install claude-agent-sdk") {
-		t.Error("Dockerfile missing 'pip install claude-agent-sdk'")
+	if !strings.Contains(df, "pip install 'claude-agent-sdk>=0.1.0,<0.2.0'") {
+		t.Error("Dockerfile missing pinned claude-agent-sdk install")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Rename `ClaudeCodeOptions` → `ClaudeAgentOptions` and `cost_usd` → `total_cost_usd` in `agent_runner.py` to match claude-agent-sdk v0.1 API
- Pin SDK to `>=0.1.0,<0.2.0` in generated Dockerfile to prevent future surprise breakage
- Add SDK version check item to Phase 7 roadmap

## Test plan
- [x] `go test ./...` passes
- [ ] Rebuild Docker image and run `godark implement` against an issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)