### PR TITLE
feat: add internal/rundata package with Writer and write methods

### DIFF
--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -21,9 +21,9 @@ type RunMeta struct {
 
 // RunSummary holds the outcome summary written by FinalizeRun.
 type RunSummary struct {
-	IssuesProcessed int    `json:"issues_processed"`
-	IssuesFailed    int    `json:"issues_failed"`
-	Notes           string `json:"notes,omitempty"`
+	Total       int `json:"total"`
+	Implemented int `json:"implemented"`
+	Failed      int `json:"failed"`
 }
 
 // StepResult holds the output of a single agent step.
@@ -36,8 +36,8 @@ type StepResult struct {
 // Outcome records the final result for a single issue.
 type Outcome struct {
 	IssueNumber int    `json:"issue_number"`
-	Result      string `json:"result"`
-	Summary     string `json:"summary,omitempty"`
+	Status      string `json:"status"`
+	PRNumber    int    `json:"pr_number"`
 }
 
 // Writer manages a per-run directory and writes JSON files for each agent loop step.
@@ -122,15 +122,11 @@ func (w *Writer) WriteRetryResult(issueNum, retryNum int, step StepResult) error
 	return writeJSONMkdirs(path, step)
 }
 
-// WriteRetryReviewResult writes a review result for a retry step.
-// kind must be "quality" or "functional".
-// Path: issues/<issueNum>/retries/<retryNum>/<kind>-review.json
-func (w *Writer) WriteRetryReviewResult(issueNum, retryNum int, kind string, step StepResult) error {
-	if kind != "quality" && kind != "functional" {
-		return fmt.Errorf("review kind must be %q or %q, got %q", "quality", "functional", kind)
-	}
+// WriteRetryReviewResult writes a quality review result for a retry step.
+// Path: issues/<issueNum>/retries/<retryNum>/quality-review.json
+func (w *Writer) WriteRetryReviewResult(issueNum, retryNum int, step StepResult) error {
 	path := filepath.Join(w.dir, "issues", fmt.Sprintf("%d", issueNum),
-		"retries", fmt.Sprintf("%d", retryNum), kind+"-review.json")
+		"retries", fmt.Sprintf("%d", retryNum), "quality-review.json")
 	return writeJSONMkdirs(path, step)
 }
 

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -99,7 +99,7 @@ func TestRunJSONFinalized(t *testing.T) {
 		t.Fatalf("New() error: %v", err)
 	}
 
-	summary := RunSummary{IssuesProcessed: 3, IssuesFailed: 1, Notes: "all done"}
+	summary := RunSummary{Total: 2, Implemented: 1, Failed: 1}
 	beforeFinalize := time.Now().UTC().Truncate(time.Second)
 	if err := w.FinalizeRun(summary); err != nil {
 		t.Fatalf("FinalizeRun() error: %v", err)
@@ -124,11 +124,14 @@ func TestRunJSONFinalized(t *testing.T) {
 	if meta.Summary == nil {
 		t.Fatal("summary should be set after FinalizeRun")
 	}
-	if meta.Summary.IssuesProcessed != 3 {
-		t.Errorf("summary.issues_processed: got %d, want 3", meta.Summary.IssuesProcessed)
+	if meta.Summary.Total != 2 {
+		t.Errorf("summary.total: got %d, want 2", meta.Summary.Total)
 	}
-	if meta.Summary.IssuesFailed != 1 {
-		t.Errorf("summary.issues_failed: got %d, want 1", meta.Summary.IssuesFailed)
+	if meta.Summary.Implemented != 1 {
+		t.Errorf("summary.implemented: got %d, want 1", meta.Summary.Implemented)
+	}
+	if meta.Summary.Failed != 1 {
+		t.Errorf("summary.failed: got %d, want 1", meta.Summary.Failed)
 	}
 }
 
@@ -218,6 +221,24 @@ func TestRetryWritten(t *testing.T) {
 	}
 }
 
+func TestRetryReviewWritten(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := StepResult{Output: "retry review output"}
+	if err := w.WriteRetryReviewResult(42, 2, step); err != nil {
+		t.Fatalf("WriteRetryReviewResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "retries", "2", "quality-review.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file at %s, got: %v", path, err)
+	}
+}
+
 func TestOutcomeWritten(t *testing.T) {
 	base := t.TempDir()
 	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
@@ -225,7 +246,7 @@ func TestOutcomeWritten(t *testing.T) {
 		t.Fatalf("New() error: %v", err)
 	}
 
-	outcome := Outcome{IssueNumber: 42, Result: "success"}
+	outcome := Outcome{IssueNumber: 42, Status: "implemented", PRNumber: 57}
 	if err := w.WriteOutcome(outcome); err != nil {
 		t.Fatalf("WriteOutcome() error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Creates `internal/rundata/` package with `Writer`, `RunMeta`, `RunSummary`, `StepResult`, and `Outcome` types
- `New(repo, milestone, issueNumbers)` creates `~/.godark/runs/<owner>/<repo>/<YYYYMMDD-HHMMSS>/` and writes initial `run.json`
- Repo components containing `..` or path separators are rejected to prevent directory traversal
- Write methods: `WriteImplementResult`, `WriteReviewResult` (validates kind as "quality" or "functional"), `WriteRetryResult`, `WriteRetryReviewResult`, `WriteOutcome`
- `FinalizeRun(summary)` updates `run.json` with `finished_at` and `summary`
- 11 unit tests covering all test cases from the issue spec

## Test plan

- [x] `TestRunDirectoryCreated` — `New()` creates expected directory under temp base
- [x] `TestTimestampFormat` — directory name matches `YYYYMMDD-HHMMSS` pattern
- [x] `TestRunJSONAtStart` — `run.json` has `started_at`, `repo`, `issue_numbers` after `New()`
- [x] `TestRunJSONFinalized` — `run.json` has `finished_at` and `summary` after `FinalizeRun()`
- [x] `TestImplementWritten` — creates `issues/42/implement.json`
- [x] `TestReviewWritten` — creates `issues/42/quality-review.json`
- [x] `TestFunctionalReviewWritten` — creates `issues/42/functional-review.json`
- [x] `TestReviewKindValidated` — invalid kind returns error
- [x] `TestRetryWritten` — creates `issues/42/retries/1/retry.json`
- [x] `TestOutcomeWritten` — creates `issues/42/outcome.json`
- [x] `TestPathTraversalRejected` — `..` in repo components returns error
- [x] All existing tests still pass (`go test ./...`)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)