### PR TITLE
feat: wire quality flags into config and agent loop

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/quality"
 	"github.com/phs/dark-factory/internal/rundata"
 )
 
@@ -129,13 +131,18 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				outcome.Err = fmt.Errorf("quality reviewer agent: %w", err)
 				return outcome
 			}
+			// Quality reviewer is exempt from CheckReviewTestExecution.
+			qFlags := computeReviewFlags(qResult.AgentResult, cfg, false)
+			qRDFlags := logAndRecordFlags(qFlags, logger, issue.Number)
 			if hook != nil {
+				qStep := ResultToStep(qResult.AgentResult)
+				qStep.Flags = qRDFlags
 				if qAttempt == 0 {
-					if err := hook.WriteReviewResult(issue.Number, "quality", ResultToStep(qResult.AgentResult)); err != nil {
+					if err := hook.WriteReviewResult(issue.Number, "quality", qStep); err != nil {
 						logger.Warn("failed to write quality review result", "error", err)
 					}
 				} else {
-					if err := hook.WriteRetryReviewResult(issue.Number, qAttempt-1, ResultToStep(qResult.AgentResult)); err != nil {
+					if err := hook.WriteRetryReviewResult(issue.Number, qAttempt-1, qStep); err != nil {
 						logger.Warn("failed to write retry review result", "error", err)
 					}
 				}
@@ -221,8 +228,13 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			outcome.Err = fmt.Errorf("reviewer agent: %w", err)
 			return outcome
 		}
+		// Functional reviewer is subject to all quality checks including CheckReviewTestExecution.
+		fFlags := computeReviewFlags(reviewResult.AgentResult, cfg, true)
+		fRDFlags := logAndRecordFlags(fFlags, logger, issue.Number)
 		if hook != nil {
-			if err := hook.WriteReviewResult(issue.Number, "functional", ResultToStep(reviewResult.AgentResult)); err != nil {
+			fStep := ResultToStep(reviewResult.AgentResult)
+			fStep.Flags = fRDFlags
+			if err := hook.WriteReviewResult(issue.Number, "functional", fStep); err != nil {
 				logger.Warn("failed to write functional review result", "error", err)
 			}
 		}
@@ -331,4 +343,46 @@ func trimOutput(b []byte) string {
 		return s[:idx]
 	}
 	return s
+}
+
+// computeReviewFlags runs quality analysis on an agent Result and returns any flags found.
+// If checkTestExecution is false, CheckReviewTestExecution is skipped (used for the
+// quality reviewer, which is exempt from that check).
+func computeReviewFlags(result *Result, cfg *config.Config, checkTestExecution bool) []quality.Flag {
+	var flags []quality.Flag
+
+	if f := quality.CheckCostFloor(result.CostUSD, cfg.Quality.MinReviewCostUSD); f != nil {
+		flags = append(flags, *f)
+	}
+
+	duration := result.FinishedAt.Sub(result.StartedAt)
+	threshold := time.Duration(cfg.Quality.MinReviewDurationSeconds) * time.Second
+	if f := quality.CheckDuration(duration, threshold); f != nil {
+		flags = append(flags, *f)
+	}
+
+	flags = append(flags, quality.CheckToolTrace(result.ToolTrace)...)
+
+	if checkTestExecution {
+		flags = append(flags, quality.CheckReviewTestExecution(result.ToolTrace, cfg.ReviewDir, cfg.TestCommand)...)
+	}
+
+	return flags
+}
+
+// logAndRecordFlags logs each flag as a warning and returns a []rundata.Flag for storage.
+func logAndRecordFlags(flags []quality.Flag, logger *slog.Logger, issueNum int) []rundata.Flag {
+	if len(flags) == 0 {
+		return nil
+	}
+	rdFlags := make([]rundata.Flag, len(flags))
+	for i, f := range flags {
+		logger.Warn("quality flag detected",
+			"issue_number", issueNum,
+			"code", f.Code,
+			"message", f.Message,
+		)
+		rdFlags[i] = rundata.Flag{Code: f.Code, Message: f.Message}
+	}
+	return rdFlags
 }

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -950,5 +952,199 @@ func TestProcessIssue_NilHookSafe(t *testing.T) {
 	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
 	if outcome.Status != "implemented" {
 		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+}
+
+// --- Quality flag tests ---
+
+// captureRunDataHook captures review steps (including flags) for inspection.
+type captureRunDataHook struct {
+	testRunDataHook
+	reviewSteps map[string]rundata.StepResult // keyed by "quality" or "functional"
+}
+
+func newCaptureHook() *captureRunDataHook {
+	return &captureRunDataHook{reviewSteps: make(map[string]rundata.StepResult)}
+}
+
+func (h *captureRunDataHook) WriteReviewResult(issueNum int, kind string, step rundata.StepResult) error {
+	h.reviewKinds = append(h.reviewKinds, kind)
+	h.reviewSteps[kind] = step
+	return nil
+}
+
+// bufferLogger returns a logger that captures all log records into buf.
+func bufferLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestComputeReviewFlags_QualityReviewerExemptFromTestExecution(t *testing.T) {
+	// A result with no tool trace entries — would normally trigger no_diff_read,
+	// no_tests_run, no_review_tests_written, and no_review_tests_run for the functional reviewer.
+	result := &Result{ToolTrace: nil}
+	cfg := &config.Config{
+		TestCommand: "go test ./...",
+		ReviewDir:   "tests/review/",
+	}
+
+	// Quality reviewer (checkTestExecution=false): should NOT produce test-execution flags.
+	qFlags := computeReviewFlags(result, cfg, false)
+	for _, f := range qFlags {
+		if f.Code == "no_review_tests_written" || f.Code == "no_review_tests_run" {
+			t.Errorf("quality reviewer should be exempt from %q, got flag: %+v", f.Code, f)
+		}
+	}
+
+	// Functional reviewer (checkTestExecution=true): SHOULD produce test-execution flags.
+	fFlags := computeReviewFlags(result, cfg, true)
+	var hasTestFlag bool
+	for _, f := range fFlags {
+		if f.Code == "no_review_tests_written" || f.Code == "no_review_tests_run" {
+			hasTestFlag = true
+			break
+		}
+	}
+	if !hasTestFlag {
+		t.Error("functional reviewer should produce test-execution flags when tests not found in trace")
+	}
+}
+
+func TestComputeReviewFlags_CostFloorFlag(t *testing.T) {
+	result := &Result{
+		CostUSD:   0.001, // below threshold
+		ToolTrace: []string{"Read file", "go test ./..."},
+	}
+	cfg := &config.Config{
+		Quality: config.Quality{MinReviewCostUSD: 0.10},
+	}
+
+	flags := computeReviewFlags(result, cfg, false)
+
+	var found bool
+	for _, f := range flags {
+		if f.Code == "low_cost" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected low_cost flag when cost $0.001 < threshold $0.10, got flags: %+v", flags)
+	}
+}
+
+func TestComputeReviewFlags_DisabledWhenZeroThreshold(t *testing.T) {
+	result := &Result{
+		CostUSD:   0.0001,
+		ToolTrace: nil,
+	}
+	cfg := &config.Config{
+		// Zero thresholds = disabled
+		Quality: config.Quality{MinReviewCostUSD: 0, MinReviewDurationSeconds: 0},
+	}
+
+	flags := computeReviewFlags(result, cfg, false)
+	for _, f := range flags {
+		if f.Code == "low_cost" || f.Code == "short_duration" {
+			t.Errorf("cost/duration flags should be disabled when threshold is 0, got: %+v", f)
+		}
+	}
+}
+
+func TestProcessIssue_QualityFlagsLoggedAsWarnings(t *testing.T) {
+	// Set a high cost threshold so the mock agent's $0 cost triggers a low_cost flag.
+	cfg := loopConfig()
+	cfg.Quality.MinReviewCostUSD = 0.10
+
+	var logBuf bytes.Buffer
+	logger := bufferLogger(&logBuf)
+
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, logger, nil)
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+
+	logOutput := logBuf.String()
+	if !strings.Contains(logOutput, "quality flag detected") {
+		t.Errorf("expected 'quality flag detected' warning in log output, got:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "low_cost") {
+		t.Errorf("expected 'low_cost' code in log output, got:\n%s", logOutput)
+	}
+}
+
+func TestProcessIssue_FlagsIncludedInHookStepResult(t *testing.T) {
+	// Set a high cost threshold so flags are generated.
+	cfg := loopConfig()
+	cfg.Quality.MinReviewCostUSD = 0.10
+
+	hook := newCaptureHook()
+
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+
+	qStep, ok := hook.reviewSteps["quality"]
+	if !ok {
+		t.Fatal("quality review step not found in hook")
+	}
+	var hasLowCost bool
+	for _, f := range qStep.Flags {
+		if f.Code == "low_cost" {
+			hasLowCost = true
+			break
+		}
+	}
+	if !hasLowCost {
+		t.Errorf("expected low_cost flag in quality review step, got flags: %+v", qStep.Flags)
+	}
+}
+
+func TestProcessIssue_QualityReviewerExemptInLoop(t *testing.T) {
+	// Set a non-empty TestCommand and ReviewDir so CheckReviewTestExecution would
+	// produce flags — but only for the functional reviewer, not the quality reviewer.
+	cfg := loopConfig()
+	cfg.TestCommand = "go test ./..."
+	cfg.ReviewDir = "tests/review/"
+
+	hook := newCaptureHook()
+
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
+
+	qStep := hook.reviewSteps["quality"]
+	for _, f := range qStep.Flags {
+		if f.Code == "no_review_tests_written" || f.Code == "no_review_tests_run" {
+			t.Errorf("quality reviewer should be exempt from test-execution flags, got: %+v", f)
+		}
+	}
+
+	fStep := hook.reviewSteps["functional"]
+	var hasTestFlag bool
+	for _, f := range fStep.Flags {
+		if f.Code == "no_review_tests_written" || f.Code == "no_review_tests_run" {
+			hasTestFlag = true
+			break
+		}
+	}
+	if !hasTestFlag {
+		t.Errorf("functional reviewer should have test-execution flags, got flags: %+v", fStep.Flags)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,13 @@ type Runtime struct {
 	Version string `yaml:"version"` // optional — auto-detected if empty
 }
 
+// Quality holds quality-gate thresholds for review steps.
+// A threshold of 0 disables that check.
+type Quality struct {
+	MinReviewCostUSD         float64 `yaml:"min_review_cost_usd"`
+	MinReviewDurationSeconds int     `yaml:"min_review_duration_seconds"`
+}
+
 // Config holds all configuration for a godark run.
 type Config struct {
 	Repo       string `yaml:"repo"`
@@ -42,6 +49,7 @@ type Config struct {
 
 	Docker  Docker  `yaml:"docker"`
 	Prompts Prompts `yaml:"prompts"`
+	Quality Quality `yaml:"quality"`
 }
 
 // Docker holds Docker sandbox configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -442,6 +442,65 @@ auth_preference: token
 	}
 }
 
+func TestQualityConfigParsed(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+quality:
+  min_review_cost_usd: 0.10
+  min_review_duration_seconds: 30
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Quality.MinReviewCostUSD != 0.10 {
+		t.Errorf("Quality.MinReviewCostUSD = %v, want 0.10", cfg.Quality.MinReviewCostUSD)
+	}
+	if cfg.Quality.MinReviewDurationSeconds != 30 {
+		t.Errorf("Quality.MinReviewDurationSeconds = %d, want 30", cfg.Quality.MinReviewDurationSeconds)
+	}
+}
+
+func TestQualityConfigDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Quality.MinReviewCostUSD != 0 {
+		t.Errorf("Quality.MinReviewCostUSD = %v, want 0 (default/disabled)", cfg.Quality.MinReviewCostUSD)
+	}
+	if cfg.Quality.MinReviewDurationSeconds != 0 {
+		t.Errorf("Quality.MinReviewDurationSeconds = %d, want 0 (default/disabled)", cfg.Quality.MinReviewDurationSeconds)
+	}
+}
+
+func TestQualityConfigPartial(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+quality:
+  min_review_cost_usd: 0.10
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Quality.MinReviewCostUSD != 0.10 {
+		t.Errorf("Quality.MinReviewCostUSD = %v, want 0.10", cfg.Quality.MinReviewCostUSD)
+	}
+	if cfg.Quality.MinReviewDurationSeconds != 0 {
+		t.Errorf("Quality.MinReviewDurationSeconds = %d, want 0 (unset)", cfg.Quality.MinReviewDurationSeconds)
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -26,13 +26,20 @@ type RunSummary struct {
 	Failed      int `json:"failed"`
 }
 
+// Flag records a quality issue detected in a review step.
+type Flag struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 // StepResult holds the output of a single agent step.
 type StepResult struct {
-	Output          string    `json:"output,omitempty"`
-	Error           string    `json:"error,omitempty"`
+	Output          string     `json:"output,omitempty"`
+	Error           string     `json:"error,omitempty"`
 	StartedAt       *time.Time `json:"started_at,omitempty"`
 	FinishedAt      *time.Time `json:"finished_at,omitempty"`
-	DurationSeconds float64   `json:"duration_seconds,omitempty"`
+	DurationSeconds float64    `json:"duration_seconds,omitempty"`
+	Flags           []Flag     `json:"flags,omitempty"`
 }
 
 // Outcome records the final result for a single issue.

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -257,6 +257,74 @@ func TestOutcomeWritten(t *testing.T) {
 	}
 }
 
+func TestFlagsWrittenToReviewJSON(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	flags := []Flag{
+		{Code: "low_cost", Message: "review cost $0.0001 is below threshold $0.1000"},
+		{Code: "short_duration", Message: "review duration 1s is below threshold 30s"},
+	}
+	step := StepResult{Output: "review output", Flags: flags}
+	if err := w.WriteReviewResult(42, "quality", step); err != nil {
+		t.Fatalf("WriteReviewResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "quality-review.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading quality-review.json: %v", err)
+	}
+
+	var written StepResult
+	if err := json.Unmarshal(data, &written); err != nil {
+		t.Fatalf("parsing quality-review.json: %v", err)
+	}
+
+	if len(written.Flags) != 2 {
+		t.Fatalf("Flags: got %d, want 2", len(written.Flags))
+	}
+	if written.Flags[0].Code != "low_cost" {
+		t.Errorf("Flags[0].Code = %q, want %q", written.Flags[0].Code, "low_cost")
+	}
+	if written.Flags[1].Code != "short_duration" {
+		t.Errorf("Flags[1].Code = %q, want %q", written.Flags[1].Code, "short_duration")
+	}
+}
+
+func TestNoFlagsOmittedFromJSON(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := StepResult{Output: "review output"}
+	if err := w.WriteReviewResult(42, "functional", step); err != nil {
+		t.Fatalf("WriteReviewResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "functional-review.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading functional-review.json: %v", err)
+	}
+
+	// flags field should be omitted (omitempty) when empty
+	if string(data) != "" {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("parsing JSON: %v", err)
+		}
+		if _, ok := raw["flags"]; ok {
+			t.Error("flags key should be omitted from JSON when empty")
+		}
+	}
+}
+
 func TestPathTraversalRejected(t *testing.T) {
 	cases := []string{
 		"../evil/../../path",


### PR DESCRIPTION
## Summary

- Adds `quality:` config block with `min_review_cost_usd` and `min_review_duration_seconds` fields (both default to 0 = disabled)
- Adds `Flag` type and `Flags []Flag` field to `rundata.StepResult` so quality flags are persisted in review JSON files
- After each review step in `ProcessIssue`, computes quality flags and logs any flags as `slog.Warn`
- Quality reviewer is exempt from `CheckReviewTestExecution`; functional reviewer runs all four quality checks
- Flags do NOT affect run outcomes — a flagged review still counts as approved

## Test plan

- [x] `TestQualityConfigParsed` — `quality: {min_review_cost_usd: 0.10}` parsed correctly
- [x] `TestQualityConfigDefaults` — missing `quality:` block uses zero defaults
- [x] `TestQualityConfigPartial` — partial quality block works
- [x] `TestFlagsWrittenToReviewJSON` — flags appear in written JSON
- [x] `TestNoFlagsOmittedFromJSON` — flags key is omitted when empty
- [x] `TestComputeReviewFlags_QualityReviewerExemptFromTestExecution` — QA reviewer skips test execution check
- [x] `TestComputeReviewFlags_CostFloorFlag` — cost below threshold produces low_cost flag
- [x] `TestComputeReviewFlags_DisabledWhenZeroThreshold` — zero thresholds disable checks
- [x] `TestProcessIssue_QualityFlagsLoggedAsWarnings` — flags logged as slog.Warn
- [x] `TestProcessIssue_FlagsIncludedInHookStepResult` — flags included in hook StepResult
- [x] `TestProcessIssue_QualityReviewerExemptInLoop` — integration test confirming exemption

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)