### PR TITLE
feat: re-resolve dependencies after each merge

### DIFF
--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -51,7 +51,8 @@ _ROLE_PERMISSIONS: dict[str, dict] = {
         "disallowed_tools": ["Bash"],
     },
     "punchlist": {
-        "disallowed_tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+        "allowed_tools": ["Read", "Glob", "Grep"],
+        "disallowed_tools": ["Write", "Edit", "Bash"],
     },
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -19,7 +19,9 @@ import (
 
 // Run is the main entry point for the orchestration loop.
 // It fetches issues, resolves dependencies, and either prints the execution
-// plan (dry-run) or iterates through processable issues.
+// plan (dry-run) or iterates through processable issues. After each successful
+// merge, dependencies are re-resolved so newly unblocked issues can be
+// processed in the same run.
 //
 // force bypasses an existing run lock (useful to clear stale locks left by
 // crashed instances). punchlistPath is the optional file path to write the
@@ -56,18 +58,7 @@ func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone
 	closedSet := deps.ClosedSet(closedNumbers)
 
 	// Step 3: Categorize issues into blocked and processable.
-	var blocked []blockedIssue
-	var processable []github.Issue
-
-	for _, issue := range issues {
-		issueDeps := deps.ParseDeps(issue.Body)
-		openDeps := openDependencies(issueDeps, closedSet)
-		if len(openDeps) > 0 {
-			blocked = append(blocked, blockedIssue{Issue: issue, BlockedBy: openDeps})
-		} else {
-			processable = append(processable, issue)
-		}
-	}
+	processable, blocked := categorizeIssues(issues, closedSet)
 
 	// Single-issue mode: filter processable to the requested issue.
 	if issue != 0 {
@@ -89,21 +80,25 @@ func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone
 		return nil
 	}
 
-	// Step 5: Acquire run lock to prevent concurrent godark executions.
-	if len(processable) > 0 {
-		locker := lock.New(cfg.Repo, logger)
-		issueNums := issueNumbers(processable)
-		if err := locker.Acquire(issueNums, force); err != nil {
-			return fmt.Errorf("acquiring run lock: %w", err)
-		}
-		defer func() {
-			if err := locker.Release(issueNums); err != nil {
-				logger.Warn("failed to release run lock", "error", err)
-			}
-		}()
-	}
+	return processIssues(ctx, issues, closedSet, cfg, logger, force, punchlistPath)
+}
 
-	return processIssues(ctx, processable, blocked, len(issues), cfg, logger, punchlistPath)
+// categorizeIssues splits issues into processable and blocked based on the
+// closed set. Returns (processable, blocked).
+func categorizeIssues(issues []github.Issue, closedSet map[int]bool) ([]github.Issue, []blockedIssue) {
+	var blocked []blockedIssue
+	var processable []github.Issue
+
+	for _, issue := range issues {
+		issueDeps := deps.ParseDeps(issue.Body)
+		openDeps := openDependencies(issueDeps, closedSet)
+		if len(openDeps) > 0 {
+			blocked = append(blocked, blockedIssue{Issue: issue, BlockedBy: openDeps})
+		} else {
+			processable = append(processable, issue)
+		}
+	}
+	return processable, blocked
 }
 
 // filterSingleIssue extracts a single issue from processable, returning an
@@ -167,12 +162,17 @@ func printDryRun(processable []github.Issue, blocked []blockedIssue, total int) 
 	printSummary(total, len(blocked), len(processable))
 }
 
-// processIssues runs each processable issue through the agent loop and prints
-// summary stats. punchlistPath is the optional file path to write the punchlist to.
-func processIssues(ctx context.Context, processable []github.Issue, blocked []blockedIssue, total int, cfg *config.Config, logger *slog.Logger, punchlistPath string) error {
+// processIssues runs processable issues through the agent loop with
+// re-resolution after each merge. When an issue is successfully merged,
+// the closed set is refreshed and dependencies re-resolved so that newly
+// unblocked issues can be processed in the same run.
+func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[int]bool, cfg *config.Config, logger *slog.Logger, force bool, punchlistPath string) error {
+	// Initial categorization.
+	processable, blocked := categorizeIssues(allIssues, closedSet)
+
 	if len(processable) == 0 {
 		fmt.Println("All issues are blocked — nothing to process.")
-		printSummary(total, len(blocked), 0)
+		printSummary(len(allIssues), len(blocked), 0)
 		return nil
 	}
 
@@ -198,12 +198,13 @@ func processIssues(ctx context.Context, processable []github.Issue, blocked []bl
 		cfg.Docker.Image = tag
 	}
 
-	// Process each issue.
+	// Track stats across all waves.
 	var stats struct {
 		implemented      int
 		readyToMerge     int
 		needsHumanReview int
 		failed           int
+		blocked          int
 	}
 
 	type processedItem struct {
@@ -212,53 +213,130 @@ func processIssues(ctx context.Context, processable []github.Issue, blocked []bl
 	}
 	var processed []processedItem
 
-	for _, issue := range processable {
-		if ctx.Err() != nil {
-			logger.Warn("context cancelled, stopping", "error", ctx.Err())
+	// Locking: create a locker and track all locked issue numbers across waves.
+	locker := lock.New(cfg.Repo, logger)
+	var allLockedNums []int
+	defer func() {
+		if len(allLockedNums) > 0 {
+			if err := locker.Release(allLockedNums); err != nil {
+				logger.Warn("failed to release run lock", "error", err)
+			}
+		}
+	}()
+
+	// Track which issues have been seen (processed or failed) to avoid reprocessing.
+	seen := make(map[int]bool)
+	wave := 0
+
+	for {
+		wave++
+
+		// Filter out already-seen issues from the current processable batch.
+		var batch []github.Issue
+		for _, issue := range processable {
+			if !seen[issue.Number] {
+				batch = append(batch, issue)
+			}
+		}
+
+		if len(batch) == 0 {
+			if wave == 1 {
+				fmt.Println("All issues are blocked — nothing to process.")
+				printSummary(len(allIssues), len(blocked), 0)
+			}
 			break
 		}
 
-		outcome := agent.ProcessIssue(ctx, issue, cfg, prompts, authEnv, logger)
+		if wave > 1 {
+			logger.Info("re-resolving dependencies",
+				"wave", wave,
+				"newly_unblocked", len(batch),
+			)
+			fmt.Printf("\n--- Wave %d: %d newly unblocked issues ---\n", wave, len(batch))
+		}
 
-		switch outcome.Status {
-		case "implemented":
-			stats.implemented++
-			fmt.Printf("  #%d %s — implemented (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
-			if err := PullAfterMerge(logger); err != nil {
-				logger.Warn("stopping loop: could not sync local repo after merge", "error", err)
+		// Lock this wave's issues.
+		batchNums := issueNumbers(batch)
+		if err := locker.Acquire(batchNums, force); err != nil {
+			return fmt.Errorf("acquiring run lock (wave %d): %w", wave, err)
+		}
+		allLockedNums = append(allLockedNums, batchNums...)
+		// Only use force for the first wave; subsequent waves should not force.
+		force = false
+
+		// Process each issue in the batch.
+		merged := false
+		for _, issue := range batch {
+			if ctx.Err() != nil {
+				logger.Warn("context cancelled, stopping", "error", ctx.Err())
+				goto done
+			}
+
+			seen[issue.Number] = true
+			outcome := processIssueFn(ctx, issue, cfg, prompts, authEnv, logger)
+
+			switch outcome.Status {
+			case "implemented":
+				stats.implemented++
+				fmt.Printf("  #%d %s — implemented (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
+				if err := PullAfterMerge(logger); err != nil {
+					logger.Warn("stopping loop: could not sync local repo after merge", "error", err)
+					goto done
+				}
+				merged = true
+			case "ready-to-merge":
+				stats.readyToMerge++
+				fmt.Printf("  #%d %s — ready-to-merge (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
+			case "needs-human-review":
+				stats.needsHumanReview++
+				fmt.Printf("  #%d %s — needs human review (PR #%d)\n", issue.Number, issue.Title, outcome.PRNumber)
+			default:
+				stats.failed++
+				errMsg := ""
+				if outcome.Err != nil {
+					errMsg = outcome.Err.Error()
+				}
+				fmt.Printf("  #%d %s — failed: %s\n", issue.Number, issue.Title, errMsg)
+			}
+
+			logger.Info("issue outcome",
+				"issue_number", outcome.IssueNumber,
+				"status", outcome.Status,
+				"pr_number", outcome.PRNumber,
+				"retries", outcome.Retries,
+				"error", outcome.Err,
+			)
+
+			if outcome.PRNumber > 0 {
+				processed = append(processed, processedItem{issue, outcome})
+			}
+
+			// After a merge, break out of the inner loop to re-resolve.
+			if outcome.Status == "implemented" {
 				break
 			}
-		case "ready-to-merge":
-			stats.readyToMerge++
-			fmt.Printf("  #%d %s — ready-to-merge (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
-		case "needs-human-review":
-			stats.needsHumanReview++
-			fmt.Printf("  #%d %s — needs human review (PR #%d)\n", issue.Number, issue.Title, outcome.PRNumber)
-		default:
-			stats.failed++
-			errMsg := ""
-			if outcome.Err != nil {
-				errMsg = outcome.Err.Error()
-			}
-			fmt.Printf("  #%d %s — failed: %s\n", issue.Number, issue.Title, errMsg)
 		}
 
-		logger.Info("issue outcome",
-			"issue_number", outcome.IssueNumber,
-			"status", outcome.Status,
-			"pr_number", outcome.PRNumber,
-			"retries", outcome.Retries,
-			"error", outcome.Err,
-		)
-
-		if outcome.PRNumber > 0 {
-			processed = append(processed, processedItem{issue, outcome})
+		if !merged {
+			// No merges in this wave — no point re-resolving.
+			break
 		}
+
+		// Re-fetch closed issues and re-categorize for the next wave.
+		closedNumbers, err := github.FetchClosedIssueNumbers(cfg.Repo)
+		if err != nil {
+			logger.Warn("failed to re-fetch closed issues, stopping re-resolution", "error", err)
+			break
+		}
+		closedSet = deps.ClosedSet(closedNumbers)
+		processable, blocked = categorizeIssues(allIssues, closedSet)
 	}
 
+done:
+	stats.blocked = len(blocked)
 	fmt.Println()
 	fmt.Printf("Results: %d implemented, %d ready-to-merge, %d needs-human-review, %d failed, %d skipped (blocked)\n",
-		stats.implemented, stats.readyToMerge, stats.needsHumanReview, stats.failed, len(blocked))
+		stats.implemented, stats.readyToMerge, stats.needsHumanReview, stats.failed, stats.blocked)
 
 	if len(processed) > 0 {
 		entries := make([]punchlist.Entry, 0, len(processed))
@@ -298,6 +376,10 @@ func processIssues(ctx context.Context, processable []github.Issue, blocked []bl
 func printSummary(total, blocked, processable int) {
 	fmt.Printf("Summary: %d total, %d blocked, %d processable\n", total, blocked, processable)
 }
+
+// processIssueFn is the function called to process each issue.
+// Replaceable for testing.
+var processIssueFn = agent.ProcessIssue
 
 // CommandRunner executes a command and returns its combined output.
 // Replaceable for testing.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/phs/dark-factory/internal/agent"
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/logging"
@@ -352,6 +353,180 @@ func TestSingleIssueMode_ErrorWhenNotFound(t *testing.T) {
 			t.Errorf("expected 'not found' in error, got: %v", err)
 		}
 	})
+}
+
+func TestCategorizeIssues(t *testing.T) {
+	closedSet := map[int]bool{10: true}
+	issues := []github.Issue{
+		{Number: 1, Title: "free"},
+		{Number: 2, Title: "blocked by 10", Body: "**Blocked by**: #10"},
+		{Number: 3, Title: "blocked by 99", Body: "**Blocked by**: #99"},
+	}
+
+	processable, blocked := categorizeIssues(issues, closedSet)
+	if len(processable) != 2 {
+		t.Fatalf("expected 2 processable, got %d", len(processable))
+	}
+	if processable[0].Number != 1 || processable[1].Number != 2 {
+		t.Errorf("expected issues 1 and 2 processable, got %v", processable)
+	}
+	if len(blocked) != 1 || blocked[0].Issue.Number != 3 {
+		t.Errorf("expected issue 3 blocked, got %v", blocked)
+	}
+}
+
+// setupProcessMocks configures all the mocks needed to test processIssues.
+// It returns a cleanup function. closedNumbersFn is called each time
+// FetchClosedIssueNumbers is invoked (to simulate issues closing over time).
+func setupProcessMocks(t *testing.T, closedNumbersFn func() []int, processFn func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger) agent.IssueOutcome) {
+	t.Helper()
+
+	// Mock processIssueFn.
+	origProcess := processIssueFn
+	t.Cleanup(func() { processIssueFn = origProcess })
+	processIssueFn = processFn
+
+	// Mock orchestrator.CommandRunner (used by PullAfterMerge).
+	origCmdRunner := CommandRunner
+	t.Cleanup(func() { CommandRunner = origCmdRunner })
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte("ok"), nil
+	}
+
+	// Mock github.CommandRunner (used by lock, FetchClosedIssueNumbers).
+	origGHRunner := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGHRunner })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		// FetchClosedIssueNumbers: state=closed query.
+		for i, a := range args {
+			if a == "--state" && i+1 < len(args) && args[i+1] == "closed" {
+				numbers := closedNumbersFn()
+				type num struct {
+					Number int `json:"number"`
+				}
+				items := make([]num, len(numbers))
+				for j, n := range numbers {
+					items[j] = num{Number: n}
+				}
+				return json.Marshal(items)
+			}
+		}
+		// EnsureLabel, AddIssueLabel, RemoveIssueLabel, FindIssuesWithLabel:
+		// return empty list / success.
+		return []byte("[]"), nil
+	}
+
+	// Auth env vars so CollectAuthEnv doesn't fail.
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("GH_TOKEN", "test-gh-token")
+}
+
+func TestProcessIssues_MultiWaveReResolution(t *testing.T) {
+	// Issue 1: no deps (processable).
+	// Issue 2: blocked by #1. After #1 is "implemented" (merged & closed),
+	// #2 should become processable in wave 2.
+	allIssues := []github.Issue{
+		{Number: 1, Title: "first task"},
+		{Number: 2, Title: "second task", Body: "**Blocked by**: #1"},
+	}
+
+	// Track which issues were processed.
+	var processedNumbers []int
+	callCount := 0
+
+	closedNumbers := []int{} // initially nothing closed
+	setupProcessMocks(t, func() []int {
+		return closedNumbers
+	}, func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger) agent.IssueOutcome {
+		callCount++
+		processedNumbers = append(processedNumbers, issue.Number)
+		if issue.Number == 1 {
+			// Simulate merge: mark #1 as closed for re-resolution.
+			closedNumbers = []int{1}
+			return agent.IssueOutcome{
+				IssueNumber: 1,
+				Status:      "implemented",
+				PRNumber:    101,
+			}
+		}
+		// Issue 2: also succeeds.
+		return agent.IssueOutcome{
+			IssueNumber: 2,
+			Status:      "implemented",
+			PRNumber:    102,
+		}
+	})
+
+	closedSet := map[int]bool{} // initially empty
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	output := captureStdout(t, func() {
+		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), false, "")
+		if err != nil {
+			t.Fatalf("processIssues() error = %v", err)
+		}
+	})
+
+	// Both issues should have been processed.
+	if len(processedNumbers) != 2 {
+		t.Fatalf("expected 2 issues processed, got %d: %v", len(processedNumbers), processedNumbers)
+	}
+	if processedNumbers[0] != 1 || processedNumbers[1] != 2 {
+		t.Errorf("expected issues processed in order [1, 2], got %v", processedNumbers)
+	}
+
+	// Output should mention wave 2.
+	if !strings.Contains(output, "Wave 2") {
+		t.Errorf("expected 'Wave 2' in output, got:\n%s", output)
+	}
+	// Both implemented.
+	if !strings.Contains(output, "2 implemented") {
+		t.Errorf("expected '2 implemented' in output, got:\n%s", output)
+	}
+}
+
+func TestProcessIssues_AllFailNoInfiniteLoop(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 1, Title: "will fail"},
+		{Number: 2, Title: "also fails"},
+	}
+
+	var processedNumbers []int
+	setupProcessMocks(t, func() []int {
+		return nil
+	}, func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger) agent.IssueOutcome {
+		processedNumbers = append(processedNumbers, issue.Number)
+		return agent.IssueOutcome{
+			IssueNumber: issue.Number,
+			Status:      "failed",
+			Err:         fmt.Errorf("test failure"),
+		}
+	})
+
+	closedSet := map[int]bool{}
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	output := captureStdout(t, func() {
+		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), false, "")
+		if err != nil {
+			t.Fatalf("processIssues() error = %v", err)
+		}
+	})
+
+	// Each issue processed exactly once.
+	if len(processedNumbers) != 2 {
+		t.Fatalf("expected 2 issues processed, got %d: %v", len(processedNumbers), processedNumbers)
+	}
+
+	// No second wave.
+	if strings.Contains(output, "Wave 2") {
+		t.Errorf("expected no second wave when no merges, got:\n%s", output)
+	}
+	if !strings.Contains(output, "2 failed") {
+		t.Errorf("expected '2 failed' in output, got:\n%s", output)
+	}
 }
 
 // Suppress unused import warnings.


### PR DESCRIPTION
## Summary

- Restructure `processIssues` into an outer loop that re-resolves dependencies after each successful merge, so a single `godark run` handles the full dependency cascade
- Grant the punchlist agent read-only tool access (`Read`, `Glob`, `Grep`) to improve acceptance test quality

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] `godark run --tag phase-7 --dry-run` still prints correct plan
- [ ] `godark run` with dependency chain processes multiple waves in one run

🤖 Generated with [Claude Code](https://claude.com/claude-code)