### PR TITLE
feat: role-scoped tool permissions for each agent role

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -55,7 +55,7 @@ func Retry(ctx context.Context, issue github.Issue, prNumber int, cfg *config.Co
 		return nil, fmt.Errorf("rendering implementer_retry prompt: %w", err)
 	}
 
-	opts, err := newRunOpts(rendered, cfg, authEnv, "implementer")
+	opts, err := newRunOpts(rendered, cfg, authEnv, "implementer_retry")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -167,6 +167,40 @@ func TestImplement_BranchExistsDetection(t *testing.T) {
 	}
 }
 
+func TestImplement_SetsImplementerRole(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Implement(context.Background(), testIssue(), testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_ROLE"] != "implementer" {
+		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "implementer")
+	}
+}
+
+func TestRetry_SetsImplementerRetryRole(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Retry(context.Background(), testIssue(), 7, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Retry() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_ROLE"] != "implementer_retry" {
+		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "implementer_retry")
+	}
+}
+
 func TestImplement_NonZeroExitSurfacedInResult(t *testing.T) {
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		return []byte("fail output"), []byte(""), 1, nil

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -32,3 +32,20 @@ func TestReview_ChangesRequested(t *testing.T) {
 		t.Errorf("Verdict = %q, want %q", result.Verdict, "CHANGES_REQUESTED")
 	}
 }
+
+func TestReview_SetsReviewerRole(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte("REVIEW_RESULT=APPROVED\n"), []byte(""), 0, nil
+	})
+
+	_, err := Review(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Review() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_ROLE"] != "reviewer" {
+		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "reviewer")
+	}
+}

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -7,7 +7,7 @@ structured result line.
 
 Environment variables:
   GODARK_PROMPT          The prompt text to send to the agent
-  GODARK_ROLE            Agent role: implementer, reviewer, or spec_generator
+  GODARK_ROLE            Agent role: implementer, implementer_retry, reviewer, or spec_generator
   GODARK_SESSION_ID      Session ID for resuming a previous session
   GODARK_WORKDIR         Working directory (default: /workspace)
   GH_TOKEN               GitHub token forwarded to the agent environment
@@ -21,11 +21,42 @@ import sys
 import claude_agent_sdk
 from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
 
+# Role-scoped tool permissions. Each role maps to allowed_tools and optionally
+# disallowed_tools. disallowed_tools are hard-denied even if allowed_tools
+# would otherwise permit them.
+_ROLE_PERMISSIONS: dict[str, dict] = {
+    "implementer": {
+        "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+    },
+    "implementer_retry": {
+        "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+    },
+    "reviewer": {
+        "allowed_tools": ["Read", "Glob", "Grep", "Bash"],
+        "disallowed_tools": ["Write", "Edit"],
+    },
+    "spec_generator": {
+        "allowed_tools": ["Read", "Write", "Glob", "Grep"],
+        "disallowed_tools": ["Bash"],
+    },
+}
+
 
 async def main() -> None:
     prompt = os.environ.get("GODARK_PROMPT", "")
+    role = os.environ.get("GODARK_ROLE", "")
     session_id = os.environ.get("GODARK_SESSION_ID", "")
     work_dir = os.environ.get("GODARK_WORKDIR", "/workspace")
+
+    if role not in _ROLE_PERMISSIONS:
+        valid = ", ".join(sorted(_ROLE_PERMISSIONS.keys()))
+        print(
+            f"error: unknown GODARK_ROLE {role!r}; valid roles are: {valid}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    permissions = _ROLE_PERMISSIONS[role]
 
     env: dict = {}
     for key in ("GH_TOKEN", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
@@ -38,6 +69,8 @@ async def main() -> None:
         system_prompt={"type": "preset", "preset": "claude_code"},
         cwd=work_dir,
         env=env if env else None,
+        allowed_tools=permissions.get("allowed_tools"),
+        disallowed_tools=permissions.get("disallowed_tools"),
     )
 
     if session_id:

--- a/internal/agent/runner/embed_test.go
+++ b/internal/agent/runner/embed_test.go
@@ -37,3 +37,59 @@ func TestAgentRunnerPyReadsGodarkPrompt(t *testing.T) {
 		t.Error("agent_runner.py does not read GODARK_PROMPT from environment")
 	}
 }
+
+// TestAgentRunnerPyReviewerDisallowsWrite verifies that the reviewer role
+// configuration in agent_runner.py hard-denies Write and Edit tools via
+// disallowed_tools.
+func TestAgentRunnerPyReviewerDisallowsWrite(t *testing.T) {
+	content, err := runner.FS.ReadFile("agent_runner.py")
+	if err != nil {
+		t.Fatalf("ReadFile(agent_runner.py): %v", err)
+	}
+	s := string(content)
+	if !strings.Contains(s, `"reviewer"`) {
+		t.Error("agent_runner.py does not define reviewer role")
+	}
+	if !strings.Contains(s, "disallowed_tools") {
+		t.Error("agent_runner.py does not use disallowed_tools")
+	}
+	// Verify that Write and Edit appear in the disallowed section associated with reviewer.
+	reviewerIdx := strings.Index(s, `"reviewer"`)
+	if reviewerIdx < 0 {
+		t.Fatal("reviewer role not found in agent_runner.py")
+	}
+	reviewerSection := s[reviewerIdx:]
+	// The next role entry starts a new quoted key; find the boundary.
+	nextRoleIdx := strings.Index(reviewerSection[1:], `"implementer"`)
+	if nextRoleIdx < 0 {
+		nextRoleIdx = len(reviewerSection)
+	} else {
+		nextRoleIdx++ // account for the offset
+	}
+	reviewerSection = reviewerSection[:nextRoleIdx]
+	if !strings.Contains(reviewerSection, `"Write"`) {
+		t.Error("reviewer disallowed_tools does not include Write")
+	}
+	if !strings.Contains(reviewerSection, `"Edit"`) {
+		t.Error("reviewer disallowed_tools does not include Edit")
+	}
+}
+
+// TestAgentRunnerPyUnknownRoleExits verifies that agent_runner.py contains
+// logic to exit with a non-zero code when GODARK_ROLE is not a known role.
+func TestAgentRunnerPyUnknownRoleExits(t *testing.T) {
+	content, err := runner.FS.ReadFile("agent_runner.py")
+	if err != nil {
+		t.Fatalf("ReadFile(agent_runner.py): %v", err)
+	}
+	s := string(content)
+	if !strings.Contains(s, "GODARK_ROLE") {
+		t.Error("agent_runner.py does not read GODARK_ROLE from environment")
+	}
+	if !strings.Contains(s, "sys.exit(1)") {
+		t.Error("agent_runner.py does not call sys.exit(1) for unknown roles")
+	}
+	if !strings.Contains(s, "unknown GODARK_ROLE") {
+		t.Error("agent_runner.py does not print a descriptive error for unknown roles")
+	}
+}

--- a/internal/agent/specgen_test.go
+++ b/internal/agent/specgen_test.go
@@ -34,6 +34,27 @@ func TestGenerateSpec_RendersPromptAndCallsRun(t *testing.T) {
 	}
 }
 
+func TestGenerateSpec_SetsSpecGeneratorRole(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	prompts := &Prompts{
+		SpecGenerator: "Generate spec for #{{.IssueNumber}}",
+	}
+
+	_, err := GenerateSpec(context.Background(), testIssue(), testConfig(), prompts, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("GenerateSpec() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_ROLE"] != "spec_generator" {
+		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "spec_generator")
+	}
+}
+
 func TestGenerateSpec_InvalidTimeout(t *testing.T) {
 	stubRunner(t)
 


### PR DESCRIPTION
## Summary

- Adds `_ROLE_PERMISSIONS` dict in `agent_runner.py` mapping each role to `allowed_tools` and `disallowed_tools`:
  - `implementer` / `implementer_retry`: full read/write/execute (`Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`)
  - `reviewer`: read-only tools + `Bash` for test/diff commands; `Write` and `Edit` hard-denied via `disallowed_tools`
  - `spec_generator`: can create files (`Read`, `Write`, `Glob`, `Grep`); `Bash` hard-denied
- Validates `GODARK_ROLE` at startup — unknown roles exit with code 1 and a descriptive error message
- Applies `allowed_tools` / `disallowed_tools` to `ClaudeAgentOptions` when invoking the SDK
- Fixes `Retry()` in `implementer.go` to pass role `"implementer_retry"` (was incorrectly passing `"implementer"`)
- Adds Go tests verifying each agent function sets the correct `GODARK_ROLE` env var
- Adds embed tests verifying reviewer `disallowed_tools` content and unknown-role exit logic in `agent_runner.py`

## Test plan

- [x] `go test ./internal/agent/...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` clean
- [x] `TestImplement_SetsImplementerRole` — `Implement()` sets `GODARK_ROLE=implementer`
- [x] `TestRetry_SetsImplementerRetryRole` — `Retry()` sets `GODARK_ROLE=implementer_retry`
- [x] `TestReview_SetsReviewerRole` — `Review()` sets `GODARK_ROLE=reviewer`
- [x] `TestGenerateSpec_SetsSpecGeneratorRole` — `GenerateSpec()` sets `GODARK_ROLE=spec_generator`
- [x] `TestAgentRunnerPyReviewerDisallowsWrite` — reviewer config contains `Write`/`Edit` in `disallowed_tools`
- [x] `TestAgentRunnerPyUnknownRoleExits` — `sys.exit(1)` and descriptive error present for unknown roles

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)