### PR TITLE
feat: add configurable auth token preference

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -82,7 +82,7 @@ loop directly, without milestone or dependency resolution.`,
 		// Auto-detect project type when no runtime/commands are explicitly configured.
 		detect.ApplyToConfig(cfg, ".", logger)
 
-		authEnv, err := sandbox.CollectAuthEnv(logger)
+		authEnv, err := sandbox.CollectAuthEnv(logger, cfg.AuthPreference)
 		if err != nil {
 			return fmt.Errorf("collecting auth: %w", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,11 @@ type Config struct {
 	NoMerge                bool `yaml:"no_merge"`
 	QualityStrictnessDecay bool `yaml:"quality_strictness_decay"`
 
+	// AuthPreference controls which Anthropic auth token is preferred when both
+	// ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN are set.
+	// Valid values: "oauth" (default) or "api_key".
+	AuthPreference string `yaml:"auth_preference"`
+
 	Docker  Docker  `yaml:"docker"`
 	Prompts Prompts `yaml:"prompts"`
 }
@@ -104,6 +109,7 @@ func defaults() *Config {
 		ReviewDir:              "tests/review/",
 		LogDir:                 "logs/",
 		QualityStrictnessDecay: true,
+		AuthPreference:         "oauth",
 	}
 }
 
@@ -125,6 +131,12 @@ func applyFlags(cfg *Config, flags CLIFlags) {
 func validate(cfg *Config) error {
 	if cfg.Repo == "" {
 		return fmt.Errorf("repo is required (set in config file or pass --repo)")
+	}
+	switch cfg.AuthPreference {
+	case "oauth", "api_key":
+		// valid
+	default:
+		return fmt.Errorf("auth_preference must be \"oauth\" or \"api_key\", got %q", cfg.AuthPreference)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -369,6 +369,70 @@ no_merge: false
 	}
 }
 
+func TestAuthPreferenceDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AuthPreference != "oauth" {
+		t.Errorf("AuthPreference = %q, want %q", cfg.AuthPreference, "oauth")
+	}
+}
+
+func TestAuthPreferenceOAuthFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+auth_preference: oauth
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AuthPreference != "oauth" {
+		t.Errorf("AuthPreference = %q, want %q", cfg.AuthPreference, "oauth")
+	}
+}
+
+func TestAuthPreferenceAPIKeyFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+auth_preference: api_key
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AuthPreference != "api_key" {
+		t.Errorf("AuthPreference = %q, want %q", cfg.AuthPreference, "api_key")
+	}
+}
+
+func TestAuthPreferenceInvalidValue(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+auth_preference: token
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for invalid auth_preference, got nil")
+	}
+	if !strings.Contains(err.Error(), "auth_preference") {
+		t.Errorf("error = %q, want mention of 'auth_preference'", err.Error())
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -159,7 +159,7 @@ func processIssues(ctx context.Context, processable []github.Issue, blocked []bl
 	}
 
 	// Collect auth tokens once at the start.
-	authEnv, err := sandbox.CollectAuthEnv(logger)
+	authEnv, err := sandbox.CollectAuthEnv(logger, cfg.AuthPreference)
 	if err != nil {
 		return fmt.Errorf("collecting auth: %w", err)
 	}

--- a/internal/sandbox/auth.go
+++ b/internal/sandbox/auth.go
@@ -10,13 +10,23 @@ import (
 
 // CollectAuthEnv reads authentication tokens from the host environment
 // and returns a map suitable for passing as container environment variables.
-func CollectAuthEnv(logger *slog.Logger) (map[string]string, error) {
+// authPreference controls which token is preferred when both are set:
+// "oauth" (default) prefers CLAUDE_CODE_OAUTH_TOKEN; "api_key" prefers ANTHROPIC_API_KEY.
+func CollectAuthEnv(logger *slog.Logger, authPreference string) (map[string]string, error) {
 	env := make(map[string]string)
 
 	oauthToken := os.Getenv("CLAUDE_CODE_OAUTH_TOKEN")
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 
+	preferAPIKey := authPreference == "api_key"
+
 	switch {
+	case preferAPIKey && apiKey != "":
+		env["ANTHROPIC_API_KEY"] = apiKey
+		logger.Info("using ANTHROPIC_API_KEY for Anthropic auth")
+	case preferAPIKey && oauthToken != "":
+		env["CLAUDE_CODE_OAUTH_TOKEN"] = oauthToken
+		logger.Info("using CLAUDE_CODE_OAUTH_TOKEN for Anthropic auth (api_key preferred but not set)")
 	case oauthToken != "":
 		env["CLAUDE_CODE_OAUTH_TOKEN"] = oauthToken
 		logger.Info("using CLAUDE_CODE_OAUTH_TOKEN for Anthropic auth")

--- a/internal/sandbox/auth_test.go
+++ b/internal/sandbox/auth_test.go
@@ -23,7 +23,7 @@ func TestCollectAuthEnv_APIKey(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("GH_TOKEN", "gho_test")
 
-	env, err := CollectAuthEnv(slog.Default())
+	env, err := CollectAuthEnv(slog.Default(), "oauth")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestCollectAuthEnv_NoAuthTokens(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("GH_TOKEN", "")
 
-	_, err := CollectAuthEnv(slog.Default())
+	_, err := CollectAuthEnv(slog.Default(), "oauth")
 	if err == nil {
 		t.Fatal("expected error when no auth tokens set")
 	}
@@ -59,7 +59,7 @@ func TestCollectAuthEnv_OAuthTokenOnly(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token-abc")
 	t.Setenv("GH_TOKEN", "gho_test")
 
-	env, err := CollectAuthEnv(slog.Default())
+	env, err := CollectAuthEnv(slog.Default(), "oauth")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestCollectAuthEnv_OAuthPreferredOverAPIKey(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token-abc")
 	t.Setenv("GH_TOKEN", "gho_test")
 
-	env, err := CollectAuthEnv(slog.Default())
+	env, err := CollectAuthEnv(slog.Default(), "oauth")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -89,6 +89,48 @@ func TestCollectAuthEnv_OAuthPreferredOverAPIKey(t *testing.T) {
 	}
 	if _, ok := env["ANTHROPIC_API_KEY"]; ok {
 		t.Error("ANTHROPIC_API_KEY should not be set when OAuth token takes priority")
+	}
+}
+
+func TestCollectAuthEnv_APIKeyPreferredOverOAuth(t *testing.T) {
+	defer stubCommandRunner(func(string, ...string) ([]byte, error) {
+		return []byte("gho_fake\n"), nil
+	})()
+
+	t.Setenv("ANTHROPIC_API_KEY", "sk-key")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token-abc")
+	t.Setenv("GH_TOKEN", "gho_test")
+
+	env, err := CollectAuthEnv(slog.Default(), "api_key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if env["ANTHROPIC_API_KEY"] != "sk-key" {
+		t.Errorf("ANTHROPIC_API_KEY = %q, want sk-key", env["ANTHROPIC_API_KEY"])
+	}
+	if _, ok := env["CLAUDE_CODE_OAUTH_TOKEN"]; ok {
+		t.Error("CLAUDE_CODE_OAUTH_TOKEN should not be set when API key takes priority")
+	}
+}
+
+func TestCollectAuthEnv_APIKeyPreference_FallsBackToOAuth(t *testing.T) {
+	defer stubCommandRunner(func(string, ...string) ([]byte, error) {
+		return []byte("gho_fake\n"), nil
+	})()
+
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "oauth-token-abc")
+	t.Setenv("GH_TOKEN", "gho_test")
+
+	env, err := CollectAuthEnv(slog.Default(), "api_key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if env["CLAUDE_CODE_OAUTH_TOKEN"] != "oauth-token-abc" {
+		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN = %q, want oauth-token-abc", env["CLAUDE_CODE_OAUTH_TOKEN"])
+	}
+	if _, ok := env["ANTHROPIC_API_KEY"]; ok {
+		t.Error("ANTHROPIC_API_KEY should not be set when falling back to OAuth")
 	}
 }
 
@@ -102,7 +144,7 @@ func TestCollectAuthEnv_GHTokenFromEnv(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("GH_TOKEN", "gho_from_env")
 
-	env, err := CollectAuthEnv(slog.Default())
+	env, err := CollectAuthEnv(slog.Default(), "oauth")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -123,7 +165,7 @@ func TestCollectAuthEnv_GHTokenFallback(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("GH_TOKEN", "")
 
-	env, err := CollectAuthEnv(slog.Default())
+	env, err := CollectAuthEnv(slog.Default(), "oauth")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -141,7 +183,7 @@ func TestCollectAuthEnv_GHTokenMissing(t *testing.T) {
 	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
 	t.Setenv("GH_TOKEN", "")
 
-	_, err := CollectAuthEnv(slog.Default())
+	_, err := CollectAuthEnv(slog.Default(), "oauth")
 	if err == nil {
 		t.Fatal("expected error when GH_TOKEN missing")
 	}
@@ -163,7 +205,7 @@ func TestCollectAuthEnv_NoSecretsInLog(t *testing.T) {
 	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
 	logger := slog.New(handler)
 
-	env, err := CollectAuthEnv(logger)
+	env, err := CollectAuthEnv(logger, "oauth")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Add `auth_preference: oauth | api_key` field to `Config` struct (default `oauth`)
- Update `CollectAuthEnv` to accept and honour the preference when both tokens are available
- Validate that `auth_preference` is one of the two accepted values
- Update all call sites (`orchestrator`, `implement` command) to pass `cfg.AuthPreference`
- Add config tests for default, YAML parsing, and validation
- Add sandbox auth tests for `api_key` preference and fallback behaviour

## Test plan

- [ ] `go test ./...` passes with no failures
- [ ] Config with `auth_preference: oauth` (or omitted) selects OAuth over API key when both env vars are set
- [ ] Config with `auth_preference: api_key` selects API key over OAuth when both env vars are set
- [ ] Config with `auth_preference: api_key` falls back to OAuth when only OAuth is set
- [ ] Invalid `auth_preference` value (e.g. `token`) returns a clear validation error
- [ ] `go vet ./...` clean

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)