### PR TITLE
feat: generic runtime config (issue #50)

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -84,7 +84,7 @@ loop directly, without milestone or dependency resolution.`,
 		}
 
 		if !cfg.NoSandbox {
-			dc := sandbox.DockerConfigFromConfig(cfg.Docker)
+			dc := sandbox.DockerConfigFromConfig(cfg.Docker, cfg.Runtime)
 			tag, err := sandbox.BuildImage(cmd.Context(), dc, logger)
 			if err != nil {
 				return fmt.Errorf("building Docker image: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,12 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Runtime identifies the project's toolchain and optional version.
+type Runtime struct {
+	Name    string `yaml:"name"`    // go, flutter, node, rust, python
+	Version string `yaml:"version"` // optional — auto-detected if empty
+}
+
 // Config holds all configuration for a godark run.
 type Config struct {
 	Repo       string `yaml:"repo"`
@@ -15,10 +21,11 @@ type Config struct {
 	Issue      int    `yaml:"issue"`
 	MaxRetries int    `yaml:"max_retries"`
 
-	AgentTimeout string       `yaml:"agent_timeout"`
-	BuildCommand string       `yaml:"build_command"`
-	TestCommand  string       `yaml:"test_command"`
-	CrossCompile CrossCompile `yaml:"cross_compile"`
+	AgentTimeout string            `yaml:"agent_timeout"`
+	BuildCommand string            `yaml:"build_command"`
+	TestCommand  string            `yaml:"test_command"`
+	SandboxEnv   map[string]string `yaml:"sandbox_env"`
+	Runtime      Runtime           `yaml:"runtime"`
 
 	ProtectedPaths []string `yaml:"protected_paths"`
 	RoadmapPath    string   `yaml:"roadmap_path"`
@@ -33,19 +40,12 @@ type Config struct {
 	Prompts Prompts `yaml:"prompts"`
 }
 
-// CrossCompile holds cross-compilation environment variables.
-type CrossCompile struct {
-	GOOS   string `yaml:"GOOS"`
-	GOARCH string `yaml:"GOARCH"`
-}
-
 // Docker holds Docker sandbox configuration.
 type Docker struct {
 	Image         string   `yaml:"image"`
 	Dockerfile    string   `yaml:"dockerfile"`
 	Mount         string   `yaml:"mount"`
 	User          string   `yaml:"user"`
-	GoVersion     string   `yaml:"go_version"`
 	NodeVersion   string   `yaml:"node_version"`
 	ExtraPackages []string `yaml:"extra_packages"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,9 +29,12 @@ max_retries: 3
 issue: 5
 build_command: "go build -o bin/ ./cmd/..."
 test_command: "go test ./..."
-cross_compile:
+sandbox_env:
   GOOS: linux
   GOARCH: arm64
+runtime:
+  name: go
+  version: "1.26.0"
 protected_paths:
   - tests/scenarios/
   - CLAUDE.md
@@ -72,11 +75,17 @@ prompts:
 	if cfg.TestCommand != "go test ./..." {
 		t.Errorf("TestCommand = %q", cfg.TestCommand)
 	}
-	if cfg.CrossCompile.GOOS != "linux" {
-		t.Errorf("CrossCompile.GOOS = %q, want linux", cfg.CrossCompile.GOOS)
+	if cfg.SandboxEnv["GOOS"] != "linux" {
+		t.Errorf("SandboxEnv[GOOS] = %q, want linux", cfg.SandboxEnv["GOOS"])
 	}
-	if cfg.CrossCompile.GOARCH != "arm64" {
-		t.Errorf("CrossCompile.GOARCH = %q, want arm64", cfg.CrossCompile.GOARCH)
+	if cfg.SandboxEnv["GOARCH"] != "arm64" {
+		t.Errorf("SandboxEnv[GOARCH] = %q, want arm64", cfg.SandboxEnv["GOARCH"])
+	}
+	if cfg.Runtime.Name != "go" {
+		t.Errorf("Runtime.Name = %q, want go", cfg.Runtime.Name)
+	}
+	if cfg.Runtime.Version != "1.26.0" {
+		t.Errorf("Runtime.Version = %q, want 1.26.0", cfg.Runtime.Version)
 	}
 	if len(cfg.ProtectedPaths) != 2 {
 		t.Errorf("ProtectedPaths = %v, want 2 entries", cfg.ProtectedPaths)
@@ -92,6 +101,85 @@ prompts:
 	}
 	if cfg.Prompts.Reviewer != "prompts/reviewer.md" {
 		t.Errorf("Prompts.Reviewer = %q", cfg.Prompts.Reviewer)
+	}
+}
+
+func TestRuntimeFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+milestone: "Phase 1"
+runtime:
+  name: flutter
+  version: "3.41"
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Runtime.Name != "flutter" {
+		t.Errorf("Runtime.Name = %q, want flutter", cfg.Runtime.Name)
+	}
+	if cfg.Runtime.Version != "3.41" {
+		t.Errorf("Runtime.Version = %q, want 3.41", cfg.Runtime.Version)
+	}
+}
+
+func TestEmptyRuntimeIsZeroValued(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+milestone: "Phase 1"
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Runtime.Name != "" {
+		t.Errorf("Runtime.Name = %q, want empty string", cfg.Runtime.Name)
+	}
+	if cfg.Runtime.Version != "" {
+		t.Errorf("Runtime.Version = %q, want empty string", cfg.Runtime.Version)
+	}
+}
+
+func TestSandboxEnvFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+milestone: "Phase 1"
+sandbox_env:
+  GOOS: linux
+  GOARCH: arm64
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SandboxEnv["GOOS"] != "linux" {
+		t.Errorf("SandboxEnv[GOOS] = %q, want linux", cfg.SandboxEnv["GOOS"])
+	}
+	if cfg.SandboxEnv["GOARCH"] != "arm64" {
+		t.Errorf("SandboxEnv[GOARCH] = %q, want arm64", cfg.SandboxEnv["GOARCH"])
+	}
+}
+
+func TestEmptySandboxEnvIsNil(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+milestone: "Phase 1"
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SandboxEnv != nil {
+		t.Errorf("SandboxEnv = %v, want nil", cfg.SandboxEnv)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -166,7 +166,7 @@ func processIssues(ctx context.Context, processable []github.Issue, blocked []bl
 
 	// Build Docker image once if using sandbox mode.
 	if !cfg.NoSandbox {
-		dc := sandbox.DockerConfigFromConfig(cfg.Docker)
+		dc := sandbox.DockerConfigFromConfig(cfg.Docker, cfg.Runtime)
 		tag, err := sandbox.BuildImage(ctx, dc, logger)
 		if err != nil {
 			return fmt.Errorf("building Docker image: %w", err)

--- a/internal/sandbox/config.go
+++ b/internal/sandbox/config.go
@@ -10,7 +10,7 @@ import (
 // DockerConfig holds the resolved configuration for Dockerfile generation.
 type DockerConfig struct {
 	Image         string
-	GoVersion     string
+	Runtime       config.Runtime
 	NodeVersion   string
 	User          string
 	ExtraPackages []string
@@ -21,33 +21,30 @@ type DockerConfig struct {
 func DefaultDockerConfig() DockerConfig {
 	return DockerConfig{
 		Image:       "ubuntu:22.04",
-		GoVersion:   "1.26.0",
 		NodeVersion: "20",
 		User:        "devloop",
 	}
 }
 
-// DockerConfigFromConfig maps a config.Docker into a DockerConfig,
+// DockerConfigFromConfig maps a config.Docker and config.Runtime into a DockerConfig,
 // applying defaults for any zero-value fields.
-func DockerConfigFromConfig(cfg config.Docker) DockerConfig {
+func DockerConfigFromConfig(docker config.Docker, runtime config.Runtime) DockerConfig {
 	dc := DefaultDockerConfig()
-	if cfg.Image != "" {
-		dc.Image = cfg.Image
+	if docker.Image != "" {
+		dc.Image = docker.Image
 	}
-	if cfg.GoVersion != "" {
-		dc.GoVersion = cfg.GoVersion
+	dc.Runtime = runtime
+	if docker.NodeVersion != "" {
+		dc.NodeVersion = docker.NodeVersion
 	}
-	if cfg.NodeVersion != "" {
-		dc.NodeVersion = cfg.NodeVersion
+	if docker.User != "" {
+		dc.User = docker.User
 	}
-	if cfg.User != "" {
-		dc.User = cfg.User
+	if docker.Mount != "" {
+		dc.Mount = docker.Mount
 	}
-	if cfg.Mount != "" {
-		dc.Mount = cfg.Mount
-	}
-	if len(cfg.ExtraPackages) > 0 {
-		dc.ExtraPackages = cfg.ExtraPackages
+	if len(docker.ExtraPackages) > 0 {
+		dc.ExtraPackages = docker.ExtraPackages
 	}
 	return dc
 }

--- a/internal/sandbox/dockerfile.go
+++ b/internal/sandbox/dockerfile.go
@@ -30,7 +30,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go
-RUN curl -fsSL https://go.dev/dl/go{{.GoVersion}}.linux-amd64.tar.gz \
+RUN curl -fsSL https://go.dev/dl/go{{.RuntimeVersion}}.linux-amd64.tar.gz \
       | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
@@ -57,17 +57,17 @@ WORKDIR /workspace
 // GenerateDockerfile renders a Dockerfile from the given DockerConfig.
 func GenerateDockerfile(cfg DockerConfig) (string, error) {
 	data := struct {
-		Image         string
-		GoVersion     string
-		NodeVersion   string
-		User          string
-		ExtraPackages []string
+		Image          string
+		RuntimeVersion string
+		NodeVersion    string
+		User           string
+		ExtraPackages  []string
 	}{
-		Image:         cfg.Image,
-		GoVersion:     cfg.GoVersion,
-		NodeVersion:   cfg.NodeVersion,
-		User:          cfg.User,
-		ExtraPackages: cfg.ExtraPackages,
+		Image:          cfg.Image,
+		RuntimeVersion: cfg.Runtime.Version,
+		NodeVersion:    cfg.NodeVersion,
+		User:           cfg.User,
+		ExtraPackages:  cfg.ExtraPackages,
 	}
 
 	var buf bytes.Buffer

--- a/internal/sandbox/dockerfile_test.go
+++ b/internal/sandbox/dockerfile_test.go
@@ -16,8 +16,11 @@ func TestDefaultConfig(t *testing.T) {
 	if dc.Image != "ubuntu:22.04" {
 		t.Errorf("Image = %q, want ubuntu:22.04", dc.Image)
 	}
-	if dc.GoVersion != "1.26.0" {
-		t.Errorf("GoVersion = %q, want 1.26.0", dc.GoVersion)
+	if dc.Runtime.Name != "" {
+		t.Errorf("Runtime.Name = %q, want empty string", dc.Runtime.Name)
+	}
+	if dc.Runtime.Version != "" {
+		t.Errorf("Runtime.Version = %q, want empty string", dc.Runtime.Version)
 	}
 	if dc.NodeVersion != "20" {
 		t.Errorf("NodeVersion = %q, want 20", dc.NodeVersion)
@@ -28,21 +31,24 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestDockerConfigFromConfig(t *testing.T) {
-	cfg := config.Docker{
+	docker := config.Docker{
 		Image:         "debian:bookworm",
-		GoVersion:     "1.22",
 		NodeVersion:   "18",
 		User:          "runner",
 		Mount:         "/src",
 		ExtraPackages: []string{"vim", "jq"},
 	}
-	dc := DockerConfigFromConfig(cfg)
+	runtime := config.Runtime{Name: "go", Version: "1.26.0"}
+	dc := DockerConfigFromConfig(docker, runtime)
 
 	if dc.Image != "debian:bookworm" {
 		t.Errorf("Image = %q, want debian:bookworm", dc.Image)
 	}
-	if dc.GoVersion != "1.22" {
-		t.Errorf("GoVersion = %q, want 1.22", dc.GoVersion)
+	if dc.Runtime.Name != "go" {
+		t.Errorf("Runtime.Name = %q, want go", dc.Runtime.Name)
+	}
+	if dc.Runtime.Version != "1.26.0" {
+		t.Errorf("Runtime.Version = %q, want 1.26.0", dc.Runtime.Version)
 	}
 	if dc.NodeVersion != "18" {
 		t.Errorf("NodeVersion = %q, want 18", dc.NodeVersion)
@@ -59,14 +65,17 @@ func TestDockerConfigFromConfig(t *testing.T) {
 }
 
 func TestDockerConfigFromConfigDefaults(t *testing.T) {
-	dc := DockerConfigFromConfig(config.Docker{})
+	dc := DockerConfigFromConfig(config.Docker{}, config.Runtime{})
 	def := DefaultDockerConfig()
 
 	if dc.Image != def.Image {
 		t.Errorf("Image = %q, want default %q", dc.Image, def.Image)
 	}
-	if dc.GoVersion != def.GoVersion {
-		t.Errorf("GoVersion = %q, want default %q", dc.GoVersion, def.GoVersion)
+	if dc.Runtime.Name != "" {
+		t.Errorf("Runtime.Name = %q, want empty string", dc.Runtime.Name)
+	}
+	if dc.Runtime.Version != "" {
+		t.Errorf("Runtime.Version = %q, want empty string", dc.Runtime.Version)
 	}
 }
 
@@ -84,7 +93,6 @@ func TestGenerateDockerfileDefault(t *testing.T) {
 		{"claude-code", "npm install -g @anthropic-ai/claude-code"},
 		{"user directive", "USER devloop"},
 		{"workdir", "WORKDIR /workspace"},
-		{"go install", "go1.26.0.linux-amd64.tar.gz"},
 		{"node install", "setup_20.x"},
 		{"useradd", "useradd -m -s /bin/bash devloop"},
 		{"python3 install", "python3"},
@@ -114,7 +122,7 @@ func TestGenerateDockerfileCustomImage(t *testing.T) {
 
 func TestGenerateDockerfileCustomGoVersion(t *testing.T) {
 	cfg := DefaultDockerConfig()
-	cfg.GoVersion = "1.22"
+	cfg.Runtime.Version = "1.22"
 
 	df, err := GenerateDockerfile(cfg)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `Runtime` struct with `Name` and `Version` fields to `internal/config`
- Replace `Config.CrossCompile` (Go-specific) with `Config.SandboxEnv map[string]string` — a generic env var map forwarded to the container
- Add `Config.Runtime` field (`yaml:"runtime"`)
- Remove `CrossCompile` struct and `Docker.GoVersion` field entirely (`go_version` YAML key no longer recognized)
- Replace `DockerConfig.GoVersion` with `DockerConfig.Runtime config.Runtime`
- `DefaultDockerConfig()` now has zero-valued `Runtime` (no default go version)
- `DockerConfigFromConfig` signature updated to accept `(config.Docker, config.Runtime)`
- Dockerfile template updated to use `Runtime.Version`
- All callers updated (orchestrator, implement cmd)
- Tests updated for all new types and behaviours

Closes #50