### PR TITLE
feat: structured output parsing for verdict and tool trace

### DIFF
--- a/internal/agent/launcher.go
+++ b/internal/agent/launcher.go
@@ -34,7 +34,9 @@ type Result struct {
 	TimedOut   bool
 	SessionID  string
 	CostUSD    float64
-	ResultText string // agent's final text output (from SDK result message)
+	ResultText string   // agent's final text output (from SDK result message)
+	Verdict    string   // review verdict: "APPROVED", "CHANGES_REQUESTED", or "" (reviewer only)
+	ToolTrace  []string // summary of tool calls made by the agent
 }
 
 // Runner executes a command on the host with the given environment. Replaceable for testing.
@@ -136,6 +138,8 @@ func runHost(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result, e
 		res.SessionID = parsed.SessionID
 		res.CostUSD = parsed.CostUSD
 		res.ResultText = parsed.Result
+		res.Verdict = parsed.Verdict
+		res.ToolTrace = parsed.ToolTrace
 		if parsed.IsError && res.ExitCode == 0 {
 			res.ExitCode = 1
 		}
@@ -198,6 +202,8 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 		res.SessionID = parsed.SessionID
 		res.CostUSD = parsed.CostUSD
 		res.ResultText = parsed.Result
+		res.Verdict = parsed.Verdict
+		res.ToolTrace = parsed.ToolTrace
 		if parsed.IsError && res.ExitCode == 0 {
 			res.ExitCode = 1
 		}
@@ -208,10 +214,12 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 
 // runnerFinalResult is the structured JSON output printed as the last line by agent_runner.py.
 type runnerFinalResult struct {
-	SessionID string  `json:"session_id"`
-	Result    string  `json:"result"`
-	CostUSD   float64 `json:"cost_usd"`
-	IsError   bool    `json:"is_error"`
+	SessionID string   `json:"session_id"`
+	Result    string   `json:"result"`
+	CostUSD   float64  `json:"cost_usd"`
+	IsError   bool     `json:"is_error"`
+	Verdict   string   `json:"verdict,omitempty"`
+	ToolTrace []string `json:"tool_trace,omitempty"`
 }
 
 // parseRunnerOutput extracts the structured final result from runner stdout.

--- a/internal/agent/launcher_test.go
+++ b/internal/agent/launcher_test.go
@@ -194,6 +194,58 @@ func TestRun_NoSandbox_NoDangerouslySkipPermissions(t *testing.T) {
 	}
 }
 
+func TestRun_NoSandbox_ParsesVerdict(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"","result":"text","cost_usd":0,"is_error":false,"verdict":"APPROVED"}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := Run(context.Background(), RunOpts{Prompt: "test"}, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Verdict != "APPROVED" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "APPROVED")
+	}
+}
+
+func TestRun_NoSandbox_NoVerdictField_EmptyVerdict(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		// Implementer output — no verdict field.
+		out := `{"session_id":"","result":"Implementation done","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := Run(context.Background(), RunOpts{Prompt: "test"}, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Verdict != "" {
+		t.Errorf("Verdict = %q, want empty for non-reviewer output", result.Verdict)
+	}
+}
+
+func TestRun_NoSandbox_ParsesToolTrace(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"","result":"done","cost_usd":0,"is_error":false,"tool_trace":["Read foo.go","Edit bar.go"]}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := Run(context.Background(), RunOpts{Prompt: "test"}, true, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(result.ToolTrace) != 2 {
+		t.Fatalf("ToolTrace len = %d, want 2", len(result.ToolTrace))
+	}
+	if result.ToolTrace[0] != "Read foo.go" {
+		t.Errorf("ToolTrace[0] = %q, want %q", result.ToolTrace[0], "Read foo.go")
+	}
+	if result.ToolTrace[1] != "Edit bar.go" {
+		t.Errorf("ToolTrace[1] = %q, want %q", result.ToolTrace[1], "Edit bar.go")
+	}
+}
+
 func TestRun_NoSandbox_PromptNotInArgs(t *testing.T) {
 	var capturedArgs []string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {

--- a/internal/agent/reviewer.go
+++ b/internal/agent/reviewer.go
@@ -40,7 +40,11 @@ func Review(ctx context.Context, issue github.Issue, prNum int, cfg *config.Conf
 		return nil, fmt.Errorf("running reviewer agent: %w", err)
 	}
 
-	verdict := ParseReviewResult(result.ResultText)
+	// Use structured verdict from runner JSON first; fall back to parsing result text.
+	verdict := result.Verdict
+	if verdict == "" {
+		verdict = ParseReviewResult(result.ResultText)
+	}
 	logger.Info("reviewer finished",
 		"issue_number", issue.Number,
 		"pr_number", prNum,

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -51,3 +51,64 @@ func TestReview_SetsReviewerRole(t *testing.T) {
 		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "reviewer")
 	}
 }
+
+func TestReview_StructuredVerdictApproved(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"","result":"some text","cost_usd":0,"is_error":false,"verdict":"APPROVED"}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := Review(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Review() error = %v", err)
+	}
+	if result.Verdict != "APPROVED" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "APPROVED")
+	}
+}
+
+func TestReview_StructuredVerdictChangesRequested(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"","result":"some text","cost_usd":0,"is_error":false,"verdict":"CHANGES_REQUESTED"}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := Review(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Review() error = %v", err)
+	}
+	if result.Verdict != "CHANGES_REQUESTED" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "CHANGES_REQUESTED")
+	}
+}
+
+func TestReview_NoStructuredVerdict_FallsBackToStdout(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		// No verdict field in JSON; result text contains the sentinel.
+		out := `{"session_id":"","result":"REVIEW_RESULT=APPROVED\n","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := Review(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Review() error = %v", err)
+	}
+	if result.Verdict != "APPROVED" {
+		t.Errorf("Verdict = %q, want %q (fallback)", result.Verdict, "APPROVED")
+	}
+}
+
+func TestReview_NeitherSource_EmptyVerdict(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"","result":"no sentinel here","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := Review(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Review() error = %v", err)
+	}
+	if result.Verdict != "" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "")
+	}
+}

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -175,20 +175,39 @@ async def main() -> None:
     result_text = ""
     cost_usd = 0.0
     is_error = False
+    tool_trace: list[str] = []
 
     async def _collect_messages(opts):
         """Stream messages from the SDK, printing each one. Returns (session_id, result, cost, is_error)."""
-        nonlocal result_session_id, result_text, cost_usd, is_error
+        nonlocal result_session_id, result_text, cost_usd, is_error, tool_trace
         result_session_id = ""
         result_text = ""
         cost_usd = 0.0
         is_error = False
+        tool_trace = []
         async for message in claude_agent_sdk.query(prompt=prompt, options=opts):
             try:
                 msg_dict = message.model_dump(mode="json") if hasattr(message, "model_dump") else vars(message)
             except Exception:
                 msg_dict = {"type": type(message).__name__, "raw": str(message)}
             print(json.dumps(msg_dict, default=str), flush=True)
+
+            # Collect tool-use summaries from AssistantMessage content blocks.
+            msg_type = type(message).__name__
+            if msg_type == "AssistantMessage":
+                for block in getattr(message, "content", []):
+                    block_type = type(block).__name__
+                    if block_type == "ToolUseBlock":
+                        tool_name = getattr(block, "name", "")
+                        tool_input = getattr(block, "input", {}) or {}
+                        if tool_name in ("Edit", "Write", "Read"):
+                            fp = tool_input.get("file_path", "")
+                            tool_trace.append(f"{tool_name} {fp}" if fp else tool_name)
+                        elif tool_name == "Bash":
+                            cmd = (tool_input.get("command", "") or "")[:80]
+                            tool_trace.append(f"Bash: {cmd}")
+                        elif tool_name:
+                            tool_trace.append(tool_name)
 
             if isinstance(message, ResultMessage):
                 result_session_id = getattr(message, "session_id", "") or ""
@@ -210,12 +229,30 @@ async def main() -> None:
         else:
             raise
 
-    final = {
+    # For the reviewer role, extract the verdict from result_text.
+    verdict = ""
+    if role == "reviewer" and result_text:
+        upper = result_text.upper()
+        for line in upper.splitlines():
+            stripped = line.strip()
+            if "REVIEW" in stripped and "RESULT" in stripped:
+                if "CHANGES" in stripped:
+                    verdict = "CHANGES_REQUESTED"
+                    break
+                elif "APPROVED" in stripped:
+                    verdict = "APPROVED"
+                    break
+
+    final: dict = {
         "session_id": result_session_id,
         "result": result_text,
         "cost_usd": cost_usd,
         "is_error": is_error,
     }
+    if verdict:
+        final["verdict"] = verdict
+    if tool_trace:
+        final["tool_trace"] = tool_trace
     print(json.dumps(final), flush=True)
 
 


### PR DESCRIPTION
## Summary

- Add `Verdict` and `ToolTrace` fields to `Result` struct and `runnerFinalResult` struct in `launcher.go`
- Update `Review()` in `reviewer.go` to use `result.Verdict` from structured JSON first, falling back to `ParseReviewResult(result.ResultText)` for backward compatibility
- Update `agent_runner.py` to collect tool-use summaries from `AssistantMessage` content blocks into a `tool_trace` list, and extract verdict for reviewer role from `result_text`, both included in the final JSON output

## Test plan

- [x] `TestReview_StructuredVerdictApproved` — runner JSON with `"verdict":"APPROVED"` → `result.Verdict == "APPROVED"`
- [x] `TestReview_StructuredVerdictChangesRequested` — runner JSON with `"verdict":"CHANGES_REQUESTED"` → `result.Verdict == "CHANGES_REQUESTED"`
- [x] `TestReview_NoStructuredVerdict_FallsBackToStdout` — no verdict field, result text has sentinel → fallback works
- [x] `TestReview_NeitherSource_EmptyVerdict` — no verdict anywhere → `""`
- [x] `TestRun_NoSandbox_ParsesVerdict` — `Result.Verdict` populated from structured JSON
- [x] `TestRun_NoSandbox_NoVerdictField_EmptyVerdict` — implementer output without verdict → empty
- [x] `TestRun_NoSandbox_ParsesToolTrace` — `Result.ToolTrace` populated from structured JSON
- [x] `go test ./internal/agent/...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)