### PR TITLE
feat: quality review diminishing strictness

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -102,7 +102,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				return outcome
 			}
 
-			qResult, err := QualityReview(ctx, issue, prNum, cfg, prompts, authEnv, logger)
+			qResult, err := QualityReview(ctx, issue, prNum, cfg, prompts, authEnv, logger, qAttempt)
 			if err != nil {
 				outcome.Status = "failed"
 				outcome.Err = fmt.Errorf("quality reviewer agent: %w", err)

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -600,6 +600,66 @@ func TestProcessIssue_QualityReviewChangesRequestedTriggersRetry(t *testing.T) {
 	}
 }
 
+func TestProcessIssue_PassesCycleToQualityReview(t *testing.T) {
+	cfg := loopConfig()
+	cfg.QualityStrictnessDecay = true
+	// MaxRetries=2 → qualityMaxAttempts=3
+
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = loopGuardFn
+
+	callIdx := 0
+	var qualityPrompts []string
+
+	// Prompts with StrictnessDirective variable so we can observe the rendered output.
+	prompts := testPrompts(t)
+	prompts.QualityReviewer = "Quality review PR #{{.PRNumber}}{{if .StrictnessDirective}}\n{{.StrictnessDirective}}{{end}}"
+
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2: // quality review cycle=0 (should have no directive)
+			if env["GODARK_ROLE"] == "quality_reviewer" {
+				qualityPrompts = append(qualityPrompts, env["GODARK_PROMPT"])
+			}
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		case 3: // retry
+			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
+		case 4: // quality review cycle=1 (should have directive)
+			if env["GODARK_ROLE"] == "quality_reviewer" {
+				qualityPrompts = append(qualityPrompts, env["GODARK_PROMPT"])
+			}
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	ProcessIssue(context.Background(), loopIssue(), cfg, prompts, nil, testLogger(t))
+
+	if len(qualityPrompts) != 2 {
+		t.Fatalf("expected 2 quality review calls, got %d", len(qualityPrompts))
+	}
+	// First call (cycle=0) should not have directive.
+	if strings.Contains(qualityPrompts[0], "STRICTNESS OVERRIDE") {
+		t.Errorf("first quality review (cycle=0) should not have strictness directive, got: %q", qualityPrompts[0])
+	}
+	// Second call (cycle=1, maxAttempts=3, not final) should have the narrowing directive.
+	if !strings.Contains(qualityPrompts[1], "STRICTNESS OVERRIDE") {
+		t.Errorf("second quality review (cycle=1) should have strictness directive, got: %q", qualityPrompts[1])
+	}
+	if !strings.Contains(qualityPrompts[1], "security vulnerabilities and correctness issues only") {
+		t.Errorf("second quality review (cycle=1) should narrow to security+correctness, got: %q", qualityPrompts[1])
+	}
+}
+
 func TestProcessIssue_SkipsQualityReviewWhenNoPrompt(t *testing.T) {
 	agentCallCount := 0
 	setupLoopTest(t, nil, func(name string, args ...string) ([]byte, error) {

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -34,7 +34,8 @@ type PromptData struct {
 	ProtectedPaths string
 	ScenarioDir    string
 	ReviewDir      string
-	BranchExists   bool
+	BranchExists        bool
+	StrictnessDirective string
 }
 
 // loadPromptFile reads a prompt from the config path if set, otherwise from

--- a/internal/agent/quality_reviewer.go
+++ b/internal/agent/quality_reviewer.go
@@ -17,9 +17,13 @@ type QualityReviewResult struct {
 }
 
 // QualityReview runs the quality reviewer agent for the given PR and returns the verdict.
-func QualityReview(ctx context.Context, issue github.Issue, prNum int, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*QualityReviewResult, error) {
+// cycle is 0-indexed: 0 = first pass, 1 = first retry, etc.
+func QualityReview(ctx context.Context, issue github.Issue, prNum int, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger, cycle int) (*QualityReviewResult, error) {
+	maxAttempts := cfg.MaxRetries + 1
+
 	data := newPromptData(issue, cfg, Slugify(issue.Title))
 	data.PRNumber = prNum
+	data.StrictnessDirective = strictnessDirective(cycle, maxAttempts, cfg.QualityStrictnessDecay)
 
 	rendered, err := RenderPrompt(prompts.QualityReviewer, data)
 	if err != nil {
@@ -34,6 +38,7 @@ func QualityReview(ctx context.Context, issue github.Issue, prNum int, cfg *conf
 	logger.Info("starting quality reviewer agent",
 		"issue_number", issue.Number,
 		"pr_number", prNum,
+		"cycle", cycle+1,
 	)
 
 	result, err := Run(ctx, opts, cfg.NoSandbox, logger)
@@ -56,6 +61,19 @@ func QualityReview(ctx context.Context, issue github.Issue, prNum int, cfg *conf
 		Verdict:     verdict,
 		AgentResult: result,
 	}, nil
+}
+
+// strictnessDirective returns the strictness override text to append to the
+// quality reviewer prompt for a given cycle. Returns empty string for the
+// first pass (cycle==0), when decay is disabled, or when maxAttempts <= 1.
+func strictnessDirective(cycle, maxAttempts int, decay bool) string {
+	if !decay || maxAttempts <= 1 || cycle == 0 {
+		return ""
+	}
+	if cycle == maxAttempts-1 {
+		return "STRICTNESS OVERRIDE: This is the final quality review cycle. Only block on security vulnerabilities or data-safety issues. All other observations should be noted as comments but must NOT result in CHANGES_REQUESTED. Only print QUALITY_RESULT=CHANGES_REQUESTED if you find a genuine security vulnerability."
+	}
+	return fmt.Sprintf("STRICTNESS OVERRIDE: This is quality review retry %d. Narrow your focus to security vulnerabilities and correctness issues only. Do not block on style, naming, minor performance, or code craft observations. Only print QUALITY_RESULT=CHANGES_REQUESTED for security or correctness defects.", cycle+1)
 }
 
 // ParseQualityResult scans agent output for a QUALITY_RESULT line and

--- a/internal/agent/quality_reviewer_test.go
+++ b/internal/agent/quality_reviewer_test.go
@@ -2,7 +2,10 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
+
+	"github.com/phs/dark-factory/internal/config"
 )
 
 func TestQualityReview_ReturnsVerdict(t *testing.T) {
@@ -11,7 +14,7 @@ func TestQualityReview_ReturnsVerdict(t *testing.T) {
 		return []byte(out), []byte(""), 0, nil
 	})
 
-	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t), 0)
 	if err != nil {
 		t.Fatalf("QualityReview() error = %v", err)
 	}
@@ -26,7 +29,7 @@ func TestQualityReview_ChangesRequested(t *testing.T) {
 		return []byte(out), []byte(""), 0, nil
 	})
 
-	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t), 0)
 	if err != nil {
 		t.Fatalf("QualityReview() error = %v", err)
 	}
@@ -42,7 +45,7 @@ func TestQualityReview_SetsQualityReviewerRole(t *testing.T) {
 		return []byte("QUALITY_RESULT=APPROVED\n"), []byte(""), 0, nil
 	})
 
-	_, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	_, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t), 0)
 	if err != nil {
 		t.Fatalf("QualityReview() error = %v", err)
 	}
@@ -58,7 +61,7 @@ func TestQualityReview_StructuredVerdict(t *testing.T) {
 		return []byte(out), []byte(""), 0, nil
 	})
 
-	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t))
+	result, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t), 0)
 	if err != nil {
 		t.Fatalf("QualityReview() error = %v", err)
 	}
@@ -85,5 +88,194 @@ func TestParseQualityResult_NoMatch(t *testing.T) {
 	got := ParseQualityResult("no sentinel here")
 	if got != "" {
 		t.Errorf("ParseQualityResult() = %q, want %q", got, "")
+	}
+}
+
+// --- strictnessDirective unit tests ---
+
+func TestStrictnessDirective_Cycle0NoDirective(t *testing.T) {
+	got := strictnessDirective(0, 3, true)
+	if got != "" {
+		t.Errorf("cycle=0 should have no directive, got %q", got)
+	}
+}
+
+func TestStrictnessDirective_DecayDisabled(t *testing.T) {
+	got := strictnessDirective(2, 3, false)
+	if got != "" {
+		t.Errorf("decay=false should have no directive, got %q", got)
+	}
+}
+
+func TestStrictnessDirective_SingleAttemptNoDirective(t *testing.T) {
+	got := strictnessDirective(0, 1, true)
+	if got != "" {
+		t.Errorf("maxAttempts=1 should have no directive, got %q", got)
+	}
+}
+
+func TestStrictnessDirective_MidCycleNarrowsScope(t *testing.T) {
+	got := strictnessDirective(1, 3, true)
+	if !strings.Contains(got, "security vulnerabilities and correctness issues only") {
+		t.Errorf("mid-cycle directive should mention correctness narrowing, got %q", got)
+	}
+	if !strings.Contains(got, "STRICTNESS OVERRIDE") {
+		t.Errorf("mid-cycle directive should have STRICTNESS OVERRIDE prefix, got %q", got)
+	}
+}
+
+func TestStrictnessDirective_FinalCycleSecurityOnly(t *testing.T) {
+	got := strictnessDirective(2, 3, true)
+	if !strings.Contains(got, "final quality review cycle") {
+		t.Errorf("final cycle directive should mention 'final quality review cycle', got %q", got)
+	}
+	if !strings.Contains(got, "security vulnerability") {
+		t.Errorf("final cycle directive should mention 'security vulnerability', got %q", got)
+	}
+}
+
+func TestStrictnessDirective_MidCycleContainsRetryNumber(t *testing.T) {
+	got := strictnessDirective(1, 5, true)
+	if !strings.Contains(got, "retry 2") {
+		t.Errorf("mid-cycle directive should contain retry number 2, got %q", got)
+	}
+}
+
+// --- QualityReview prompt rendering tests ---
+
+func qualityConfigWithDecay(maxRetries int) *config.Config {
+	cfg := testConfig()
+	cfg.MaxRetries = maxRetries
+	cfg.QualityStrictnessDecay = true
+	return cfg
+}
+
+func qualityPromptsWithDirective(t *testing.T) *Prompts {
+	t.Helper()
+	p := testPrompts(t)
+	p.QualityReviewer = "Quality review PR #{{.PRNumber}} for #{{.IssueNumber}}{{if .StrictnessDirective}}\n{{.StrictnessDirective}}{{end}}"
+	return p
+}
+
+func TestQualityReview_Cycle0NoDirectiveInPrompt(t *testing.T) {
+	var capturedPrompt string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedPrompt = env["GODARK_PROMPT"]
+		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	cfg := qualityConfigWithDecay(2) // maxAttempts=3
+	_, err := QualityReview(context.Background(), testIssue(), 10, cfg, qualityPromptsWithDirective(t), nil, testLogger(t), 0)
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+
+	if strings.Contains(capturedPrompt, "STRICTNESS OVERRIDE") {
+		t.Errorf("cycle=0 prompt should not contain STRICTNESS OVERRIDE, got: %q", capturedPrompt)
+	}
+}
+
+func TestQualityReview_Cycle1NarrowsScope(t *testing.T) {
+	var capturedPrompt string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedPrompt = env["GODARK_PROMPT"]
+		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	cfg := qualityConfigWithDecay(2) // maxAttempts=3
+	_, err := QualityReview(context.Background(), testIssue(), 10, cfg, qualityPromptsWithDirective(t), nil, testLogger(t), 1)
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+
+	if !strings.Contains(capturedPrompt, "security vulnerabilities and correctness issues only") {
+		t.Errorf("cycle=1 prompt should contain correctness narrowing, got: %q", capturedPrompt)
+	}
+}
+
+func TestQualityReview_FinalCycleSecurityOnly(t *testing.T) {
+	var capturedPrompt string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedPrompt = env["GODARK_PROMPT"]
+		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	cfg := qualityConfigWithDecay(2) // maxAttempts=3, final cycle=2
+	_, err := QualityReview(context.Background(), testIssue(), 10, cfg, qualityPromptsWithDirective(t), nil, testLogger(t), 2)
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+
+	if !strings.Contains(capturedPrompt, "final quality review cycle") {
+		t.Errorf("final cycle prompt should contain 'final quality review cycle', got: %q", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "security vulnerability") {
+		t.Errorf("final cycle prompt should contain 'security vulnerability', got: %q", capturedPrompt)
+	}
+}
+
+func TestQualityReview_SingleAttemptNoDirective(t *testing.T) {
+	var capturedPrompt string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedPrompt = env["GODARK_PROMPT"]
+		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	cfg := qualityConfigWithDecay(0) // maxAttempts=1
+	_, err := QualityReview(context.Background(), testIssue(), 10, cfg, qualityPromptsWithDirective(t), nil, testLogger(t), 0)
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+
+	if strings.Contains(capturedPrompt, "STRICTNESS OVERRIDE") {
+		t.Errorf("single-attempt prompt should not contain STRICTNESS OVERRIDE, got: %q", capturedPrompt)
+	}
+}
+
+func TestQualityReview_DecayDisabledNoDirective(t *testing.T) {
+	var capturedPrompt string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedPrompt = env["GODARK_PROMPT"]
+		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	cfg := testConfig()
+	cfg.MaxRetries = 2
+	cfg.QualityStrictnessDecay = false
+	_, err := QualityReview(context.Background(), testIssue(), 10, cfg, qualityPromptsWithDirective(t), nil, testLogger(t), 2)
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+
+	if strings.Contains(capturedPrompt, "STRICTNESS OVERRIDE") {
+		t.Errorf("decay=false prompt should not contain STRICTNESS OVERRIDE, got: %q", capturedPrompt)
+	}
+}
+
+func TestQualityReview_DirectiveAppendedNotReplaced(t *testing.T) {
+	var capturedPrompt string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedPrompt = env["GODARK_PROMPT"]
+		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	cfg := qualityConfigWithDecay(2) // maxAttempts=3
+	_, err := QualityReview(context.Background(), testIssue(), 10, cfg, qualityPromptsWithDirective(t), nil, testLogger(t), 1)
+	if err != nil {
+		t.Fatalf("QualityReview() error = %v", err)
+	}
+
+	// Prompt should contain both original instructions and the directive.
+	if !strings.Contains(capturedPrompt, "Quality review PR") {
+		t.Errorf("prompt should contain original quality reviewer text, got: %q", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "STRICTNESS OVERRIDE") {
+		t.Errorf("prompt should contain strictness directive, got: %q", capturedPrompt)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,8 @@ type Config struct {
 	ReviewDir      string   `yaml:"review_dir"`
 	LogDir         string   `yaml:"log_dir"`
 
-	NoSandbox bool `yaml:"no_sandbox"`
+	NoSandbox              bool `yaml:"no_sandbox"`
+	QualityStrictnessDecay bool `yaml:"quality_strictness_decay"`
 
 	Docker  Docker  `yaml:"docker"`
 	Prompts Prompts `yaml:"prompts"`
@@ -98,12 +99,13 @@ func Load(path string, flags CLIFlags) (*Config, error) {
 
 func defaults() *Config {
 	return &Config{
-		MaxRetries:  2,
-		RoadmapPath: "docs/ROADMAP.md",
-		PlanningDir: "docs/planning/",
-		ScenarioDir: "tests/scenarios/",
-		ReviewDir:   "tests/review/",
-		LogDir:      "logs/",
+		MaxRetries:             2,
+		RoadmapPath:            "docs/ROADMAP.md",
+		PlanningDir:            "docs/planning/",
+		ScenarioDir:            "tests/scenarios/",
+		ReviewDir:              "tests/review/",
+		LogDir:                 "logs/",
+		QualityStrictnessDecay: true,
 	}
 }
 

--- a/prompts/quality_reviewer.txt
+++ b/prompts/quality_reviewer.txt
@@ -35,3 +35,6 @@ Based on your findings:
 CRITICAL: You MUST print exactly one of these lines:
   QUALITY_RESULT=APPROVED
   QUALITY_RESULT=CHANGES_REQUESTED
+{{if .StrictnessDirective}}
+{{.StrictnessDirective}}
+{{end}}


### PR DESCRIPTION
## Summary

- Adds `QualityStrictnessDecay bool` config field (default `true`) to progressively narrow the quality reviewer's scope on retries
- Adds `StrictnessDirective string` to `PromptData` for template injection
- `QualityReview()` gains a `cycle int` parameter; computes the directive via `strictnessDirective()` helper
- `prompts/quality_reviewer.txt` appends `{{.StrictnessDirective}}` at the end
- `loop.go` passes `qAttempt` as the cycle argument on each quality review call

**Strictness levels:**
- Cycle 1 (first pass): full audit — no directive
- Cycle 2+: security + correctness only directive
- Final cycle: security-only directive
- When `quality_strictness_decay: false` or `max_retries: 0`: no directive on any cycle

## Test plan

- [x] `TestStrictnessDirective_*` — unit tests for all `strictnessDirective()` branches
- [x] `TestQualityReview_Cycle0NoDirectiveInPrompt` — cycle=0 renders no override
- [x] `TestQualityReview_Cycle1NarrowsScope` — cycle=1 renders correctness narrowing
- [x] `TestQualityReview_FinalCycleSecurityOnly` — final cycle renders security-only
- [x] `TestQualityReview_SingleAttemptNoDirective` — maxAttempts=1 always uses full strictness
- [x] `TestQualityReview_DecayDisabledNoDirective` — decay=false renders no override
- [x] `TestQualityReview_DirectiveAppendedNotReplaced` — both original text and directive present
- [x] `TestProcessIssue_PassesCycleToQualityReview` — loop passes correct qAttempt value
- [x] All existing quality reviewer and loop tests still pass
- [x] `go test ./internal/agent/...` passes
- [x] `go build ./cmd/godark` succeeds

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)