### PR TITLE
fix: run punchlist agent in sandbox instead of on host

### DIFF
--- a/internal/agent/punchlist.go
+++ b/internal/agent/punchlist.go
@@ -71,7 +71,7 @@ func GenerateAcceptanceTests(ctx context.Context, entry punchlist.Entry, prompts
 		Timeout: timeout,
 	}
 
-	result, err := Run(ctx, opts, true, logger) // always noSandbox
+	result, err := Run(ctx, opts, cfg.NoSandbox, logger)
 	if err != nil {
 		logger.Warn("punchlist agent run failed", "error", err)
 		return nil


### PR DESCRIPTION
## Summary

- The punchlist agent was hardcoded to `noSandbox=true`, requiring `claude-agent-sdk` installed on the host
- Now respects `cfg.NoSandbox` like all other agents, running in Docker by default
- This fixes the `exit_code=1` crashes seen during punchlist generation

## Test plan

- [x] `go test ./...` passes
- [ ] `godark run` generates "Suggested acceptance tests" in punchlist output

🤖 Generated with [Claude Code](https://claude.com/claude-code)