### PR TITLE
fix: punchlist agent fails due to empty allowed_tools

### DIFF
--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -51,7 +51,6 @@ _ROLE_PERMISSIONS: dict[str, dict] = {
         "disallowed_tools": ["Bash"],
     },
     "punchlist": {
-        "allowed_tools": [],
         "disallowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
     },
 }
@@ -199,8 +198,8 @@ async def main() -> None:
         system_prompt={"type": "preset", "preset": "claude_code"},
         cwd=work_dir,
         env=env if env else None,
-        allowed_tools=permissions.get("allowed_tools"),
-        disallowed_tools=permissions.get("disallowed_tools"),
+        allowed_tools=permissions.get("allowed_tools") or None,
+        disallowed_tools=permissions.get("disallowed_tools") or None,
         hooks=hooks,
     )
 


### PR DESCRIPTION
## Summary
- Remove `allowed_tools: []` from the punchlist role — the SDK rejects an empty list, causing exit code 1
- Add `or None` guard so empty lists are never passed to the SDK for any role
- Punchlist role now relies solely on `disallowed_tools` to block tool use

Fixes #90

## Test plan
- [ ] Rebuild binary, run `godark implement <issue>`, verify "Suggested acceptance tests" appear in punchlist output

🤖 Generated with [Claude Code](https://claude.com/claude-code)