### PR TITLE
feat: wire RunDataWriter into agent loop

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/rundata"
 )
 
 // IssueOutcome records the result of processing a single issue.
@@ -20,8 +21,23 @@ type IssueOutcome struct {
 
 // ProcessIssue runs the full per-issue lifecycle:
 // implement → find PR → guard rails → review/retry loop → merge or label.
-func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) IssueOutcome {
+// hook is optional; if non-nil, it is called after each agent step to record
+// run data. Hook errors are logged as warnings and do not abort processing.
+func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger, hook RunDataHook) IssueOutcome {
 	outcome := IssueOutcome{IssueNumber: issue.Number}
+
+	// Write outcome data on every return path.
+	defer func() {
+		if hook != nil {
+			if err := hook.WriteOutcome(rundata.Outcome{
+				IssueNumber: outcome.IssueNumber,
+				Status:      outcome.Status,
+				PRNumber:    outcome.PRNumber,
+			}); err != nil {
+				logger.Warn("failed to write outcome", "error", err)
+			}
+		}
+	}()
 
 	slug := Slugify(issue.Title)
 	branch := BranchName(issue.Number, slug)
@@ -59,6 +75,11 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		outcome.Status = "failed"
 		outcome.Err = fmt.Errorf("implementer agent timed out")
 		return outcome
+	}
+	if hook != nil {
+		if err := hook.WriteImplementResult(issue.Number, ResultToStep(implResult)); err != nil {
+			logger.Warn("failed to write implement result", "error", err)
+		}
 	}
 
 	// Capture session ID so retries can resume the agent's context.
@@ -108,6 +129,17 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				outcome.Err = fmt.Errorf("quality reviewer agent: %w", err)
 				return outcome
 			}
+			if hook != nil {
+				if qAttempt == 0 {
+					if err := hook.WriteReviewResult(issue.Number, "quality", ResultToStep(qResult.AgentResult)); err != nil {
+						logger.Warn("failed to write quality review result", "error", err)
+					}
+				} else {
+					if err := hook.WriteRetryReviewResult(issue.Number, qAttempt-1, ResultToStep(qResult.AgentResult)); err != nil {
+						logger.Warn("failed to write retry review result", "error", err)
+					}
+				}
+			}
 
 			switch qResult.Verdict {
 			case "APPROVED":
@@ -134,6 +166,11 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 					outcome.Status = "failed"
 					outcome.Err = fmt.Errorf("retry agent (quality) timed out")
 					return outcome
+				}
+				if hook != nil {
+					if err := hook.WriteRetryResult(issue.Number, qAttempt, ResultToStep(retryResult)); err != nil {
+						logger.Warn("failed to write retry result", "error", err)
+					}
 				}
 
 				sessionID = retryResult.SessionID
@@ -184,6 +221,11 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			outcome.Err = fmt.Errorf("reviewer agent: %w", err)
 			return outcome
 		}
+		if hook != nil {
+			if err := hook.WriteReviewResult(issue.Number, "functional", ResultToStep(reviewResult.AgentResult)); err != nil {
+				logger.Warn("failed to write functional review result", "error", err)
+			}
+		}
 
 		switch reviewResult.Verdict {
 		case "APPROVED":
@@ -226,6 +268,11 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				outcome.Status = "failed"
 				outcome.Err = fmt.Errorf("retry agent timed out")
 				return outcome
+			}
+			if hook != nil {
+				if err := hook.WriteRetryResult(issue.Number, attempt, ResultToStep(retryResult)); err != nil {
+					logger.Warn("failed to write retry result", "error", err)
+				}
 			}
 
 			// Update session ID so the next retry can resume this session's context.

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/rundata"
 )
 
 // loopTestSetup stubs both Runner (for agent invocations) and GuardRunner
@@ -97,7 +98,7 @@ func TestProcessIssue_ImplementedOnFirstApproval(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
@@ -137,7 +138,7 @@ func TestProcessIssue_RetriesOnChangesRequested(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
@@ -175,7 +176,7 @@ func TestProcessIssue_NeedsHumanReviewAfterMaxRetries(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "needs-human-review" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "needs-human-review", outcome.Err)
@@ -194,7 +195,7 @@ func TestProcessIssue_FailedWhenNoPRFound(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "failed" {
 		t.Errorf("Status = %q, want %q", outcome.Status, "failed")
@@ -222,7 +223,7 @@ func TestProcessIssue_FailedOnProtectedDrift(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "failed" {
 		t.Errorf("Status = %q, want %q", outcome.Status, "failed")
@@ -261,7 +262,7 @@ func TestProcessIssue_RechecksProtectedDriftAfterRetry(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "failed" {
 		t.Errorf("Status = %q, want %q", outcome.Status, "failed")
@@ -303,7 +304,7 @@ func TestProcessIssue_MergeOnApproval(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
@@ -402,7 +403,7 @@ func TestProcessIssue_SkipsSpecGenWhenNoPrompt(t *testing.T) {
 
 	// No SpecGenerator prompt → should only have 3 agent calls (implement + quality + review).
 	prompts := testPrompts(t)
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t), nil)
 
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
@@ -464,7 +465,7 @@ func TestProcessIssue_PassesSessionIDToFirstRetry(t *testing.T) {
 		}
 	}
 
-	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if retryEnv == nil {
 		t.Fatal("retry was never called")
@@ -516,7 +517,7 @@ func TestProcessIssue_UpdatesSessionIDFromRetryResult(t *testing.T) {
 		}
 	}
 
-	ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
 
 	if secondRetryEnv == nil {
 		t.Fatal("second retry was never called")
@@ -556,7 +557,7 @@ func TestProcessIssue_ReviewerHasNoSessionID(t *testing.T) {
 		}
 	}
 
-	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if len(reviewerEnvs) == 0 {
 		t.Fatal("reviewer was never called")
@@ -593,7 +594,7 @@ func TestProcessIssue_QualityReviewChangesRequestedTriggersRetry(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
@@ -642,7 +643,7 @@ func TestProcessIssue_PassesCycleToQualityReview(t *testing.T) {
 		}
 	}
 
-	ProcessIssue(context.Background(), loopIssue(), cfg, prompts, nil, testLogger(t))
+	ProcessIssue(context.Background(), loopIssue(), cfg, prompts, nil, testLogger(t), nil)
 
 	if len(qualityPrompts) != 2 {
 		t.Fatalf("expected 2 quality review calls, got %d", len(qualityPrompts))
@@ -689,7 +690,7 @@ func TestProcessIssue_NoMerge_SkipsMergeOnApproval(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "ready-to-merge" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "ready-to-merge", outcome.Err)
@@ -712,7 +713,7 @@ func TestProcessIssue_NoMerge_OutcomeStatus(t *testing.T) {
 		"REVIEW_RESULT=APPROVED",
 	}, loopGuardFn)
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "ready-to-merge" {
 		t.Errorf("Status = %q, want %q", outcome.Status, "ready-to-merge")
@@ -748,7 +749,7 @@ func TestProcessIssue_NoMerge_DefaultMerges(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
@@ -787,7 +788,7 @@ func TestProcessIssue_NoMerge_QualityReviewStillRuns(t *testing.T) {
 		}
 	}
 
-	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
 
 	if outcome.Status != "ready-to-merge" {
 		t.Errorf("Status = %q, want %q", outcome.Status, "ready-to-merge")
@@ -830,12 +831,124 @@ func TestProcessIssue_SkipsQualityReviewWhenNoPrompt(t *testing.T) {
 
 	prompts := testPrompts(t)
 	prompts.QualityReviewer = "" // disable quality reviewer
-	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t))
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t), nil)
 
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
 	}
 	if agentCallCount != 2 {
 		t.Errorf("expected 2 agent calls (implement + review), got %d", agentCallCount)
+	}
+}
+
+// testRunDataHook is a simple RunDataHook implementation for unit tests.
+type testRunDataHook struct {
+	implementCalls   int
+	reviewKinds      []string
+	retryCalls       int
+	retryReviewCalls int
+	outcomes         []rundata.Outcome
+}
+
+func (h *testRunDataHook) WriteImplementResult(_ int, _ rundata.StepResult) error {
+	h.implementCalls++
+	return nil
+}
+func (h *testRunDataHook) WriteReviewResult(_ int, kind string, _ rundata.StepResult) error {
+	h.reviewKinds = append(h.reviewKinds, kind)
+	return nil
+}
+func (h *testRunDataHook) WriteRetryResult(_ int, _ int, _ rundata.StepResult) error {
+	h.retryCalls++
+	return nil
+}
+func (h *testRunDataHook) WriteRetryReviewResult(_ int, _ int, _ rundata.StepResult) error {
+	h.retryReviewCalls++
+	return nil
+}
+func (h *testRunDataHook) WriteOutcome(o rundata.Outcome) error {
+	h.outcomes = append(h.outcomes, o)
+	return nil
+}
+
+func TestProcessIssue_HookCalledOnImplement(t *testing.T) {
+	hook := &testRunDataHook{}
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
+
+	if hook.implementCalls != 1 {
+		t.Errorf("WriteImplementResult called %d times, want 1", hook.implementCalls)
+	}
+}
+
+func TestProcessIssue_HookCalledOnReview(t *testing.T) {
+	hook := &testRunDataHook{}
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
+
+	if len(hook.reviewKinds) == 0 {
+		t.Fatal("WriteReviewResult was never called")
+	}
+	// Quality review then functional review both expected.
+	foundQuality := false
+	foundFunctional := false
+	for _, k := range hook.reviewKinds {
+		if k == "quality" {
+			foundQuality = true
+		}
+		if k == "functional" {
+			foundFunctional = true
+		}
+	}
+	if !foundQuality {
+		t.Errorf("WriteReviewResult(\"quality\") not called; calls: %v", hook.reviewKinds)
+	}
+	if !foundFunctional {
+		t.Errorf("WriteReviewResult(\"functional\") not called; calls: %v", hook.reviewKinds)
+	}
+}
+
+func TestProcessIssue_HookCalledOnOutcome(t *testing.T) {
+	hook := &testRunDataHook{}
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
+
+	if len(hook.outcomes) != 1 {
+		t.Fatalf("WriteOutcome called %d times, want 1", len(hook.outcomes))
+	}
+	if hook.outcomes[0].Status != outcome.Status {
+		t.Errorf("WriteOutcome status = %q, want %q", hook.outcomes[0].Status, outcome.Status)
+	}
+	if hook.outcomes[0].IssueNumber != loopIssue().Number {
+		t.Errorf("WriteOutcome issue_number = %d, want %d", hook.outcomes[0].IssueNumber, loopIssue().Number)
+	}
+}
+
+func TestProcessIssue_NilHookSafe(t *testing.T) {
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	// Should not panic with nil hook.
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
 	}
 }

--- a/internal/agent/runhook.go
+++ b/internal/agent/runhook.go
@@ -1,0 +1,14 @@
+package agent
+
+import "github.com/phs/dark-factory/internal/rundata"
+
+// RunDataHook is an optional sink for per-step run data. ProcessIssue calls
+// these methods after each agent step. Callers should check for nil before
+// passing; individual methods are not required to be nil-safe themselves.
+type RunDataHook interface {
+	WriteImplementResult(issueNumber int, step rundata.StepResult) error
+	WriteReviewResult(issueNumber int, kind string, step rundata.StepResult) error
+	WriteRetryResult(issueNumber int, attempt int, step rundata.StepResult) error
+	WriteRetryReviewResult(issueNumber int, attempt int, step rundata.StepResult) error
+	WriteOutcome(outcome rundata.Outcome) error
+}

--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -17,6 +17,7 @@ import (
 	"github.com/phs/dark-factory/internal/orchestrator"
 	"github.com/phs/dark-factory/internal/punchlist"
 	"github.com/phs/dark-factory/internal/pypi"
+	"github.com/phs/dark-factory/internal/rundata"
 	"github.com/phs/dark-factory/internal/sandbox"
 	"github.com/spf13/cobra"
 )
@@ -121,7 +122,35 @@ loop directly, without milestone or dependency resolution.`,
 			}
 		}()
 
-		outcome := agent.ProcessIssue(ctx, issue, cfg, prompts, authEnv, logger)
+		// Create a RunDataWriter for this single-issue run. Failure is non-fatal.
+		var hook agent.RunDataHook
+		writer, writerErr := rundata.New(cfg.Repo, "", []int{issueNumber})
+		if writerErr != nil {
+			logger.Warn("failed to create run data writer, run data will not be recorded", "error", writerErr)
+		} else {
+			hook = writer
+		}
+
+		outcome := agent.ProcessIssue(ctx, issue, cfg, prompts, authEnv, logger, hook)
+
+		// Finalize run data regardless of outcome.
+		if writer != nil {
+			implemented := 0
+			failed := 0
+			if outcome.Status == "implemented" {
+				implemented = 1
+			} else if outcome.Status == "failed" {
+				failed = 1
+			}
+			if err := writer.FinalizeRun(rundata.RunSummary{
+				Total:       1,
+				Implemented: implemented,
+				Failed:      failed,
+			}); err != nil {
+				logger.Warn("failed to finalize run data", "error", err)
+			}
+		}
+
 		if outcome.Err != nil {
 			return fmt.Errorf("issue #%d failed: %w", issueNumber, outcome.Err)
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/lock"
 	"github.com/phs/dark-factory/internal/punchlist"
+	"github.com/phs/dark-factory/internal/rundata"
 	"github.com/phs/dark-factory/internal/sandbox"
 )
 
@@ -80,7 +81,7 @@ func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone
 		return nil
 	}
 
-	return processIssues(ctx, issues, closedSet, cfg, logger, force, punchlistPath)
+	return processIssues(ctx, issues, closedSet, cfg, logger, force, punchlistPath, milestone)
 }
 
 // categorizeIssues splits issues into processable and blocked based on the
@@ -166,7 +167,7 @@ func printDryRun(processable []github.Issue, blocked []blockedIssue, total int) 
 // re-resolution after each merge. When an issue is successfully merged,
 // the closed set is refreshed and dependencies re-resolved so that newly
 // unblocked issues can be processed in the same run.
-func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[int]bool, cfg *config.Config, logger *slog.Logger, force bool, punchlistPath string) error {
+func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[int]bool, cfg *config.Config, logger *slog.Logger, force bool, punchlistPath string, milestone string) error {
 	// Initial categorization.
 	processable, blocked := categorizeIssues(allIssues, closedSet)
 
@@ -196,6 +197,16 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 			return fmt.Errorf("building Docker image: %w", err)
 		}
 		cfg.Docker.Image = tag
+	}
+
+	// Create a RunDataWriter for this run. Failures are non-fatal.
+	issueNums := issueNumbers(allIssues)
+	var hook agent.RunDataHook
+	writer, err := newRunDataWriterFn(cfg.Repo, milestone, issueNums)
+	if err != nil {
+		logger.Warn("failed to create run data writer, run data will not be recorded", "error", err)
+	} else {
+		hook = writer
 	}
 
 	// Track stats across all waves.
@@ -273,7 +284,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 			}
 
 			seen[issue.Number] = true
-			outcome := processIssueFn(ctx, issue, cfg, prompts, authEnv, logger)
+			outcome := processIssueFn(ctx, issue, cfg, prompts, authEnv, logger, hook)
 
 			switch outcome.Status {
 			case "implemented":
@@ -338,6 +349,18 @@ done:
 	fmt.Printf("Results: %d implemented, %d ready-to-merge, %d needs-human-review, %d failed, %d skipped (blocked)\n",
 		stats.implemented, stats.readyToMerge, stats.needsHumanReview, stats.failed, stats.blocked)
 
+	// Finalize run data.
+	if writer != nil {
+		summary := rundata.RunSummary{
+			Total:       stats.implemented + stats.readyToMerge + stats.needsHumanReview + stats.failed,
+			Implemented: stats.implemented,
+			Failed:      stats.failed,
+		}
+		if err := writer.FinalizeRun(summary); err != nil {
+			logger.Warn("failed to finalize run data", "error", err)
+		}
+	}
+
 	if len(processed) > 0 {
 		entries := make([]punchlist.Entry, 0, len(processed))
 		for _, p := range processed {
@@ -380,6 +403,11 @@ func printSummary(total, blocked, processable int) {
 // processIssueFn is the function called to process each issue.
 // Replaceable for testing.
 var processIssueFn = agent.ProcessIssue
+
+// newRunDataWriterFn creates a new RunDataWriter. Replaceable for testing.
+var newRunDataWriterFn = func(repo, milestone string, issueNumbers []int) (*rundata.Writer, error) {
+	return rundata.New(repo, milestone, issueNumbers)
+}
 
 // CommandRunner executes a command and returns its combined output.
 // Replaceable for testing.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/logging"
+	"github.com/phs/dark-factory/internal/rundata"
 )
 
 // ghIssue mirrors the JSON shape for test fixtures.
@@ -378,13 +380,20 @@ func TestCategorizeIssues(t *testing.T) {
 // setupProcessMocks configures all the mocks needed to test processIssues.
 // It returns a cleanup function. closedNumbersFn is called each time
 // FetchClosedIssueNumbers is invoked (to simulate issues closing over time).
-func setupProcessMocks(t *testing.T, closedNumbersFn func() []int, processFn func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger) agent.IssueOutcome) {
+func setupProcessMocks(t *testing.T, closedNumbersFn func() []int, processFn func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger, hook agent.RunDataHook) agent.IssueOutcome) {
 	t.Helper()
 
 	// Mock processIssueFn.
 	origProcess := processIssueFn
 	t.Cleanup(func() { processIssueFn = origProcess })
 	processIssueFn = processFn
+
+	// Mock newRunDataWriterFn to avoid creating real files during tests.
+	origWriter := newRunDataWriterFn
+	t.Cleanup(func() { newRunDataWriterFn = origWriter })
+	newRunDataWriterFn = func(repo, milestone string, issueNums []int) (*rundata.Writer, error) {
+		return nil, fmt.Errorf("disabled in test")
+	}
 
 	// Mock orchestrator.CommandRunner (used by PullAfterMerge).
 	origCmdRunner := CommandRunner
@@ -437,7 +446,7 @@ func TestProcessIssues_MultiWaveReResolution(t *testing.T) {
 	closedNumbers := []int{} // initially nothing closed
 	setupProcessMocks(t, func() []int {
 		return closedNumbers
-	}, func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger) agent.IssueOutcome {
+	}, func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger, hook agent.RunDataHook) agent.IssueOutcome {
 		callCount++
 		processedNumbers = append(processedNumbers, issue.Number)
 		if issue.Number == 1 {
@@ -462,7 +471,7 @@ func TestProcessIssues_MultiWaveReResolution(t *testing.T) {
 	cfg.NoSandbox = true
 
 	output := captureStdout(t, func() {
-		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), false, "")
+		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), false, "", "test-milestone")
 		if err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
@@ -495,7 +504,7 @@ func TestProcessIssues_AllFailNoInfiniteLoop(t *testing.T) {
 	var processedNumbers []int
 	setupProcessMocks(t, func() []int {
 		return nil
-	}, func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger) agent.IssueOutcome {
+	}, func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger, hook agent.RunDataHook) agent.IssueOutcome {
 		processedNumbers = append(processedNumbers, issue.Number)
 		return agent.IssueOutcome{
 			IssueNumber: issue.Number,
@@ -509,7 +518,7 @@ func TestProcessIssues_AllFailNoInfiniteLoop(t *testing.T) {
 	cfg.NoSandbox = true
 
 	output := captureStdout(t, func() {
-		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), false, "")
+		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), false, "", "")
 		if err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
@@ -526,6 +535,80 @@ func TestProcessIssues_AllFailNoInfiniteLoop(t *testing.T) {
 	}
 	if !strings.Contains(output, "2 failed") {
 		t.Errorf("expected '2 failed' in output, got:\n%s", output)
+	}
+}
+
+func TestProcessIssues_FinalizeRunCalled(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 10, Title: "implemented issue"},
+		{Number: 11, Title: "failed issue"},
+	}
+
+	setupProcessMocks(t, func() []int {
+		return nil
+	}, func(ctx context.Context, issue github.Issue, cfg *config.Config, prompts *agent.Prompts, authEnv map[string]string, logger *slog.Logger, hook agent.RunDataHook) agent.IssueOutcome {
+		if issue.Number == 10 {
+			return agent.IssueOutcome{IssueNumber: 10, Status: "implemented", PRNumber: 100}
+		}
+		return agent.IssueOutcome{IssueNumber: 11, Status: "failed", Err: fmt.Errorf("boom")}
+	})
+
+	// Use a real RunDataWriter in a temp HOME so we can verify FinalizeRun.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	origWriter := newRunDataWriterFn
+	t.Cleanup(func() { newRunDataWriterFn = origWriter })
+	newRunDataWriterFn = rundata.New // use real writer with temp HOME
+
+	closedSet := map[int]bool{}
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	captureStdout(t, func() {
+		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), false, "", "test-milestone"); err != nil {
+			t.Fatalf("processIssues() error = %v", err)
+		}
+	})
+
+	// Find the run.json and verify it has a finished_at timestamp and correct summary.
+	pattern := tmpHome + "/.godark/runs/owner/repo/*/run.json"
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		t.Fatalf("expected run.json to be created at %s, found: %v (err: %v)", pattern, matches, err)
+	}
+
+	data, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+
+	var meta struct {
+		FinishedAt *string `json:"finished_at"`
+		Summary    *struct {
+			Total       int `json:"total"`
+			Implemented int `json:"implemented"`
+			Failed      int `json:"failed"`
+		} `json:"summary"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("parsing run.json: %v", err)
+	}
+
+	if meta.FinishedAt == nil {
+		t.Error("run.json missing finished_at — FinalizeRun was not called")
+	}
+	if meta.Summary == nil {
+		t.Fatal("run.json missing summary — FinalizeRun was not called")
+	}
+	if meta.Summary.Implemented != 1 {
+		t.Errorf("summary.implemented = %d, want 1", meta.Summary.Implemented)
+	}
+	if meta.Summary.Failed != 1 {
+		t.Errorf("summary.failed = %d, want 1", meta.Summary.Failed)
+	}
+	if meta.Summary.Total != 2 {
+		t.Errorf("summary.total = %d, want 2", meta.Summary.Total)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Defines `RunDataHook` interface in `internal/agent/runhook.go` so `ProcessIssue` can record step results without a hard dependency on `rundata`
- Adds `hook RunDataHook` parameter to `ProcessIssue` (nil-safe throughout via `if hook != nil` guards)
- Calls the appropriate hook method after each agent step: `WriteImplementResult`, `WriteReviewResult` (quality/functional), `WriteRetryResult`, `WriteRetryReviewResult`, and `WriteOutcome` (via `defer`)
- Creates a `RunDataWriter` in `orchestrator.processIssues` and `cmd/implement.go`; passes it as the hook and calls `FinalizeRun` at end of run
- Adds `newRunDataWriterFn` package variable in orchestrator for test injection (avoids touching `$HOME` in most tests)

## Test plan

- [x] `TestProcessIssue_HookCalledOnImplement` — mock hook verifies `WriteImplementResult` called after implementer
- [x] `TestProcessIssue_HookCalledOnReview` — mock hook verifies `WriteReviewResult` called for both "quality" and "functional" reviewer
- [x] `TestProcessIssue_HookCalledOnOutcome` — mock hook verifies `WriteOutcome` called with correct status
- [x] `TestProcessIssue_NilHookSafe` — `ProcessIssue` with nil hook does not panic
- [x] `TestProcessIssues_FinalizeRunCalled` — orchestrator calls `FinalizeRun` with correct summary counts (verified via real `run.json` in temp HOME)
- [x] All existing tests updated for new `ProcessIssue` signature and `processIssues` milestone parameter
- [x] `go test ./...` passes, `go vet ./...` clean

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)