### PR TITLE
fix: handle empty gh label list output in EnsureLabel

### DIFF
--- a/internal/github/labels.go
+++ b/internal/github/labels.go
@@ -21,7 +21,10 @@ func EnsureLabel(repo, name, color, description string) error {
 	var labels []struct {
 		Name string `json:"name"`
 	}
-	if err := json.Unmarshal(out, &labels); err != nil {
+	if len(out) == 0 {
+		// gh returns empty output (not "[]") when no labels match.
+		labels = nil
+	} else if err := json.Unmarshal(out, &labels); err != nil {
 		return fmt.Errorf("parsing label list: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- `gh label list --json name` returns empty output (not `[]`) when no labels match
- `json.Unmarshal` on empty bytes fails with "unexpected end of JSON input"
- Treat empty output as an empty list so `EnsureLabel` can proceed to create the label

## Test plan
- [x] `go test ./internal/github/` passes
- [x] `go vet ./...` clean
- [x] Manual: `godark run --tag phase-7` no longer errors on lock label creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)