### PR TITLE
feat: add auto-detect project type (#52)

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -75,7 +75,7 @@ loop directly, without milestone or dependency resolution.`,
 		}
 
 		// Auto-detect project type when no runtime/commands are explicitly configured.
-		detect.ApplyToConfig(cfg, logger)
+		detect.ApplyToConfig(cfg, ".", logger)
 
 		authEnv, err := sandbox.CollectAuthEnv(logger)
 		if err != nil {

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -82,11 +82,11 @@ func DetectRuntime(repoPath string) (*DetectedProject, error) {
 
 // ApplyToConfig runs detection if no runtime or commands are explicitly configured,
 // and applies the detected values to cfg, logging results to logger.
-func ApplyToConfig(cfg *config.Config, logger *slog.Logger) {
+func ApplyToConfig(cfg *config.Config, repoPath string, logger *slog.Logger) {
 	if cfg.Runtime.Name != "" || cfg.BuildCommand != "" || cfg.TestCommand != "" {
 		return
 	}
-	dp, err := DetectRuntime(".")
+	dp, err := DetectRuntime(repoPath)
 	if err != nil {
 		logger.Info("project type detection failed, continuing without defaults", "error", err)
 		return

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -1,6 +1,7 @@
 package detect
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,28 +189,46 @@ func TestDetectRuntime_FlutterVersionParsing(t *testing.T) {
 	}
 }
 
-// TestApplyDetection_ConfigWins verifies that explicit config values are not
-// overwritten by detection. This tests the orchestration wiring condition.
-func TestApplyDetection_ConfigWins(t *testing.T) {
+// TestApplyToConfig_ConfigWins verifies that ApplyToConfig does not overwrite
+// explicit config values.
+func TestApplyToConfig_ConfigWins(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/foo\n\ngo 1.26\n")
 
 	cfg := &config.Config{
 		Runtime: config.Runtime{Name: "node"},
 	}
+	logger := slog.Default()
 
-	// Simulate the orchestrator condition: only detect when all three are empty.
-	if cfg.Runtime.Name == "" && cfg.BuildCommand == "" && cfg.TestCommand == "" {
-		dp, err := DetectRuntime(dir)
-		if err == nil {
-			cfg.Runtime = dp.Runtime
-			cfg.BuildCommand = dp.BuildCommand
-			cfg.TestCommand = dp.TestCommand
-		}
-	}
+	ApplyToConfig(cfg, dir, logger)
 
 	if cfg.Runtime.Name != "node" {
 		t.Errorf("Runtime.Name = %q, want %q (explicit config must not be overwritten)", cfg.Runtime.Name, "node")
+	}
+}
+
+// TestApplyToConfig_DetectionApplied verifies that ApplyToConfig applies
+// detected values when no runtime or commands are explicitly configured.
+func TestApplyToConfig_DetectionApplied(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/foo\n\ngo 1.26\n")
+
+	cfg := &config.Config{}
+	logger := slog.Default()
+
+	ApplyToConfig(cfg, dir, logger)
+
+	if cfg.Runtime.Name != "go" {
+		t.Errorf("Runtime.Name = %q, want %q", cfg.Runtime.Name, "go")
+	}
+	if cfg.Runtime.Version != "1.26" {
+		t.Errorf("Runtime.Version = %q, want %q", cfg.Runtime.Version, "1.26")
+	}
+	if cfg.TestCommand != "go test ./..." {
+		t.Errorf("TestCommand = %q, want %q", cfg.TestCommand, "go test ./...")
+	}
+	if cfg.BuildCommand != "go build ./..." {
+		t.Errorf("BuildCommand = %q, want %q", cfg.BuildCommand, "go build ./...")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -26,7 +26,7 @@ func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, dryRun bo
 	)
 
 	// Auto-detect project type when no runtime/commands are explicitly configured.
-	detect.ApplyToConfig(cfg, logger)
+	detect.ApplyToConfig(cfg, ".", logger)
 
 	// Step 1: Fetch open issues for the milestone.
 	issues, err := github.FetchMilestoneIssues(cfg.Repo, cfg.Milestone)


### PR DESCRIPTION
## Summary

- Adds `internal/detect` package with `DetectRuntime(repoPath string) (*DetectedProject, error)` that scans for language marker files in detection order: `go.mod` → `pubspec.yaml` → `package.json` → `Cargo.toml` → `pyproject.toml` / `requirements.txt`
- Version parsing: extracts Go version from `go.mod`, Flutter SDK from `pubspec.yaml` `environment.sdk`, and Node engine from `package.json` `engines.node`
- Wired into `orchestrator.Run` and `implement` command: detection runs on `.` when all three of `cfg.Runtime.Name`, `cfg.BuildCommand`, and `cfg.TestCommand` are empty; explicit config always wins

## Test plan

- [x] `go test ./internal/detect/...` passes (12 tests covering all cases from the issue)
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` clean

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)