### PR TITLE
feat: session resumption for implementer retries

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -45,7 +45,9 @@ func Implement(ctx context.Context, issue github.Issue, cfg *config.Config, prom
 
 // Retry runs the implementer agent in retry mode for an existing PR.
 // It renders the retry prompt with the PR number and invokes Run.
-func Retry(ctx context.Context, issue github.Issue, prNumber int, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*Result, error) {
+// prevSessionID, if non-empty, is passed as GODARK_SESSION_ID so the agent
+// can resume its previous session context.
+func Retry(ctx context.Context, issue github.Issue, prNumber int, prevSessionID string, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*Result, error) {
 	slug := Slugify(issue.Title)
 	data := newPromptData(issue, cfg, slug)
 	data.PRNumber = prNumber
@@ -60,9 +62,14 @@ func Retry(ctx context.Context, issue github.Issue, prNumber int, cfg *config.Co
 		return nil, err
 	}
 
+	if prevSessionID != "" {
+		opts.Env["GODARK_SESSION_ID"] = prevSessionID
+	}
+
 	logger.Info("starting implementer retry agent",
 		"issue_number", issue.Number,
 		"pr_number", prNumber,
+		"resume_session", prevSessionID != "",
 	)
 
 	return Run(ctx, opts, cfg.NoSandbox, logger)

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -51,7 +51,7 @@ func TestRetry_RendersRetryPromptWithPR(t *testing.T) {
 		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
 	})
 
-	result, err := Retry(context.Background(), testIssue(), 7, testConfig(), testPrompts(t), nil, testLogger(t))
+	result, err := Retry(context.Background(), testIssue(), 7, "", testConfig(), testPrompts(t), nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("Retry() error = %v", err)
 	}
@@ -65,6 +65,57 @@ func TestRetry_RendersRetryPromptWithPR(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "#42") {
 		t.Errorf("expected issue number in retry prompt, got: %s", prompt)
+	}
+}
+
+func TestRetry_WithSessionID_SetsGODARK_SESSION_ID(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"sess-new","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Retry(context.Background(), testIssue(), 7, "sess-abc123", testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Retry() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_SESSION_ID"] != "sess-abc123" {
+		t.Errorf("GODARK_SESSION_ID = %q, want %q", capturedEnv["GODARK_SESSION_ID"], "sess-abc123")
+	}
+}
+
+func TestRetry_WithoutSessionID_NoSessionEnv(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Retry(context.Background(), testIssue(), 7, "", testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Retry() error = %v", err)
+	}
+
+	if _, ok := capturedEnv["GODARK_SESSION_ID"]; ok {
+		t.Errorf("GODARK_SESSION_ID should not be set when prevSessionID is empty, got %q", capturedEnv["GODARK_SESSION_ID"])
+	}
+}
+
+func TestImplement_DoesNotSetSessionIDEnv(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	_, err := Implement(context.Background(), testIssue(), testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() error = %v", err)
+	}
+
+	if _, ok := capturedEnv["GODARK_SESSION_ID"]; ok {
+		t.Errorf("Implement should not set GODARK_SESSION_ID, got %q", capturedEnv["GODARK_SESSION_ID"])
 	}
 }
 
@@ -247,7 +298,7 @@ func TestRetry_SetsImplementerRetryRole(t *testing.T) {
 		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
 	})
 
-	_, err := Retry(context.Background(), testIssue(), 7, testConfig(), testPrompts(t), nil, testLogger(t))
+	_, err := Retry(context.Background(), testIssue(), 7, "", testConfig(), testPrompts(t), nil, testLogger(t))
 	if err != nil {
 		t.Fatalf("Retry() error = %v", err)
 	}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -61,6 +61,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		return outcome
 	}
 
+	// Capture session ID so retries can resume the agent's context.
+	sessionID := implResult.SessionID
+
 	// Step 2: Find PR.
 	prNum, err := FindPR(cfg.Repo, branch)
 	if err != nil {
@@ -128,7 +131,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				"retries_left", retriesLeft,
 			)
 
-			retryResult, err := Retry(ctx, issue, prNum, cfg, prompts, authEnv, logger)
+			retryResult, err := Retry(ctx, issue, prNum, sessionID, cfg, prompts, authEnv, logger)
 			if err != nil {
 				outcome.Status = "failed"
 				outcome.Err = fmt.Errorf("retry agent: %w", err)
@@ -139,6 +142,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				outcome.Err = fmt.Errorf("retry agent timed out")
 				return outcome
 			}
+
+			// Update session ID so the next retry can resume this session's context.
+			sessionID = retryResult.SessionID
 
 			// Re-check drift after retry.
 			if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -402,3 +402,153 @@ func TestProcessIssue_SkipsSpecGenWhenNoPrompt(t *testing.T) {
 		t.Errorf("expected 2 agent calls (implement + review), got %d", agentCallCount)
 	}
 }
+
+// loopGuardFn returns a GuardRunner stub for standard loop tests (rev-parse, PR view, diff).
+func loopGuardFn(name string, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+	if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+		return []byte("abc123\n"), nil
+	}
+	if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+		return []byte(`{"number": 10}`), nil
+	}
+	if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+		return []byte(`{"body": "Closes #5"}`), nil
+	}
+	if name == "git" && strings.Contains(joined, "diff --name-only") {
+		return []byte("src/main.go\n"), nil
+	}
+	return []byte(""), nil
+}
+
+func TestProcessIssue_PassesSessionIDToFirstRetry(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = loopGuardFn
+
+	callIdx := 0
+	var retryEnv map[string]string
+
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer — returns a session ID
+			out := `{"session_id":"sess-impl-001","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 2: // reviewer — requests changes
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		case 3: // first retry — capture env
+			retryEnv = make(map[string]string, len(env))
+			for k, v := range env {
+				retryEnv[k] = v
+			}
+			out := `{"session_id":"sess-retry-002","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		default: // reviewer after retry — approve
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if retryEnv == nil {
+		t.Fatal("retry was never called")
+	}
+	if retryEnv["GODARK_SESSION_ID"] != "sess-impl-001" {
+		t.Errorf("GODARK_SESSION_ID passed to first retry = %q, want %q", retryEnv["GODARK_SESSION_ID"], "sess-impl-001")
+	}
+}
+
+func TestProcessIssue_UpdatesSessionIDFromRetryResult(t *testing.T) {
+	cfg := loopConfig()
+	cfg.MaxRetries = 2
+
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = loopGuardFn
+
+	callIdx := 0
+	var secondRetryEnv map[string]string
+
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			out := `{"session_id":"sess-impl","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 2: // reviewer — changes requested
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		case 3: // first retry — returns its own session ID
+			out := `{"session_id":"sess-retry-1","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 4: // reviewer — changes requested again
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		case 5: // second retry — capture env
+			secondRetryEnv = make(map[string]string, len(env))
+			for k, v := range env {
+				secondRetryEnv[k] = v
+			}
+			out := `{"session_id":"sess-retry-2","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		default: // reviewer after second retry — approve
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t))
+
+	if secondRetryEnv == nil {
+		t.Fatal("second retry was never called")
+	}
+	if secondRetryEnv["GODARK_SESSION_ID"] != "sess-retry-1" {
+		t.Errorf("GODARK_SESSION_ID passed to second retry = %q, want %q", secondRetryEnv["GODARK_SESSION_ID"], "sess-retry-1")
+	}
+}
+
+func TestProcessIssue_ReviewerHasNoSessionID(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = loopGuardFn
+
+	callIdx := 0
+	var reviewerEnvs []map[string]string
+
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer — returns a session ID
+			out := `{"session_id":"sess-impl-001","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		default: // reviewer calls — capture env
+			captured := make(map[string]string, len(env))
+			for k, v := range env {
+				captured[k] = v
+			}
+			reviewerEnvs = append(reviewerEnvs, captured)
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if len(reviewerEnvs) == 0 {
+		t.Fatal("reviewer was never called")
+	}
+	for i, env := range reviewerEnvs {
+		if _, ok := env["GODARK_SESSION_ID"]; ok {
+			t.Errorf("reviewer call %d should not receive GODARK_SESSION_ID, got %q", i+1, env["GODARK_SESSION_ID"])
+		}
+	}
+}

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -176,18 +176,39 @@ async def main() -> None:
     cost_usd = 0.0
     is_error = False
 
-    async for message in claude_agent_sdk.query(prompt=prompt, options=options):
-        try:
-            msg_dict = message.model_dump(mode="json") if hasattr(message, "model_dump") else vars(message)
-        except Exception:
-            msg_dict = {"type": type(message).__name__, "raw": str(message)}
-        print(json.dumps(msg_dict, default=str), flush=True)
+    async def _collect_messages(opts):
+        """Stream messages from the SDK, printing each one. Returns (session_id, result, cost, is_error)."""
+        nonlocal result_session_id, result_text, cost_usd, is_error
+        result_session_id = ""
+        result_text = ""
+        cost_usd = 0.0
+        is_error = False
+        async for message in claude_agent_sdk.query(prompt=prompt, options=opts):
+            try:
+                msg_dict = message.model_dump(mode="json") if hasattr(message, "model_dump") else vars(message)
+            except Exception:
+                msg_dict = {"type": type(message).__name__, "raw": str(message)}
+            print(json.dumps(msg_dict, default=str), flush=True)
 
-        if isinstance(message, ResultMessage):
-            result_session_id = getattr(message, "session_id", "") or ""
-            result_text = getattr(message, "result", "") or ""
-            cost_usd = float(getattr(message, "total_cost_usd", 0.0) or 0.0)
-            is_error = bool(getattr(message, "is_error", False))
+            if isinstance(message, ResultMessage):
+                result_session_id = getattr(message, "session_id", "") or ""
+                result_text = getattr(message, "result", "") or ""
+                cost_usd = float(getattr(message, "total_cost_usd", 0.0) or 0.0)
+                is_error = bool(getattr(message, "is_error", False))
+
+    try:
+        await _collect_messages(options)
+    except Exception as exc:
+        if session_id:
+            # Resume failed — fall back to a fresh session with the retry prompt.
+            warning = {
+                "warning": f"session resume failed, starting fresh session: {exc!r}",
+            }
+            print(json.dumps(warning), file=sys.stderr, flush=True)
+            options.resume = None
+            await _collect_messages(options)
+        else:
+            raise
 
     final = {
         "session_id": result_session_id,


### PR DESCRIPTION
## Summary

- `Retry()` in `implementer.go` gains a `prevSessionID string` parameter; when non-empty, it sets `GODARK_SESSION_ID` in the agent's env so `agent_runner.py` passes `resume=session_id` to the Claude Agent SDK
- `ProcessIssue()` in `loop.go` captures `implResult.SessionID` after `Implement()` and threads it through the retry loop, updating after each retry so chained retries each resume the previous session's context
- `agent_runner.py` wraps the `query()` call in try/except; if resume fails (expired/unavailable session), it falls back to a fresh session and logs a warning to stderr — never crashes
- Reviewer path is unchanged: never receives `GODARK_SESSION_ID` (always starts fresh)

## Test plan

- [x] `TestRetry_WithSessionID_SetsGODARK_SESSION_ID` — retry with session ID sets env var
- [x] `TestRetry_WithoutSessionID_NoSessionEnv` — retry without session ID omits env var
- [x] `TestImplement_DoesNotSetSessionIDEnv` — first-run implement never sets session env
- [x] `TestProcessIssue_PassesSessionIDToFirstRetry` — loop threads implement session ID to first retry
- [x] `TestProcessIssue_UpdatesSessionIDFromRetryResult` — second retry gets first retry's session ID
- [x] `TestProcessIssue_ReviewerHasNoSessionID` — reviewer calls never receive session ID
- [x] `go test ./internal/agent/...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` clean

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)