### PR TITLE
feat: preventive guardrails via SDK hooks

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -96,10 +96,19 @@ func newRunOpts(rendered string, cfg *config.Config, authEnv map[string]string, 
 	if err != nil {
 		return RunOpts{}, fmt.Errorf("parsing agent_timeout: %w", err)
 	}
+
+	// Merge authEnv with GODARK_PROTECTED_PATHS so the agent runner can
+	// enforce protected-path guardrails via in-process hooks.
+	env := make(map[string]string, len(authEnv)+1)
+	for k, v := range authEnv {
+		env[k] = v
+	}
+	env["GODARK_PROTECTED_PATHS"] = strings.Join(cfg.ProtectedPaths, ",")
+
 	return RunOpts{
 		Prompt:  rendered,
 		Role:    role,
-		Env:     authEnv,
+		Env:     env,
 		Image:   cfg.Docker.Image,
 		Repo:    cfg.Repo,
 		WorkDir: "/workspace",

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -135,6 +135,62 @@ func TestNewRunOpts_InvalidTimeout(t *testing.T) {
 	}
 }
 
+func TestNewRunOpts_SetsProtectedPathsEnv(t *testing.T) {
+	cfg := testConfig() // ProtectedPaths: ["CLAUDE.md", "tests/scenarios/"]
+	opts, err := newRunOpts("prompt", cfg, nil, "implementer")
+	if err != nil {
+		t.Fatalf("newRunOpts() error = %v", err)
+	}
+	got := opts.Env["GODARK_PROTECTED_PATHS"]
+	if got != "CLAUDE.md,tests/scenarios/" {
+		t.Errorf("GODARK_PROTECTED_PATHS = %q, want %q", got, "CLAUDE.md,tests/scenarios/")
+	}
+}
+
+func TestNewRunOpts_EmptyProtectedPathsEnv(t *testing.T) {
+	cfg := testConfig()
+	cfg.ProtectedPaths = nil
+	opts, err := newRunOpts("prompt", cfg, nil, "implementer")
+	if err != nil {
+		t.Fatalf("newRunOpts() error = %v", err)
+	}
+	got := opts.Env["GODARK_PROTECTED_PATHS"]
+	if got != "" {
+		t.Errorf("GODARK_PROTECTED_PATHS = %q, want empty string", got)
+	}
+}
+
+func TestImplement_ProtectedPathsInEnv(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Implement(context.Background(), testIssue(), testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() error = %v", err)
+	}
+
+	got := capturedEnv["GODARK_PROTECTED_PATHS"]
+	if got != "CLAUDE.md,tests/scenarios/" {
+		t.Errorf("GODARK_PROTECTED_PATHS = %q, want %q", got, "CLAUDE.md,tests/scenarios/")
+	}
+}
+
+func TestNewRunOpts_DoesNotMutateAuthEnv(t *testing.T) {
+	cfg := testConfig()
+	authEnv := map[string]string{"GH_TOKEN": "tok-xyz"}
+	_, err := newRunOpts("prompt", cfg, authEnv, "implementer")
+	if err != nil {
+		t.Fatalf("newRunOpts() error = %v", err)
+	}
+	// authEnv should not have been modified
+	if _, ok := authEnv["GODARK_PROTECTED_PATHS"]; ok {
+		t.Error("newRunOpts must not mutate the caller's authEnv map")
+	}
+}
+
 func TestImplement_BranchExistsDetection(t *testing.T) {
 	// Stub Runner (agent call) and GuardRunner (git ls-remote).
 	var capturedEnv map[string]string

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -10,16 +10,23 @@ Environment variables:
   GODARK_ROLE            Agent role: implementer, implementer_retry, reviewer, or spec_generator
   GODARK_SESSION_ID      Session ID for resuming a previous session
   GODARK_WORKDIR         Working directory (default: /workspace)
+  GODARK_PROTECTED_PATHS Comma-separated list of protected paths (exact or dir prefix)
   GH_TOKEN               GitHub token forwarded to the agent environment
 """
 
 import asyncio
+import datetime
 import json
 import os
 import sys
 
 import claude_agent_sdk
 from claude_agent_sdk import ClaudeAgentOptions, ResultMessage
+from claude_agent_sdk.types import (
+    HookMatcher,
+    PostToolUseHookInput,
+    PreToolUseHookInput,
+)
 
 # Role-scoped tool permissions. Each role maps to allowed_tools and optionally
 # disallowed_tools. disallowed_tools are hard-denied even if allowed_tools
@@ -42,11 +49,76 @@ _ROLE_PERMISSIONS: dict[str, dict] = {
 }
 
 
+def _is_protected(file_path: str, protected_paths: list[str]) -> str | None:
+    """Return the first matching protected path if file_path is protected, else None.
+
+    Matching rules:
+    - Exact match: file_path == protected_path (ignoring trailing slash on protected_path)
+    - Directory prefix: file_path starts with protected_path (with trailing slash normalised)
+    """
+    for p in protected_paths:
+        # Normalise: strip trailing slash for prefix comparison
+        prefix = p.rstrip("/")
+        if file_path == prefix:
+            return p
+        if file_path.startswith(prefix + "/"):
+            return p
+    return None
+
+
+def make_protected_path_hook(protected_paths: list[str]):
+    """Return an async PreToolUse hook that blocks writes to protected paths."""
+
+    async def hook(hook_input: PreToolUseHookInput, matcher: str | None, ctx) -> dict:
+        file_path = hook_input.get("tool_input", {}).get("file_path", "")
+        if not file_path:
+            return {}
+        matched = _is_protected(file_path, protected_paths)
+        if matched is None:
+            return {}
+        return {
+            "decision": "block",
+            "systemMessage": (
+                f"Cannot modify protected path: {file_path}. "
+                f"This path is listed in GODARK_PROTECTED_PATHS ({matched!r}) "
+                "and must not be modified by implementing agents. "
+                "Please adjust your approach to avoid writing to this path."
+            ),
+        }
+
+    return hook
+
+
+def make_audit_hook():
+    """Return an async PostToolUse hook that logs tool calls to stderr as JSON."""
+
+    async def hook(hook_input: PostToolUseHookInput, matcher: str | None, ctx) -> dict:
+        tool_name = hook_input.get("tool_name", "")
+        tool_input = hook_input.get("tool_input", {})
+        # Build a brief input summary (first 200 chars of JSON representation)
+        try:
+            input_repr = json.dumps(tool_input)
+        except Exception:
+            input_repr = str(tool_input)
+        input_summary = input_repr[:200] + ("..." if len(input_repr) > 200 else "")
+
+        record = {
+            "tool": tool_name,
+            "input_summary": input_summary,
+            "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+        }
+        print(json.dumps(record), file=sys.stderr, flush=True)
+        return {}
+
+    return hook
+
+
 async def main() -> None:
     prompt = os.environ.get("GODARK_PROMPT", "")
     role = os.environ.get("GODARK_ROLE", "")
     session_id = os.environ.get("GODARK_SESSION_ID", "")
     work_dir = os.environ.get("GODARK_WORKDIR", "/workspace")
+    protected_paths_raw = os.environ.get("GODARK_PROTECTED_PATHS", "")
 
     if role not in _ROLE_PERMISSIONS:
         valid = ", ".join(sorted(_ROLE_PERMISSIONS.keys()))
@@ -67,6 +139,24 @@ async def main() -> None:
     if os.environ.get("GH_TOKEN"):
         env["GH_TOKEN"] = os.environ["GH_TOKEN"]
 
+    # Build hooks: PreToolUse guard for protected paths + PostToolUse audit log.
+    protected_paths = [p.strip() for p in protected_paths_raw.split(",") if p.strip()]
+
+    hooks: dict = {}
+    if protected_paths:
+        hooks["PreToolUse"] = [
+            HookMatcher(
+                matcher="Write|Edit",
+                hooks=[make_protected_path_hook(protected_paths)],
+            )
+        ]
+    hooks["PostToolUse"] = [
+        HookMatcher(
+            matcher=None,
+            hooks=[make_audit_hook()],
+        )
+    ]
+
     options = ClaudeAgentOptions(
         permission_mode="bypassPermissions",
         setting_sources=["project"],
@@ -75,6 +165,7 @@ async def main() -> None:
         env=env if env else None,
         allowed_tools=permissions.get("allowed_tools"),
         disallowed_tools=permissions.get("disallowed_tools"),
+        hooks=hooks,
     )
 
     if session_id:

--- a/internal/agent/runner/test_hooks.py
+++ b/internal/agent/runner/test_hooks.py
@@ -1,0 +1,170 @@
+"""Unit tests for the hook logic in agent_runner.py."""
+
+import asyncio
+import io
+import json
+import sys
+import unittest
+from unittest.mock import patch
+
+# Import helpers directly from agent_runner
+from agent_runner import _is_protected, make_audit_hook, make_protected_path_hook
+
+
+def run(coro):
+    """Run a coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestIsProtected(unittest.TestCase):
+    """Tests for the _is_protected path-matching helper."""
+
+    def test_exact_match(self):
+        result = _is_protected("CLAUDE.md", ["CLAUDE.md", "tests/scenarios/"])
+        self.assertEqual(result, "CLAUDE.md")
+
+    def test_directory_prefix_match(self):
+        result = _is_protected(
+            "tests/scenarios/foo.md", ["CLAUDE.md", "tests/scenarios/"]
+        )
+        self.assertEqual(result, "tests/scenarios/")
+
+    def test_directory_prefix_match_without_trailing_slash(self):
+        # Protected path listed without trailing slash should still match files inside it
+        result = _is_protected(
+            "tests/scenarios/bar.md", ["tests/scenarios"]
+        )
+        self.assertEqual(result, "tests/scenarios")
+
+    def test_non_protected_path_returns_none(self):
+        result = _is_protected(
+            "internal/foo/bar.go", ["CLAUDE.md", "tests/scenarios/"]
+        )
+        self.assertIsNone(result)
+
+    def test_empty_protected_paths(self):
+        result = _is_protected("CLAUDE.md", [])
+        self.assertIsNone(result)
+
+    def test_partial_prefix_not_matched(self):
+        # "tests/scenarios_extra/file.md" should NOT match "tests/scenarios/"
+        result = _is_protected(
+            "tests/scenarios_extra/file.md", ["tests/scenarios/"]
+        )
+        self.assertIsNone(result)
+
+    def test_exact_match_with_trailing_slash_in_protected(self):
+        # A protected dir path without a filename should not match just the dir itself
+        # as a file path, but exact normalisation: strip trailing slash → "tests/scenarios"
+        # so "tests/scenarios" matches "tests/scenarios" (exact)
+        result = _is_protected("tests/scenarios", ["tests/scenarios/"])
+        self.assertEqual(result, "tests/scenarios/")
+
+
+class TestProtectedPathHook(unittest.TestCase):
+    """Tests for the make_protected_path_hook PreToolUse hook."""
+
+    def _call(self, hook, tool_input: dict) -> dict:
+        hook_input = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Write",
+            "tool_input": tool_input,
+            "tool_use_id": "tu_001",
+            "session_id": "sess_001",
+            "transcript_path": "/tmp/transcript",
+            "cwd": "/workspace",
+        }
+        return run(hook(hook_input, "Write|Edit", None))
+
+    def test_exact_path_blocked(self):
+        hook = make_protected_path_hook(["CLAUDE.md", "tests/scenarios/"])
+        result = self._call(hook, {"file_path": "CLAUDE.md"})
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("CLAUDE.md", result.get("systemMessage", ""))
+
+    def test_directory_prefix_blocked(self):
+        hook = make_protected_path_hook(["tests/scenarios/"])
+        result = self._call(hook, {"file_path": "tests/scenarios/foo.md"})
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("tests/scenarios/foo.md", result.get("systemMessage", ""))
+
+    def test_non_protected_path_allowed(self):
+        hook = make_protected_path_hook(["CLAUDE.md", "tests/scenarios/"])
+        result = self._call(hook, {"file_path": "internal/foo/bar.go"})
+        self.assertNotEqual(result.get("decision"), "block")
+
+    def test_system_message_injected(self):
+        hook = make_protected_path_hook(["CLAUDE.md"])
+        result = self._call(hook, {"file_path": "CLAUDE.md"})
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIsNotNone(result.get("systemMessage"))
+        self.assertGreater(len(result["systemMessage"]), 0)
+
+    def test_empty_protected_paths_allows_all(self):
+        hook = make_protected_path_hook([])
+        result = self._call(hook, {"file_path": "CLAUDE.md"})
+        self.assertNotEqual(result.get("decision"), "block")
+
+    def test_missing_file_path_allowed(self):
+        hook = make_protected_path_hook(["CLAUDE.md"])
+        result = self._call(hook, {})  # no file_path key
+        self.assertNotEqual(result.get("decision"), "block")
+
+
+class TestAuditHook(unittest.TestCase):
+    """Tests for the make_audit_hook PostToolUse hook."""
+
+    def _call(self, hook, tool_name: str, tool_input: dict) -> tuple[dict, str]:
+        """Returns (hook_result, stderr_output)."""
+        hook_input = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_response": "ok",
+            "tool_use_id": "tu_002",
+            "session_id": "sess_001",
+            "transcript_path": "/tmp/transcript",
+            "cwd": "/workspace",
+        }
+        buf = io.StringIO()
+        with patch("sys.stderr", buf):
+            result = run(hook(hook_input, None, None))
+        return result, buf.getvalue()
+
+    def test_writes_json_to_stderr(self):
+        hook = make_audit_hook()
+        _, stderr = self._call(hook, "Bash", {"command": "go test ./..."})
+        self.assertTrue(stderr.strip(), "Expected non-empty stderr output")
+        record = json.loads(stderr.strip())
+        self.assertIn("tool", record)
+        self.assertIn("input_summary", record)
+        self.assertIn("timestamp", record)
+
+    def test_tool_name_in_log(self):
+        hook = make_audit_hook()
+        _, stderr = self._call(hook, "Write", {"file_path": "foo.go", "content": "x"})
+        record = json.loads(stderr.strip())
+        self.assertEqual(record["tool"], "Write")
+
+    def test_input_summary_in_log(self):
+        hook = make_audit_hook()
+        _, stderr = self._call(hook, "Read", {"file_path": "bar.go"})
+        record = json.loads(stderr.strip())
+        self.assertIn("bar.go", record["input_summary"])
+
+    def test_long_input_truncated(self):
+        long_content = "x" * 500
+        hook = make_audit_hook()
+        _, stderr = self._call(hook, "Write", {"file_path": "f.go", "content": long_content})
+        record = json.loads(stderr.strip())
+        # input_summary should be truncated to at most ~203 chars (200 + "...")
+        self.assertLessEqual(len(record["input_summary"]), 203)
+
+    def test_returns_empty_dict(self):
+        hook = make_audit_hook()
+        result, _ = self._call(hook, "Glob", {"pattern": "*.go"})
+        self.assertEqual(result, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Registers a `PreToolUse` hook on `Write|Edit` in `agent_runner.py` that reads `GODARK_PROTECTED_PATHS` from the environment and blocks any write to a protected path before it happens, injecting a `systemMessage` so the agent can adjust its approach.
- Registers a `PostToolUse` audit hook (all tools) that logs tool name, input summary, and timestamp to stderr as structured JSON for telemetry.
- Sets `GODARK_PROTECTED_PATHS` in `RunOpts.Env` from `cfg.ProtectedPaths` (comma-joined) in `newRunOpts` so it flows through to both host and sandbox agent runs.
- `CheckProtectedDrift` in `guardrails.go` remains untouched as a belt-and-suspenders fallback.

## Test plan

- [ ] All 18 Python unit tests in `test_hooks.py` pass (`python3 -m unittest test_hooks -v`)
- [ ] All Go tests pass (`go test ./...`)
- [ ] `go vet ./...` clean
- [ ] Exact path blocked: `Write` to `CLAUDE.md` returns `decision=block` with non-empty `systemMessage`
- [ ] Directory prefix blocked: `Edit` of `tests/scenarios/foo.md` is blocked when `tests/scenarios/` is protected
- [ ] Non-protected path allowed: `Write` to `internal/foo/bar.go` passes through
- [ ] Empty `GODARK_PROTECTED_PATHS` allows all paths
- [ ] Audit log writes JSON with `tool`, `input_summary`, `timestamp` keys to stderr

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)