### PR TITLE
feat: add quality reviewer agent to dev-loop

### DIFF
--- a/internal/agent/helpers_test.go
+++ b/internal/agent/helpers_test.go
@@ -90,5 +90,6 @@ func testPrompts(t *testing.T) *Prompts {
 		Implementer:      "Implement #{{.IssueNumber}} {{.IssueTitle}} repo={{.Repo}} slug={{.Slug}}",
 		ImplementerRetry: "Retry PR #{{.PRNumber}} for #{{.IssueNumber}} repo={{.Repo}}",
 		Reviewer:         "Review PR #{{.PRNumber}} for #{{.IssueNumber}}",
+		QualityReviewer:  "Quality review PR #{{.PRNumber}} for #{{.IssueNumber}}",
 	}
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -91,7 +91,85 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 
 	_ = WarnMissingScenario(cfg.Repo, prNum, issue.Number, cfg.ScenarioDir, logger)
 
-	// Step 4: Review/retry loop.
+	// Step 4: Quality review gate (if prompt is configured).
+	if prompts.QualityReviewer != "" {
+		qualityMaxAttempts := cfg.MaxRetries + 1
+		qualityPassed := false
+		for qAttempt := 0; qAttempt < qualityMaxAttempts; qAttempt++ {
+			if ctx.Err() != nil {
+				outcome.Status = "failed"
+				outcome.Err = ctx.Err()
+				return outcome
+			}
+
+			qResult, err := QualityReview(ctx, issue, prNum, cfg, prompts, authEnv, logger)
+			if err != nil {
+				outcome.Status = "failed"
+				outcome.Err = fmt.Errorf("quality reviewer agent: %w", err)
+				return outcome
+			}
+
+			switch qResult.Verdict {
+			case "APPROVED":
+				qualityPassed = true
+			case "CHANGES_REQUESTED":
+				retriesLeft := qualityMaxAttempts - qAttempt - 1
+				if retriesLeft <= 0 {
+					break // exit loop, will label needs-human-review
+				}
+
+				logger.Info("quality review requested changes, retrying implementation",
+					"issue_number", issue.Number,
+					"attempt", qAttempt+1,
+					"retries_left", retriesLeft,
+				)
+
+				retryResult, err := Retry(ctx, issue, prNum, sessionID, cfg, prompts, authEnv, logger)
+				if err != nil {
+					outcome.Status = "failed"
+					outcome.Err = fmt.Errorf("retry agent (quality): %w", err)
+					return outcome
+				}
+				if retryResult.TimedOut {
+					outcome.Status = "failed"
+					outcome.Err = fmt.Errorf("retry agent (quality) timed out")
+					return outcome
+				}
+
+				sessionID = retryResult.SessionID
+
+				if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
+					outcome.Status = "failed"
+					outcome.Err = driftErr
+					return outcome
+				}
+
+			default:
+				outcome.Status = "failed"
+				outcome.Err = fmt.Errorf("quality reviewer agent did not produce a verdict")
+				return outcome
+			}
+
+			if qualityPassed {
+				break
+			}
+		}
+
+		if !qualityPassed {
+			if err := LabelPR(cfg.Repo, prNum, "needs-human-review"); err != nil {
+				logger.Warn("failed to label PR", "error", err)
+			}
+			comment := fmt.Sprintf("Exhausted %d quality review/retry cycles. Labeling for human review.", qualityMaxAttempts)
+			if _, err := GuardRunner("gh", "pr", "comment", fmt.Sprintf("%d", prNum), "--repo", cfg.Repo, "--body", comment); err != nil {
+				logger.Warn("failed to comment on PR", "error", err)
+			}
+			outcome.Status = "needs-human-review"
+			outcome.Retries = qualityMaxAttempts - 1
+			return outcome
+		}
+	}
+
+	// Step 5: Review/retry loop.
 	maxAttempts := cfg.MaxRetries + 1
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if ctx.Err() != nil {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -75,9 +75,10 @@ func loopIssue() github.Issue {
 }
 
 func TestProcessIssue_ImplementedOnFirstApproval(t *testing.T) {
-	// Agent outputs: 1=implementer, 2=reviewer(APPROVED)
+	// Agent outputs: 1=implementer, 2=quality_reviewer(APPROVED), 3=reviewer(APPROVED)
 	setupLoopTest(t, []string{
 		"implementer output",
+		"QUALITY_RESULT=APPROVED",
 		"reviewer output\nREVIEW_RESULT=APPROVED\n",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
@@ -110,10 +111,11 @@ func TestProcessIssue_ImplementedOnFirstApproval(t *testing.T) {
 }
 
 func TestProcessIssue_RetriesOnChangesRequested(t *testing.T) {
-	// Agent outputs: implementer, reviewer(CHANGES), retry, reviewer(APPROVED)
+	// Agent outputs: implementer, quality(APPROVED), reviewer(CHANGES), retry, reviewer(APPROVED)
 	callIdx := 0
 	setupLoopTest(t, []string{
 		"implementer output",
+		"QUALITY_RESULT=APPROVED",
 		"REVIEW_RESULT=CHANGES_REQUESTED",
 		"retry output",
 		"REVIEW_RESULT=APPROVED",
@@ -149,9 +151,10 @@ func TestProcessIssue_NeedsHumanReviewAfterMaxRetries(t *testing.T) {
 	cfg := loopConfig()
 	cfg.MaxRetries = 1
 
-	// Agent outputs: implementer, reviewer(CHANGES), retry, reviewer(CHANGES)
+	// Agent outputs: implementer, quality(APPROVED), reviewer(CHANGES), retry, reviewer(CHANGES)
 	setupLoopTest(t, []string{
 		"implementer output",
+		"QUALITY_RESULT=APPROVED",
 		"REVIEW_RESULT=CHANGES_REQUESTED",
 		"retry output",
 		"REVIEW_RESULT=CHANGES_REQUESTED",
@@ -233,6 +236,7 @@ func TestProcessIssue_RechecksProtectedDriftAfterRetry(t *testing.T) {
 	driftCheckCount := 0
 	setupLoopTest(t, []string{
 		"implementer output",
+		"QUALITY_RESULT=APPROVED",
 		"REVIEW_RESULT=CHANGES_REQUESTED",
 		"retry output",
 	}, func(name string, args ...string) ([]byte, error) {
@@ -271,6 +275,7 @@ func TestProcessIssue_MergeOnApproval(t *testing.T) {
 	var mergedCalled bool
 	setupLoopTest(t, []string{
 		"implementer output",
+		"QUALITY_RESULT=APPROVED",
 		"REVIEW_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
@@ -385,21 +390,25 @@ func TestProcessIssue_SkipsSpecGenWhenNoPrompt(t *testing.T) {
 	t.Cleanup(func() { Runner = origRunner })
 	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		agentCallCount++
-		if agentCallCount == 2 {
+		switch agentCallCount {
+		case 1:
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2:
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default:
 			return []byte(wrapRunnerJSON("reviewer output\nREVIEW_RESULT=APPROVED\n")), []byte(""), 0, nil
 		}
-		return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 	}
 
-	// No SpecGenerator prompt → should only have 2 agent calls (implement + review).
+	// No SpecGenerator prompt → should only have 3 agent calls (implement + quality + review).
 	prompts := testPrompts(t)
 	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t))
 
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
 	}
-	if agentCallCount != 2 {
-		t.Errorf("expected 2 agent calls (implement + review), got %d", agentCallCount)
+	if agentCallCount != 3 {
+		t.Errorf("expected 3 agent calls (implement + quality + review), got %d", agentCallCount)
 	}
 }
 
@@ -439,9 +448,11 @@ func TestProcessIssue_PassesSessionIDToFirstRetry(t *testing.T) {
 		case 1: // implementer — returns a session ID
 			out := `{"session_id":"sess-impl-001","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
-		case 2: // reviewer — requests changes
+		case 2: // quality reviewer — approve
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		case 3: // reviewer — requests changes
 			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
-		case 3: // first retry — capture env
+		case 4: // first retry — capture env
 			retryEnv = make(map[string]string, len(env))
 			for k, v := range env {
 				retryEnv[k] = v
@@ -484,14 +495,16 @@ func TestProcessIssue_UpdatesSessionIDFromRetryResult(t *testing.T) {
 		case 1: // implementer
 			out := `{"session_id":"sess-impl","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
-		case 2: // reviewer — changes requested
+		case 2: // quality reviewer — approve
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		case 3: // reviewer — changes requested
 			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
-		case 3: // first retry — returns its own session ID
+		case 4: // first retry — returns its own session ID
 			out := `{"session_id":"sess-retry-1","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
-		case 4: // reviewer — changes requested again
+		case 5: // reviewer — changes requested again
 			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
-		case 5: // second retry — capture env
+		case 6: // second retry — capture env
 			secondRetryEnv = make(map[string]string, len(env))
 			for k, v := range env {
 				secondRetryEnv[k] = v
@@ -531,6 +544,8 @@ func TestProcessIssue_ReviewerHasNoSessionID(t *testing.T) {
 		case 1: // implementer — returns a session ID
 			out := `{"session_id":"sess-impl-001","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
+		case 2: // quality reviewer — approve
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // reviewer calls — capture env
 			captured := make(map[string]string, len(env))
 			for k, v := range env {
@@ -550,5 +565,80 @@ func TestProcessIssue_ReviewerHasNoSessionID(t *testing.T) {
 		if _, ok := env["GODARK_SESSION_ID"]; ok {
 			t.Errorf("reviewer call %d should not receive GODARK_SESSION_ID, got %q", i+1, env["GODARK_SESSION_ID"])
 		}
+	}
+}
+
+func TestProcessIssue_QualityReviewChangesRequestedTriggersRetry(t *testing.T) {
+	// Agent outputs: implementer, quality(CHANGES), retry, quality(APPROVED), reviewer(APPROVED)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=CHANGES_REQUESTED",
+		"retry output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+}
+
+func TestProcessIssue_SkipsQualityReviewWhenNoPrompt(t *testing.T) {
+	agentCallCount := 0
+	setupLoopTest(t, nil, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	origRunner := Runner
+	t.Cleanup(func() { Runner = origRunner })
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		agentCallCount++
+		switch agentCallCount {
+		case 1:
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		default:
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	prompts := testPrompts(t)
+	prompts.QualityReviewer = "" // disable quality reviewer
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t))
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if agentCallCount != 2 {
+		t.Errorf("expected 2 agent calls (implement + review), got %d", agentCallCount)
 	}
 }

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -17,6 +17,7 @@ type Prompts struct {
 	Implementer      string
 	ImplementerRetry string
 	Reviewer         string
+	QualityReviewer  string
 	SpecGenerator    string
 }
 
@@ -75,6 +76,14 @@ func LoadPrompts(cfg *config.Config) (*Prompts, error) {
 		Implementer:      impl,
 		ImplementerRetry: retry,
 		Reviewer:         rev,
+	}
+
+	// QualityReviewer is optional — load from config or embedded default.
+	qualRev, err := loadPromptFile(cfg.Prompts.QualityReviewer, "quality_reviewer.txt")
+	if err != nil {
+		p.QualityReviewer = ""
+	} else {
+		p.QualityReviewer = qualRev
 	}
 
 	// SpecGenerator is optional — load from config or embedded default.

--- a/internal/agent/quality_reviewer.go
+++ b/internal/agent/quality_reviewer.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// QualityReviewResult holds the outcome of a quality reviewer agent run.
+type QualityReviewResult struct {
+	Verdict     string // "APPROVED", "CHANGES_REQUESTED", or ""
+	AgentResult *Result
+}
+
+// QualityReview runs the quality reviewer agent for the given PR and returns the verdict.
+func QualityReview(ctx context.Context, issue github.Issue, prNum int, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*QualityReviewResult, error) {
+	data := newPromptData(issue, cfg, Slugify(issue.Title))
+	data.PRNumber = prNum
+
+	rendered, err := RenderPrompt(prompts.QualityReviewer, data)
+	if err != nil {
+		return nil, fmt.Errorf("rendering quality_reviewer prompt: %w", err)
+	}
+
+	opts, err := newRunOpts(rendered, cfg, authEnv, "quality_reviewer")
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("starting quality reviewer agent",
+		"issue_number", issue.Number,
+		"pr_number", prNum,
+	)
+
+	result, err := Run(ctx, opts, cfg.NoSandbox, logger)
+	if err != nil {
+		return nil, fmt.Errorf("running quality reviewer agent: %w", err)
+	}
+
+	// Use structured verdict from runner JSON first; fall back to parsing result text.
+	verdict := result.Verdict
+	if verdict == "" {
+		verdict = ParseQualityResult(result.ResultText)
+	}
+	logger.Info("quality reviewer finished",
+		"issue_number", issue.Number,
+		"pr_number", prNum,
+		"verdict", verdict,
+	)
+
+	return &QualityReviewResult{
+		Verdict:     verdict,
+		AgentResult: result,
+	}, nil
+}
+
+// ParseQualityResult scans agent output for a QUALITY_RESULT line and
+// returns "APPROVED", "CHANGES_REQUESTED", or "" if not found.
+func ParseQualityResult(stdout string) string {
+	upper := strings.ToUpper(stdout)
+	for _, line := range strings.Split(upper, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "APPROVED") && strings.Contains(line, "QUALITY") && strings.Contains(line, "RESULT") {
+			if strings.Contains(line, "CHANGES") {
+				return "CHANGES_REQUESTED"
+			}
+			return "APPROVED"
+		}
+		if strings.Contains(line, "CHANGES_REQUESTED") && strings.Contains(line, "QUALITY") {
+			return "CHANGES_REQUESTED"
+		}
+	}
+	return ""
+}

--- a/internal/agent/quality_reviewer_test.go
+++ b/internal/agent/quality_reviewer_test.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"context"
+	"testing"
+)
+
+func TestQualityReview_ReturnsVerdict(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"","result":"output\nQUALITY_RESULT=APPROVED\nmore output","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+	if result.Verdict != "APPROVED" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "APPROVED")
+	}
+}
+
+func TestQualityReview_ChangesRequested(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"","result":"QUALITY_RESULT=CHANGES_REQUESTED\n","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+	if result.Verdict != "CHANGES_REQUESTED" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "CHANGES_REQUESTED")
+	}
+}
+
+func TestQualityReview_SetsQualityReviewerRole(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte("QUALITY_RESULT=APPROVED\n"), []byte(""), 0, nil
+	})
+
+	_, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_ROLE"] != "quality_reviewer" {
+		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "quality_reviewer")
+	}
+}
+
+func TestQualityReview_StructuredVerdict(t *testing.T) {
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := `{"session_id":"","result":"some text","cost_usd":0,"is_error":false,"verdict":"APPROVED"}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+	if result.Verdict != "APPROVED" {
+		t.Errorf("Verdict = %q, want %q", result.Verdict, "APPROVED")
+	}
+}
+
+func TestParseQualityResult_Approved(t *testing.T) {
+	got := ParseQualityResult("some output\nQUALITY_RESULT=APPROVED\nmore output")
+	if got != "APPROVED" {
+		t.Errorf("ParseQualityResult() = %q, want %q", got, "APPROVED")
+	}
+}
+
+func TestParseQualityResult_ChangesRequested(t *testing.T) {
+	got := ParseQualityResult("QUALITY_RESULT=CHANGES_REQUESTED\n")
+	if got != "CHANGES_REQUESTED" {
+		t.Errorf("ParseQualityResult() = %q, want %q", got, "CHANGES_REQUESTED")
+	}
+}
+
+func TestParseQualityResult_NoMatch(t *testing.T) {
+	got := ParseQualityResult("no sentinel here")
+	if got != "" {
+		t.Errorf("ParseQualityResult() = %q, want %q", got, "")
+	}
+}

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -7,7 +7,7 @@ structured result line.
 
 Environment variables:
   GODARK_PROMPT          The prompt text to send to the agent
-  GODARK_ROLE            Agent role: implementer, implementer_retry, reviewer, or spec_generator
+  GODARK_ROLE            Agent role: implementer, implementer_retry, reviewer, quality_reviewer, or spec_generator
   GODARK_SESSION_ID      Session ID for resuming a previous session
   GODARK_WORKDIR         Working directory (default: /workspace)
   GODARK_PROTECTED_PATHS Comma-separated list of protected paths (exact or dir prefix)
@@ -39,6 +39,10 @@ _ROLE_PERMISSIONS: dict[str, dict] = {
         "allowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
     },
     "reviewer": {
+        "allowed_tools": ["Read", "Glob", "Grep", "Bash"],
+        "disallowed_tools": ["Write", "Edit"],
+    },
+    "quality_reviewer": {
         "allowed_tools": ["Read", "Glob", "Grep", "Bash"],
         "disallowed_tools": ["Write", "Edit"],
     },
@@ -257,13 +261,25 @@ async def main() -> None:
         else:
             raise
 
-    # For the reviewer role, extract the verdict from result_text.
+    # For reviewer/quality_reviewer roles, extract the verdict from result_text.
     verdict = ""
     if role == "reviewer" and result_text:
         upper = result_text.upper()
         for line in upper.splitlines():
             stripped = line.strip()
             if "REVIEW" in stripped and "RESULT" in stripped:
+                if "CHANGES" in stripped:
+                    verdict = "CHANGES_REQUESTED"
+                    break
+                elif "APPROVED" in stripped:
+                    verdict = "APPROVED"
+                    break
+
+    if role == "quality_reviewer" and result_text:
+        upper = result_text.upper()
+        for line in upper.splitlines():
+            stripped = line.strip()
+            if "QUALITY" in stripped and "RESULT" in stripped:
                 if "CHANGES" in stripped:
                     verdict = "CHANGES_REQUESTED"
                     break

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type Prompts struct {
 	Implementer      string `yaml:"implementer"`
 	ImplementerRetry string `yaml:"implementer_retry"`
 	Reviewer         string `yaml:"reviewer"`
+	QualityReviewer  string `yaml:"quality_reviewer"`
 	SpecGenerator    string `yaml:"spec_generator"`
 }
 

--- a/prompts/quality_reviewer.txt
+++ b/prompts/quality_reviewer.txt
@@ -1,0 +1,37 @@
+You are a code quality reviewer. Audit PR #{{.PRNumber}} for security, performance, and code quality issues in the {{.Repo}} repository.
+
+Issue title: {{.IssueTitle}}
+Issue body:
+{{.IssueBody}}
+
+Steps:
+1. Check out the PR: gh pr checkout {{.PRNumber}} --repo {{.Repo}}
+2. Review the code changes: gh pr diff {{.PRNumber}} --repo {{.Repo}}
+3. Audit for security issues:
+   - Injection vulnerabilities (SQL, command, path traversal)
+   - OWASP top 10 concerns
+   - Unsafe patterns (hardcoded secrets, weak crypto, unvalidated input)
+4. Audit for performance issues:
+   - Unnecessary allocations or copies
+   - N+1 query patterns
+   - Missing context propagation
+   - Unbounded operations (missing limits, timeouts)
+5. Audit for language idioms (infer conventions from the project's CLAUDE.md and codebase):
+   - Proper error handling following project conventions
+   - Safe concurrency patterns (no unhandled panics, proper cancellation)
+   - Proper resource cleanup (close handles, cancel contexts, release locks)
+   - Correct use of the language's concurrency primitives
+6. Audit for code craft:
+   - Clear naming and structure
+   - Appropriate abstraction level
+   - Testability (injectable dependencies, no global state)
+
+Based on your findings:
+- If the code has NO significant quality issues:
+  Print QUALITY_RESULT=APPROVED
+- If the code has security, performance, or quality issues that should be fixed:
+  Request changes on the PR with specific feedback and print QUALITY_RESULT=CHANGES_REQUESTED
+
+CRITICAL: You MUST print exactly one of these lines:
+  QUALITY_RESULT=APPROVED
+  QUALITY_RESULT=CHANGES_REQUESTED


### PR DESCRIPTION
## Summary

- Adds a `quality_reviewer` agent that runs **after implementation, before functional review**, creating adversarial separation — the agent auditing quality didn't write the code
- New loop flow: `implementer → quality_reviewer → reviewer → (retry loop)`
- Audits for security vulnerabilities, performance issues, language idioms, and code craft
- If quality review requests changes, the implementer retries before functional review starts
- Optional — skipped when no `quality_reviewer` prompt is configured
- Language-agnostic: prompt instructs agent to infer conventions from the project's CLAUDE.md

## Changes

- **New**: `prompts/quality_reviewer.txt` — quality audit prompt template
- **New**: `internal/agent/quality_reviewer.go` — `QualityReview()` function and `ParseQualityResult()` parser
- **New**: `internal/agent/quality_reviewer_test.go` — 7 tests
- **Modified**: `internal/agent/loop.go` — quality review gate (step 4) between guard rails and functional review
- **Modified**: `internal/agent/prompt.go`, `internal/config/config.go` — `QualityReviewer` field
- **Modified**: `internal/agent/runner/agent_runner.py` — `quality_reviewer` role (read-only) and `QUALITY_RESULT` verdict extraction
- **Modified**: `internal/agent/loop_test.go` — updated existing tests + 2 new tests for quality review gate

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go build -o bin/godark ./cmd/godark` succeeds
- [x] Quality reviewer prompt is language-agnostic (no Go-specific references)
- [x] Rebased on latest main (post phase-6 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)