### PR TITLE
feat: add dashboard UI prototype

### DIFF
--- a/docs/design/dashboard/empty.html
+++ b/docs/design/dashboard/empty.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>godark — Empty States</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .empty-gallery {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-8);
+    }
+    .empty-section {
+      border: 1px dashed var(--border-default);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+    }
+    .empty-section__label {
+      padding: var(--space-2) var(--space-4);
+      background: var(--bg-surface-2);
+      border-bottom: 1px dashed var(--border-default);
+      font-size: var(--text-xs);
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--text-muted);
+    }
+    .empty-section__content {
+      min-height: 300px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* Geometric empty state icons (CSS-only) */
+    .empty-icon {
+      width: 64px;
+      height: 64px;
+      margin-bottom: var(--space-6);
+      position: relative;
+    }
+    .empty-icon--hexagons {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .empty-icon--hexagons::before {
+      content: "";
+      width: 40px;
+      height: 40px;
+      background: var(--bg-surface-3);
+      clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+      opacity: 0.4;
+    }
+    .empty-icon--hexagons::after {
+      content: "";
+      position: absolute;
+      width: 24px;
+      height: 24px;
+      background: var(--border-default);
+      clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      opacity: 0.6;
+    }
+
+    .empty-icon--doc {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .empty-icon--doc::before {
+      content: "";
+      width: 32px;
+      height: 40px;
+      border: 2px solid var(--border-default);
+      border-radius: var(--radius-sm);
+      opacity: 0.3;
+    }
+    .empty-icon--doc::after {
+      content: "";
+      position: absolute;
+      width: 16px;
+      height: 2px;
+      background: var(--border-default);
+      opacity: 0.4;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      box-shadow: 0 -6px 0 var(--border-default), 0 6px 0 var(--border-default);
+    }
+
+    .empty-icon--search {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .empty-icon--search::before {
+      content: "";
+      width: 28px;
+      height: 28px;
+      border: 2px solid var(--border-default);
+      border-radius: 50%;
+      opacity: 0.3;
+    }
+    .empty-icon--search::after {
+      content: "";
+      position: absolute;
+      width: 12px;
+      height: 2px;
+      background: var(--border-default);
+      opacity: 0.4;
+      bottom: 12px;
+      right: 10px;
+      transform: rotate(45deg);
+    }
+
+    .empty-icon--list {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+    }
+    .empty-icon--list::before {
+      content: "";
+      width: 36px;
+      height: 2px;
+      background: var(--border-default);
+      opacity: 0.3;
+      box-shadow: 0 8px 0 var(--border-default), 0 16px 0 var(--border-default);
+    }
+
+    .empty-icon--terminal {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .empty-icon--terminal::before {
+      content: "";
+      width: 44px;
+      height: 32px;
+      border: 2px solid var(--border-default);
+      border-radius: var(--radius-sm);
+      opacity: 0.3;
+    }
+    .empty-icon--terminal::after {
+      content: ">";
+      position: absolute;
+      color: var(--border-default);
+      font-family: var(--font-mono);
+      font-size: var(--text-lg);
+      opacity: 0.4;
+    }
+
+    /* First-run welcome variant */
+    .welcome-state {
+      text-align: center;
+      padding: var(--space-16) var(--space-8);
+    }
+    .welcome-state__logo {
+      width: 48px;
+      height: 48px;
+      background: var(--accent);
+      clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+      margin: 0 auto var(--space-6);
+      opacity: 0.8;
+    }
+    .welcome-state__title {
+      font-family: var(--font-sans);
+      font-size: var(--text-xl);
+      font-weight: 600;
+      color: var(--text-primary);
+      margin-bottom: var(--space-2);
+    }
+    .welcome-state__body {
+      font-size: var(--text-sm);
+      color: var(--text-secondary);
+      max-width: 440px;
+      margin: 0 auto;
+      line-height: 1.7;
+    }
+    .welcome-state__cmd {
+      display: inline-block;
+      margin-top: var(--space-6);
+      padding: var(--space-3) var(--space-5);
+      background: var(--bg-surface-2);
+      border: 1px solid var(--border-default);
+      border-radius: var(--radius-md);
+      font-family: var(--font-mono);
+      font-size: var(--text-sm);
+      color: var(--text-primary);
+    }
+    .welcome-state__cmd .text-accent { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <div class="shell">
+
+    <!-- Top Bar -->
+    <header class="topbar">
+      <div class="topbar__logo">
+        <span class="topbar__logo-mark"></span>
+        godark
+      </div>
+      <span class="topbar__sep"></span>
+      <nav class="breadcrumbs">
+        <span class="breadcrumbs__current">Empty States</span>
+      </nav>
+      <div class="topbar__spacer"></div>
+      <div class="topbar__status">
+        <span class="topbar__dot" style="background: var(--text-muted); box-shadow: none; animation: none;"></span>
+        Idle
+      </div>
+    </header>
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar__section">
+        <div class="sidebar__label">Navigation</div>
+        <ul class="sidebar__nav">
+          <li>
+            <a href="index.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 1.75V13.5h13V1.75H1.5zm-1.5 0A1.5 1.5 0 011.5.25h13A1.5 1.5 0 0116 1.75V13.5a1.5 1.5 0 01-1.5 1.5h-13A1.5 1.5 0 010 13.5V1.75zM6.5 8a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/></svg>
+              Runs
+            </a>
+          </li>
+          <li>
+            <a href="logs.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M2 1.75C2 .784 2.784 0 3.75 0h8.5C13.216 0 14 .784 14 1.75v12.5A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V1.75a.25.25 0 00-.25-.25h-8.5zM4.75 4h6.5v1.5h-6.5V4zm0 3h6.5v1.5h-6.5V7zm0 3h4v1.5h-4V10z"/></svg>
+              Logs
+            </a>
+          </li>
+          <li>
+            <a href="empty.html" class="sidebar__link sidebar__link--active">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></svg>
+              Empty States
+            </a>
+          </li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="main">
+      <div class="page-header animate-in">
+        <h1 class="page-header__title">Empty States</h1>
+        <p class="page-header__subtitle">What the dashboard looks like with no data</p>
+      </div>
+
+      <div class="empty-gallery">
+
+        <!-- 1. First Run / Welcome -->
+        <div class="empty-section animate-in animate-in-1">
+          <div class="empty-section__label">First Run — No Runs Yet</div>
+          <div class="empty-section__content">
+            <div class="welcome-state">
+              <div class="welcome-state__logo"></div>
+              <h2 class="welcome-state__title">Welcome to godark</h2>
+              <p class="welcome-state__body">
+                No orchestration runs yet. Start your first run to see results here.
+                The dashboard will update in real-time as issues are processed.
+              </p>
+              <div class="welcome-state__cmd">
+                <span class="text-accent">$</span> godark run --milestone v1.0 --repo owner/repo
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 2. No Issues in Run -->
+        <div class="empty-section animate-in animate-in-2">
+          <div class="empty-section__label">Run Detail — No Issues</div>
+          <div class="empty-section__content">
+            <div class="empty-state">
+              <div class="empty-icon empty-icon--list"></div>
+              <h3 class="empty-state__title">No issues in this run</h3>
+              <p class="empty-state__description">
+                This milestone has no open issues matching the configured labels.
+                Check your config to make sure the right labels are set.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- 3. No Logs -->
+        <div class="empty-section animate-in animate-in-3">
+          <div class="empty-section__label">Log Viewer — No Logs</div>
+          <div class="empty-section__content">
+            <div class="empty-state">
+              <div class="empty-icon empty-icon--terminal"></div>
+              <h3 class="empty-state__title">No log entries</h3>
+              <p class="empty-state__description">
+                Log output will appear here as the run progresses.
+                If the run has completed, check that the log file exists in the run directory.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- 4. Filtered to Nothing -->
+        <div class="empty-section animate-in animate-in-4">
+          <div class="empty-section__label">Runs List — Filter Returns Nothing</div>
+          <div class="empty-section__content">
+            <div class="empty-state">
+              <div class="empty-icon empty-icon--search"></div>
+              <h3 class="empty-state__title">No matching runs</h3>
+              <p class="empty-state__description">
+                No runs match the current filters. Try adjusting the repository filter
+                or clearing the search query.
+              </p>
+              <div class="empty-state__action">
+                <button class="btn btn--ghost btn--sm">Clear filters</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- 5. No Logs Match Filter -->
+        <div class="empty-section animate-in animate-in-5">
+          <div class="empty-section__label">Log Viewer — Search Returns Nothing</div>
+          <div class="empty-section__content">
+            <div class="empty-state">
+              <div class="empty-icon empty-icon--doc"></div>
+              <h3 class="empty-state__title">No matching log entries</h3>
+              <p class="empty-state__description">
+                No log entries match the current level filter or search query.
+                Try broadening your search or selecting a different log level.
+              </p>
+              <div class="empty-state__action">
+                <button class="btn btn--ghost btn--sm">Show all levels</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/design/dashboard/index.html
+++ b/docs/design/dashboard/index.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>godark — Runs</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="shell">
+
+    <!-- Top Bar -->
+    <header class="topbar">
+      <div class="topbar__logo">
+        <span class="topbar__logo-mark"></span>
+        godark
+      </div>
+      <span class="topbar__sep"></span>
+      <nav class="breadcrumbs">
+        <span class="breadcrumbs__current">Runs</span>
+      </nav>
+      <div class="topbar__spacer"></div>
+      <div class="topbar__status">
+        <span class="topbar__dot"></span>
+        Watching
+      </div>
+    </header>
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar__section">
+        <div class="sidebar__label">Navigation</div>
+        <ul class="sidebar__nav">
+          <li>
+            <a href="index.html" class="sidebar__link sidebar__link--active">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M1.5 1.75V13.5h13V1.75H1.5zm-1.5 0A1.5 1.5 0 011.5.25h13A1.5 1.5 0 0116 1.75V13.5a1.5 1.5 0 01-1.5 1.5h-13A1.5 1.5 0 010 13.5V1.75zM6.5 8a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
+              </svg>
+              Runs
+            </a>
+          </li>
+          <li>
+            <a href="logs.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M2 1.75C2 .784 2.784 0 3.75 0h8.5C13.216 0 14 .784 14 1.75v12.5A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V1.75a.25.25 0 00-.25-.25h-8.5zM4.75 4h6.5v1.5h-6.5V4zm0 3h6.5v1.5h-6.5V7zm0 3h4v1.5h-4V10z"/>
+              </svg>
+              Logs
+            </a>
+          </li>
+          <li>
+            <a href="empty.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/>
+              </svg>
+              Empty States
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="sidebar__section">
+        <div class="sidebar__label">Recent Repos</div>
+        <ul class="sidebar__nav">
+          <li><a href="#" class="sidebar__link">phs/dark-factory</a></li>
+          <li><a href="#" class="sidebar__link">phs/widget-api</a></li>
+          <li><a href="#" class="sidebar__link">acme/payments</a></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="main">
+      <div class="page-header animate-in">
+        <h1 class="page-header__title">Runs</h1>
+        <p class="page-header__subtitle">All orchestration runs across repositories</p>
+      </div>
+
+      <!-- Stats Row -->
+      <div class="stats-row animate-in animate-in-1">
+        <div class="stat-block">
+          <div class="stat-block__label">Total Runs</div>
+          <div class="stat-block__value">47</div>
+          <div class="stat-block__detail">Last 30 days</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Pass Rate</div>
+          <div class="stat-block__value stat-block__value--success">78%</div>
+          <div class="stat-block__detail">37 passed / 10 failed</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Issues Processed</div>
+          <div class="stat-block__value">312</div>
+          <div class="stat-block__detail">Avg 6.6 per run</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Total Cost</div>
+          <div class="stat-block__value stat-block__value--accent">$184.50</div>
+          <div class="stat-block__detail">Avg $3.93/run</div>
+        </div>
+      </div>
+
+      <!-- Controls -->
+      <div class="controls animate-in animate-in-2">
+        <div class="control-group">
+          <select class="filter-select" aria-label="Filter by repository">
+            <option>All Repos</option>
+            <option>phs/dark-factory</option>
+            <option>phs/widget-api</option>
+            <option>acme/payments</option>
+          </select>
+        </div>
+        <div class="control-group">
+          <span class="filter-chip filter-chip--active">All</span>
+          <span class="filter-chip">Passed</span>
+          <span class="filter-chip">Failed</span>
+          <span class="filter-chip">Running</span>
+        </div>
+        <div class="topbar__spacer"></div>
+        <input type="search" class="search-input" placeholder="Search runs..." aria-label="Search runs">
+      </div>
+
+      <!-- Runs Table -->
+      <!-- htmx: this table body would be a partial at /partials/runs-table
+           hx-get="/partials/runs-table" hx-trigger="load, filter-changed"
+           hx-target="#runs-tbody" hx-swap="innerHTML" -->
+      <div class="card animate-in animate-in-3">
+        <table class="data-table data-table--clickable">
+          <thead>
+            <tr>
+              <th>Run</th>
+              <th>Repository</th>
+              <th>Milestone</th>
+              <th>Issues</th>
+              <th>Result</th>
+              <th>Quality</th>
+              <th class="cell-num">Cost</th>
+              <th>When</th>
+            </tr>
+          </thead>
+          <tbody id="runs-tbody">
+            <!-- Row 1: Successful run -->
+            <tr onclick="location.href='run.html'">
+              <td>
+                <span style="color: var(--text-primary); font-weight: 500;">#47</span>
+                <span class="hover-reveal" style="margin-left: 4px;">View &rarr;</span>
+              </td>
+              <td class="text-secondary">phs/dark-factory</td>
+              <td>v0.9 — Dashboard</td>
+              <td>
+                <div class="pass-fail-bar">
+                  <span class="text-success">8</span>
+                  <span class="text-muted">/</span>
+                  <span class="text-danger">1</span>
+                  <div class="pass-fail-bar__bar">
+                    <div class="progress-bar__segment progress-bar__segment--success" style="width: 89%;"></div>
+                    <div class="progress-bar__segment progress-bar__segment--danger" style="width: 11%;"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="badge badge--success"><span class="badge__dot"></span> Passed</span></td>
+              <td>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Build: pass" title="Build: pass">B</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Test: pass" title="Test: pass">T</span>
+                  <span class="quality-flag quality-flag--warn" data-tooltip="Lint: 3 warnings" title="Lint: 3 warnings">L</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Vet: pass" title="Vet: pass">V</span>
+                </div>
+              </td>
+              <td class="cell-num"><span class="cost">4.23</span></td>
+              <td class="text-secondary">2 min ago</td>
+            </tr>
+
+            <!-- Row 2: Failed run -->
+            <tr onclick="location.href='run.html'">
+              <td>
+                <span style="color: var(--text-primary); font-weight: 500;">#46</span>
+                <span class="hover-reveal" style="margin-left: 4px;">View &rarr;</span>
+              </td>
+              <td class="text-secondary">phs/widget-api</td>
+              <td>v2.1 — Auth Refactor</td>
+              <td>
+                <div class="pass-fail-bar">
+                  <span class="text-success">3</span>
+                  <span class="text-muted">/</span>
+                  <span class="text-danger">4</span>
+                  <div class="pass-fail-bar__bar">
+                    <div class="progress-bar__segment progress-bar__segment--success" style="width: 43%;"></div>
+                    <div class="progress-bar__segment progress-bar__segment--danger" style="width: 57%;"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="badge badge--danger"><span class="badge__dot"></span> Failed</span></td>
+              <td>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--fail" data-tooltip="Build: fail" title="Build: fail">B</span>
+                  <span class="quality-flag quality-flag--fail" data-tooltip="Test: fail" title="Test: fail">T</span>
+                  <span class="quality-flag quality-flag--skip" data-tooltip="Lint: skipped" title="Lint: skipped">L</span>
+                  <span class="quality-flag quality-flag--skip" data-tooltip="Vet: skipped" title="Vet: skipped">V</span>
+                </div>
+              </td>
+              <td class="cell-num"><span class="cost">8.71</span></td>
+              <td class="text-secondary">43 min ago</td>
+            </tr>
+
+            <!-- Row 3: Needs review -->
+            <tr onclick="location.href='run.html'">
+              <td>
+                <span style="color: var(--text-primary); font-weight: 500;">#45</span>
+                <span class="hover-reveal" style="margin-left: 4px;">View &rarr;</span>
+              </td>
+              <td class="text-secondary">phs/dark-factory</td>
+              <td>v0.8 — Quality Flags</td>
+              <td>
+                <div class="pass-fail-bar">
+                  <span class="text-success">5</span>
+                  <span class="text-muted">/</span>
+                  <span class="text-warning">2</span>
+                  <div class="pass-fail-bar__bar">
+                    <div class="progress-bar__segment progress-bar__segment--success" style="width: 71%;"></div>
+                    <div class="progress-bar__segment progress-bar__segment--warning" style="width: 29%;"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="badge badge--warning"><span class="badge__dot"></span> Review</span></td>
+              <td>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Build: pass" title="Build: pass">B</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Test: pass" title="Test: pass">T</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Lint: pass" title="Lint: pass">L</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Vet: pass" title="Vet: pass">V</span>
+                </div>
+              </td>
+              <td class="cell-num"><span class="cost">3.12</span></td>
+              <td class="text-secondary">2 hours ago</td>
+            </tr>
+
+            <!-- Row 4 -->
+            <tr onclick="location.href='run.html'">
+              <td>
+                <span style="color: var(--text-primary); font-weight: 500;">#44</span>
+                <span class="hover-reveal" style="margin-left: 4px;">View &rarr;</span>
+              </td>
+              <td class="text-secondary">acme/payments</td>
+              <td>v1.3 — Stripe Webhooks</td>
+              <td>
+                <div class="pass-fail-bar">
+                  <span class="text-success">12</span>
+                  <span class="text-muted">/</span>
+                  <span class="text-danger">0</span>
+                  <div class="pass-fail-bar__bar">
+                    <div class="progress-bar__segment progress-bar__segment--success" style="width: 100%;"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="badge badge--success"><span class="badge__dot"></span> Passed</span></td>
+              <td>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Build: pass" title="Build: pass">B</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Test: pass" title="Test: pass">T</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Lint: pass" title="Lint: pass">L</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Vet: pass" title="Vet: pass">V</span>
+                </div>
+              </td>
+              <td class="cell-num"><span class="cost">5.44</span></td>
+              <td class="text-secondary">5 hours ago</td>
+            </tr>
+
+            <!-- Row 5 -->
+            <tr onclick="location.href='run.html'">
+              <td>
+                <span style="color: var(--text-primary); font-weight: 500;">#43</span>
+                <span class="hover-reveal" style="margin-left: 4px;">View &rarr;</span>
+              </td>
+              <td class="text-secondary">phs/dark-factory</td>
+              <td>v0.8 — Quality Flags</td>
+              <td>
+                <div class="pass-fail-bar">
+                  <span class="text-success">6</span>
+                  <span class="text-muted">/</span>
+                  <span class="text-danger">1</span>
+                  <div class="pass-fail-bar__bar">
+                    <div class="progress-bar__segment progress-bar__segment--success" style="width: 86%;"></div>
+                    <div class="progress-bar__segment progress-bar__segment--danger" style="width: 14%;"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="badge badge--success"><span class="badge__dot"></span> Passed</span></td>
+              <td>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Build: pass" title="Build: pass">B</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Test: pass" title="Test: pass">T</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Lint: pass" title="Lint: pass">L</span>
+                  <span class="quality-flag quality-flag--warn" data-tooltip="Vet: 1 warning" title="Vet: 1 warning">V</span>
+                </div>
+              </td>
+              <td class="cell-num"><span class="cost">2.89</span></td>
+              <td class="text-secondary">Yesterday</td>
+            </tr>
+
+            <!-- Row 6: Currently running -->
+            <tr onclick="location.href='run.html'" style="background: var(--accent-subtle);">
+              <td>
+                <span style="color: var(--accent); font-weight: 500;">#48</span>
+                <span style="font-size: var(--text-xs); color: var(--accent); margin-left: 4px;">LIVE</span>
+              </td>
+              <td class="text-secondary">phs/dark-factory</td>
+              <td>v0.9 — Dashboard</td>
+              <td>
+                <div class="pass-fail-bar">
+                  <span class="text-success">2</span>
+                  <span class="text-muted">/</span>
+                  <span class="text-muted">0</span>
+                  <div class="pass-fail-bar__bar">
+                    <div class="progress-bar__segment progress-bar__segment--success" style="width: 25%;"></div>
+                    <div class="progress-bar__segment progress-bar__segment--pending" style="width: 75%;"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="badge badge--info"><span class="badge__dot"></span> Running</span></td>
+              <td>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--skip" data-tooltip="Build: pending" title="Build: pending">B</span>
+                  <span class="quality-flag quality-flag--skip" data-tooltip="Test: pending" title="Test: pending">T</span>
+                  <span class="quality-flag quality-flag--skip" data-tooltip="Lint: pending" title="Lint: pending">L</span>
+                  <span class="quality-flag quality-flag--skip" data-tooltip="Vet: pending" title="Vet: pending">V</span>
+                </div>
+              </td>
+              <td class="cell-num"><span class="cost">1.02</span></td>
+              <td class="text-secondary">Just now</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Load More -->
+      <!-- htmx: hx-get="/partials/runs-table?page=2" hx-target="#runs-tbody" hx-swap="beforeend" -->
+      <div class="load-more animate-in animate-in-4">
+        <button class="btn btn--ghost btn--sm">Load more runs</button>
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/design/dashboard/issue.html
+++ b/docs/design/dashboard/issue.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>godark — Issue #79</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .issue-header { display: flex; align-items: start; gap: var(--space-4); margin-bottom: var(--space-6); }
+    .issue-header__main { flex: 1; }
+    .issue-header__number { font-size: var(--text-sm); color: var(--text-muted); margin-bottom: var(--space-1); }
+    .issue-header__title { font-family: var(--font-sans); font-size: var(--text-xl); font-weight: 600; color: var(--text-primary); margin-bottom: var(--space-2); }
+    .issue-header__meta { display: flex; align-items: center; gap: var(--space-4); font-size: var(--text-sm); color: var(--text-secondary); flex-wrap: wrap; }
+
+    .step-details { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: var(--space-3); margin-top: var(--space-3); font-size: var(--text-xs); }
+    .step-detail { display: flex; flex-direction: column; gap: 2px; }
+    .step-detail__label { color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+    .step-detail__value { color: var(--text-primary); font-weight: 500; }
+
+    .verdict-box { margin-top: var(--space-3); padding: var(--space-3); border-radius: var(--radius-sm); font-size: var(--text-sm); line-height: 1.6; }
+    .verdict-box--pass { background: var(--status-success-muted); border: 1px solid rgba(63, 185, 80, 0.2); color: var(--text-secondary); }
+    .verdict-box--fail { background: var(--status-danger-muted); border: 1px solid rgba(248, 81, 73, 0.2); color: var(--text-secondary); }
+    .verdict-box--info { background: var(--status-info-muted); border: 1px solid rgba(88, 166, 255, 0.2); color: var(--text-secondary); }
+
+    .quality-detail { display: flex; gap: var(--space-4); margin-top: var(--space-3); flex-wrap: wrap; }
+    .quality-detail__item { display: flex; align-items: center; gap: var(--space-2); font-size: var(--text-xs); }
+  </style>
+</head>
+<body>
+  <div class="shell">
+
+    <!-- Top Bar -->
+    <header class="topbar">
+      <div class="topbar__logo">
+        <span class="topbar__logo-mark"></span>
+        godark
+      </div>
+      <span class="topbar__sep"></span>
+      <nav class="breadcrumbs">
+        <a href="index.html">Runs</a>
+        <span class="breadcrumbs__sep">/</span>
+        <a href="run.html">Run #47</a>
+        <span class="breadcrumbs__sep">/</span>
+        <span class="breadcrumbs__current">Issue #79</span>
+      </nav>
+      <div class="topbar__spacer"></div>
+      <div class="topbar__status">
+        <span class="topbar__dot"></span>
+        Watching
+      </div>
+    </header>
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar__section">
+        <div class="sidebar__label">Navigation</div>
+        <ul class="sidebar__nav">
+          <li>
+            <a href="index.html" class="sidebar__link sidebar__link--active">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 1.75V13.5h13V1.75H1.5zm-1.5 0A1.5 1.5 0 011.5.25h13A1.5 1.5 0 0116 1.75V13.5a1.5 1.5 0 01-1.5 1.5h-13A1.5 1.5 0 010 13.5V1.75zM6.5 8a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/></svg>
+              Runs
+            </a>
+          </li>
+          <li>
+            <a href="logs.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M2 1.75C2 .784 2.784 0 3.75 0h8.5C13.216 0 14 .784 14 1.75v12.5A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V1.75a.25.25 0 00-.25-.25h-8.5zM4.75 4h6.5v1.5h-6.5V4zm0 3h6.5v1.5h-6.5V7zm0 3h4v1.5h-4V10z"/></svg>
+              Logs
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="sidebar__section">
+        <div class="sidebar__label">This Issue</div>
+        <ul class="sidebar__nav">
+          <li><span class="sidebar__link text-muted">Run #47</span></li>
+          <li><span class="sidebar__link text-muted">phs/dark-factory</span></li>
+          <li><span class="sidebar__link text-muted">2 retries</span></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="main">
+
+      <!-- Issue Header -->
+      <div class="issue-header animate-in">
+        <div class="issue-header__main">
+          <div class="issue-header__number">Issue #79 &middot; Run #47</div>
+          <h1 class="issue-header__title">Implement run list page with htmx partials</h1>
+          <div class="issue-header__meta">
+            <span class="badge badge--success"><span class="badge__dot"></span> Success</span>
+            <a href="#" class="pr-link">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
+              PR #116
+            </a>
+            <span>Total: 3m 08s</span>
+            <span>Cost: <span class="cost">0.87</span></span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Summary Stats -->
+      <div class="stats-row animate-in animate-in-1">
+        <div class="stat-block">
+          <div class="stat-block__label">Attempts</div>
+          <div class="stat-block__value">3</div>
+          <div class="stat-block__detail">1 initial + 2 retries</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Total Duration</div>
+          <div class="stat-block__value">3m 08s</div>
+          <div class="stat-block__detail">Implement + QA cycles</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Quality Flags</div>
+          <div class="stat-block__value" style="display: flex; gap: var(--space-2);">
+            <span class="quality-flag quality-flag--pass" data-tooltip="Build: pass" title="Build: pass">B</span>
+            <span class="quality-flag quality-flag--pass" data-tooltip="Test: pass" title="Test: pass">T</span>
+            <span class="quality-flag quality-flag--pass" data-tooltip="Lint: pass" title="Lint: pass">L</span>
+            <span class="quality-flag quality-flag--pass" data-tooltip="Vet: pass" title="Vet: pass">V</span>
+          </div>
+          <div class="stat-block__detail">All passing on final attempt</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Total Cost</div>
+          <div class="stat-block__value stat-block__value--accent">$0.87</div>
+          <div class="stat-block__detail">Across all attempts</div>
+        </div>
+      </div>
+
+      <!-- Review Chain Timeline -->
+      <h2 style="font-family: var(--font-sans); font-size: var(--text-lg); font-weight: 600; margin-bottom: var(--space-4);" class="animate-in animate-in-2">Review Chain</h2>
+
+      <div class="timeline animate-in animate-in-3">
+
+        <!-- Step 1: Implementation (attempt 1) -->
+        <div class="timeline__item">
+          <div class="timeline__marker timeline__marker--info"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <span class="timeline__title">Implementation — Attempt 1</span>
+              <div class="timeline__meta">
+                <span>14:23:00</span>
+                <span class="cost">0.24</span>
+              </div>
+            </div>
+            <div class="timeline__body">
+              Agent created initial implementation with run list template, htmx partial endpoint, and Alpine.js filter controls.
+            </div>
+            <div class="step-details">
+              <div class="step-detail">
+                <span class="step-detail__label">Duration</span>
+                <span class="step-detail__value">48s</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Files Changed</span>
+                <span class="step-detail__value">4</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Lines Added</span>
+                <span class="step-detail__value">+187</span>
+              </div>
+            </div>
+
+            <!-- Expandable tool trace -->
+            <!-- Alpine.js: x-data="{ open: false }" on parent, @click="open = !open" on trigger, x-show="open" on content -->
+            <div class="expandable">
+              <input type="checkbox" id="trace-1" class="expandable__toggle">
+              <label for="trace-1" class="expandable__trigger">
+                <span class="expandable__arrow">&#9654;</span>
+                Tool trace (12 calls)
+              </label>
+              <div class="expandable__content">
+                <div class="code-block">
+                  <div><span class="line-num">1</span><span class="text-info">Read</span> internal/dashboard/server.go</div>
+                  <div><span class="line-num">2</span><span class="text-info">Read</span> internal/dashboard/templates/layout.html</div>
+                  <div><span class="line-num">3</span><span class="text-quality">Write</span> internal/dashboard/handlers/runs.go <span class="text-muted">+67 lines</span></div>
+                  <div><span class="line-num">4</span><span class="text-quality">Write</span> internal/dashboard/templates/runs.html <span class="text-muted">+52 lines</span></div>
+                  <div><span class="line-num">5</span><span class="text-quality">Write</span> internal/dashboard/templates/partials/runs-table.html <span class="text-muted">+38 lines</span></div>
+                  <div><span class="line-num">6</span><span class="text-quality">Write</span> internal/dashboard/handlers/runs_test.go <span class="text-muted">+30 lines</span></div>
+                  <div><span class="line-num">7</span><span class="text-accent">Bash</span> go build ./... <span class="text-success">OK</span></div>
+                  <div><span class="line-num">8</span><span class="text-accent">Bash</span> go test ./internal/dashboard/... <span class="text-success">PASS</span></div>
+                  <div><span class="line-num">9</span><span class="text-accent">Bash</span> go vet ./... <span class="text-success">OK</span></div>
+                  <div><span class="line-num">10</span><span class="text-info">Read</span> internal/dashboard/handlers/runs.go</div>
+                  <div><span class="line-num">11</span><span class="text-accent">Bash</span> git add -A &amp;&amp; git commit <span class="text-success">OK</span></div>
+                  <div><span class="line-num">12</span><span class="text-accent">Bash</span> gh pr create <span class="text-success">PR #116</span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 2: QA Review 1 — Rejected -->
+        <div class="timeline__item">
+          <div class="timeline__marker timeline__marker--danger"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <span class="timeline__title">QA Review — Cycle 1</span>
+              <div class="timeline__meta">
+                <span>14:23:48</span>
+                <span class="badge badge--danger" style="font-size: 10px;">Rejected</span>
+              </div>
+            </div>
+            <div class="verdict-box verdict-box--fail">
+              <strong>Verdict: FAIL</strong> — Missing error handling in runs handler. Template doesn't escape user-provided milestone names. Filter partial doesn't preserve query params across htmx swaps.
+            </div>
+            <div class="step-details">
+              <div class="step-detail">
+                <span class="step-detail__label">Duration</span>
+                <span class="step-detail__value">22s</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Issues Found</span>
+                <span class="step-detail__value text-danger">3</span>
+              </div>
+            </div>
+
+            <div class="expandable">
+              <input type="checkbox" id="trace-2" class="expandable__toggle">
+              <label for="trace-2" class="expandable__trigger">
+                <span class="expandable__arrow">&#9654;</span>
+                Tool trace (6 calls)
+              </label>
+              <div class="expandable__content">
+                <div class="code-block">
+                  <div><span class="line-num">1</span><span class="text-info">Read</span> internal/dashboard/handlers/runs.go</div>
+                  <div><span class="line-num">2</span><span class="text-info">Read</span> internal/dashboard/templates/runs.html</div>
+                  <div><span class="line-num">3</span><span class="text-info">Read</span> internal/dashboard/templates/partials/runs-table.html</div>
+                  <div><span class="line-num">4</span><span class="text-info">Read</span> internal/dashboard/handlers/runs_test.go</div>
+                  <div><span class="line-num">5</span><span class="text-accent">Bash</span> go test -race ./internal/dashboard/... <span class="text-success">PASS</span></div>
+                  <div><span class="line-num">6</span><span class="text-warning">Review</span> Verdict: FAIL (3 issues)</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 3: Implementation retry 1 -->
+        <div class="timeline__item">
+          <div class="timeline__marker timeline__marker--info"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <span class="timeline__title">Implementation — Retry 1</span>
+              <div class="timeline__meta">
+                <span>14:24:10</span>
+                <span class="cost">0.19</span>
+              </div>
+            </div>
+            <div class="timeline__body">
+              Fixed error handling, added template escaping, preserved query params in htmx partial responses.
+            </div>
+            <div class="step-details">
+              <div class="step-detail">
+                <span class="step-detail__label">Duration</span>
+                <span class="step-detail__value">35s</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Files Changed</span>
+                <span class="step-detail__value">3</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Lines Changed</span>
+                <span class="step-detail__value">+24 / -8</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 4: QA Review 2 — Rejected (minor) -->
+        <div class="timeline__item">
+          <div class="timeline__marker timeline__marker--danger"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <span class="timeline__title">QA Review — Cycle 2</span>
+              <div class="timeline__meta">
+                <span>14:24:45</span>
+                <span class="badge badge--danger" style="font-size: 10px;">Rejected</span>
+              </div>
+            </div>
+            <div class="verdict-box verdict-box--fail">
+              <strong>Verdict: FAIL</strong> — Test coverage missing for the new error handling path. Previous issues resolved.
+            </div>
+            <div class="step-details">
+              <div class="step-detail">
+                <span class="step-detail__label">Duration</span>
+                <span class="step-detail__value">18s</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Issues Found</span>
+                <span class="step-detail__value text-danger">1</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 5: Implementation retry 2 -->
+        <div class="timeline__item">
+          <div class="timeline__marker timeline__marker--info"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <span class="timeline__title">Implementation — Retry 2</span>
+              <div class="timeline__meta">
+                <span>14:25:03</span>
+                <span class="cost">0.14</span>
+              </div>
+            </div>
+            <div class="timeline__body">
+              Added test cases for error handling path. All tests passing.
+            </div>
+            <div class="step-details">
+              <div class="step-detail">
+                <span class="step-detail__label">Duration</span>
+                <span class="step-detail__value">28s</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Files Changed</span>
+                <span class="step-detail__value">1</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Lines Added</span>
+                <span class="step-detail__value">+18</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 6: QA Review 3 — Passed -->
+        <div class="timeline__item">
+          <div class="timeline__marker timeline__marker--success"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <span class="timeline__title">QA Review — Cycle 3</span>
+              <div class="timeline__meta">
+                <span>14:25:31</span>
+                <span class="badge badge--success" style="font-size: 10px;">Approved</span>
+              </div>
+            </div>
+            <div class="verdict-box verdict-box--pass">
+              <strong>Verdict: PASS</strong> — All previous issues resolved. Error handling is correct, templates properly escape user input, htmx partials preserve state. Test coverage adequate.
+            </div>
+            <div class="step-details">
+              <div class="step-detail">
+                <span class="step-detail__label">Duration</span>
+                <span class="step-detail__value">15s</span>
+              </div>
+              <div class="step-detail">
+                <span class="step-detail__label">Issues Found</span>
+                <span class="step-detail__value text-success">0</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 7: Functional Review — Passed -->
+        <div class="timeline__item">
+          <div class="timeline__marker timeline__marker--success"></div>
+          <div class="timeline__content">
+            <div class="timeline__header">
+              <span class="timeline__title">Functional Review</span>
+              <div class="timeline__meta">
+                <span>14:25:46</span>
+                <span class="badge badge--success" style="font-size: 10px;">Approved</span>
+              </div>
+            </div>
+            <div class="verdict-box verdict-box--pass">
+              <strong>Verdict: PASS</strong> — Implementation satisfies issue requirements. Run list displays correctly, pagination works via htmx, filter controls update table content.
+            </div>
+            <div class="quality-detail">
+              <div class="quality-detail__item">
+                <span class="quality-flag quality-flag--pass" style="width: 16px; height: 16px; font-size: 9px;">B</span>
+                <span>Build: <span class="text-success">pass</span></span>
+              </div>
+              <div class="quality-detail__item">
+                <span class="quality-flag quality-flag--pass" style="width: 16px; height: 16px; font-size: 9px;">T</span>
+                <span>Test: <span class="text-success">12/12 pass</span></span>
+              </div>
+              <div class="quality-detail__item">
+                <span class="quality-flag quality-flag--pass" style="width: 16px; height: 16px; font-size: 9px;">L</span>
+                <span>Lint: <span class="text-success">0 issues</span></span>
+              </div>
+              <div class="quality-detail__item">
+                <span class="quality-flag quality-flag--pass" style="width: 16px; height: 16px; font-size: 9px;">V</span>
+                <span>Vet: <span class="text-success">0 findings</span></span>
+              </div>
+            </div>
+            <div class="step-details">
+              <div class="step-detail">
+                <span class="step-detail__label">Duration</span>
+                <span class="step-detail__value">12s</span>
+              </div>
+            </div>
+
+            <div class="expandable">
+              <input type="checkbox" id="trace-7" class="expandable__toggle">
+              <label for="trace-7" class="expandable__trigger">
+                <span class="expandable__arrow">&#9654;</span>
+                Tool trace (8 calls)
+              </label>
+              <div class="expandable__content">
+                <div class="code-block">
+                  <div><span class="line-num">1</span><span class="text-info">Read</span> GitHub issue #79</div>
+                  <div><span class="line-num">2</span><span class="text-info">Read</span> internal/dashboard/handlers/runs.go</div>
+                  <div><span class="line-num">3</span><span class="text-info">Read</span> internal/dashboard/templates/runs.html</div>
+                  <div><span class="line-num">4</span><span class="text-info">Read</span> internal/dashboard/templates/partials/runs-table.html</div>
+                  <div><span class="line-num">5</span><span class="text-accent">Bash</span> go build ./... <span class="text-success">OK</span></div>
+                  <div><span class="line-num">6</span><span class="text-accent">Bash</span> go test ./internal/dashboard/... <span class="text-success">12/12 PASS</span></div>
+                  <div><span class="line-num">7</span><span class="text-accent">Bash</span> go vet ./... <span class="text-success">OK</span></div>
+                  <div><span class="line-num">8</span><span class="text-success">Review</span> Verdict: PASS</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 8: Complete -->
+        <div class="timeline__item">
+          <div class="timeline__marker timeline__marker--active"></div>
+          <div class="timeline__content" style="border-color: var(--accent); background: var(--accent-subtle);">
+            <div class="timeline__header">
+              <span class="timeline__title" style="color: var(--accent);">Complete</span>
+              <div class="timeline__meta">
+                <span>14:26:08</span>
+              </div>
+            </div>
+            <div class="timeline__body">
+              Issue #79 resolved. PR #116 ready for merge. Total cost: $0.87 across 3 attempts.
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/design/dashboard/logs.html
+++ b/docs/design/dashboard/logs.html
@@ -1,0 +1,406 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>godark — Logs</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .log-controls {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      margin-bottom: var(--space-4);
+      flex-wrap: wrap;
+    }
+    .log-count {
+      font-size: var(--text-xs);
+      color: var(--text-muted);
+      margin-left: auto;
+    }
+    /* Highlight matched search text */
+    .log-highlight {
+      background: rgba(240, 136, 62, 0.25);
+      color: var(--accent);
+      border-radius: 2px;
+      padding: 0 2px;
+    }
+    /* Structured fields inline display */
+    .log-fields-inline {
+      margin-left: var(--space-3);
+      display: inline;
+    }
+    .log-fields-inline span {
+      margin-right: var(--space-2);
+    }
+    /* Expandable row detail */
+    .log-detail-row td {
+      padding: 0;
+      border-bottom: 1px solid var(--border-muted);
+    }
+    .log-detail-content {
+      padding: var(--space-3) var(--space-4);
+      padding-left: calc(var(--space-3) + 8ch);
+      background: var(--bg-surface-1);
+    }
+    .log-json {
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      color: var(--text-secondary);
+      white-space: pre;
+      line-height: 1.6;
+    }
+    .log-json .json-key { color: var(--status-quality); }
+    .log-json .json-string { color: var(--status-success); }
+    .log-json .json-number { color: var(--accent); }
+    .log-json .json-bool { color: var(--status-info); }
+  </style>
+</head>
+<body>
+  <div class="shell">
+
+    <!-- Top Bar -->
+    <header class="topbar">
+      <div class="topbar__logo">
+        <span class="topbar__logo-mark"></span>
+        godark
+      </div>
+      <span class="topbar__sep"></span>
+      <nav class="breadcrumbs">
+        <a href="index.html">Runs</a>
+        <span class="breadcrumbs__sep">/</span>
+        <a href="run.html">Run #47</a>
+        <span class="breadcrumbs__sep">/</span>
+        <span class="breadcrumbs__current">Logs</span>
+      </nav>
+      <div class="topbar__spacer"></div>
+      <div class="topbar__status">
+        <span class="topbar__dot"></span>
+        Watching
+      </div>
+    </header>
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar__section">
+        <div class="sidebar__label">Navigation</div>
+        <ul class="sidebar__nav">
+          <li>
+            <a href="index.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 1.75V13.5h13V1.75H1.5zm-1.5 0A1.5 1.5 0 011.5.25h13A1.5 1.5 0 0116 1.75V13.5a1.5 1.5 0 01-1.5 1.5h-13A1.5 1.5 0 010 13.5V1.75zM6.5 8a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/></svg>
+              Runs
+            </a>
+          </li>
+          <li>
+            <a href="logs.html" class="sidebar__link sidebar__link--active">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M2 1.75C2 .784 2.784 0 3.75 0h8.5C13.216 0 14 .784 14 1.75v12.5A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V1.75a.25.25 0 00-.25-.25h-8.5zM4.75 4h6.5v1.5h-6.5V4zm0 3h6.5v1.5h-6.5V7zm0 3h4v1.5h-4V10z"/></svg>
+              Logs
+            </a>
+          </li>
+          <li>
+            <a href="empty.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></svg>
+              Empty States
+            </a>
+          </li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="main">
+      <div class="page-header animate-in">
+        <h1 class="page-header__title">Logs</h1>
+        <p class="page-header__subtitle">Run #47 &middot; phs/dark-factory &middot; 247 log entries</p>
+      </div>
+
+      <!-- Log Controls -->
+      <!-- htmx: filter controls would trigger hx-get="/partials/logs?level=info&q=..."
+           hx-trigger="change, keyup changed delay:300ms" hx-target="#log-body" -->
+      <div class="log-controls animate-in animate-in-1">
+        <div class="control-group">
+          <span class="filter-chip filter-chip--active">All</span>
+          <span class="filter-chip">
+            <span style="color: var(--status-info);">&#9679;</span> Info
+          </span>
+          <span class="filter-chip">
+            <span style="color: var(--status-warning);">&#9679;</span> Warn
+          </span>
+          <span class="filter-chip">
+            <span style="color: var(--status-danger);">&#9679;</span> Error
+          </span>
+          <span class="filter-chip">
+            <span style="color: var(--text-muted);">&#9679;</span> Debug
+          </span>
+        </div>
+        <input type="search" class="search-input" placeholder="Search logs..." aria-label="Search log messages" style="width: 280px;">
+        <span class="log-count">Showing 25 of 247</span>
+      </div>
+
+      <!-- Log Table -->
+      <div class="card animate-in animate-in-2">
+        <table class="log-table">
+          <thead>
+            <tr>
+              <th style="width: 90px;">Time</th>
+              <th style="width: 50px;">Level</th>
+              <th>Message</th>
+              <th style="width: 200px;">Fields</th>
+            </tr>
+          </thead>
+          <tbody id="log-body">
+
+            <tr>
+              <td class="text-muted">14:23:00.001</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>orchestrator started</td>
+              <td>
+                <span class="log-field-key">repo</span>=<span class="log-field-value">phs/dark-factory</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:00.003</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>loading milestone issues</td>
+              <td>
+                <span class="log-field-key">milestone</span>=<span class="log-field-value">v0.9</span>
+                <span class="log-field-key">count</span>=<span class="log-field-value">9</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:00.015</td>
+              <td><span class="log-level log-level--debug">DBG</span></td>
+              <td>resolving dependency graph</td>
+              <td>
+                <span class="log-field-key">issues</span>=<span class="log-field-value">9</span>
+                <span class="log-field-key">edges</span>=<span class="log-field-value">4</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:00.018</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>dependency order resolved</td>
+              <td>
+                <span class="log-field-key">order</span>=<span class="log-field-value">[78,79,81,82,83,84,85,86,87]</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:00.020</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>processing issue</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">78</span>
+                <span class="log-field-key">title</span>=<span class="log-field-value">Add dashboard HTTP server</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:00.022</td>
+              <td><span class="log-level log-level--debug">DBG</span></td>
+              <td>spawning implement agent</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">78</span>
+                <span class="log-field-key">sandbox</span>=<span class="log-field-value">true</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:48.107</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>implement agent completed</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">78</span>
+                <span class="log-field-key">duration</span>=<span class="log-field-value">48.085s</span>
+                <span class="log-field-key">cost</span>=<span class="log-field-value">0.24</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:48.110</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>running quality checks</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">78</span>
+                <span class="log-field-key">checks</span>=<span class="log-field-value">[build,test,lint,vet]</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:52.340</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>quality checks passed</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">78</span>
+                <span class="log-field-key">build</span>=<span class="log-field-value" style="color: var(--status-success);">pass</span>
+                <span class="log-field-key">test</span>=<span class="log-field-value" style="color: var(--status-success);">pass</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:23:52.345</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>spawning QA review agent</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">78</span>
+                <span class="log-field-key">attempt</span>=<span class="log-field-value">1</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:24:14.220</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>QA review approved</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">78</span>
+                <span class="log-field-key">verdict</span>=<span class="log-field-value" style="color: var(--status-success);">pass</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:24:14.225</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>issue completed successfully</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">78</span>
+                <span class="log-field-key">pr</span>=<span class="log-field-value">115</span>
+                <span class="log-field-key">cost</span>=<span class="log-field-value">0.52</span>
+              </td>
+            </tr>
+
+            <tr style="background: var(--accent-subtle);">
+              <td class="text-muted">14:24:14.230</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>processing issue</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">79</span>
+                <span class="log-field-key">title</span>=<span class="log-field-value">Implement run list page</span>
+              </td>
+            </tr>
+
+            <!-- Show a warning -->
+            <tr>
+              <td class="text-muted">14:24:50.112</td>
+              <td><span class="log-level log-level--warn">WARN</span></td>
+              <td>QA review rejected, scheduling retry</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">79</span>
+                <span class="log-field-key">attempt</span>=<span class="log-field-value">1</span>
+                <span class="log-field-key">issues_found</span>=<span class="log-field-value" style="color: var(--status-danger);">3</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:25:28.445</td>
+              <td><span class="log-level log-level--warn">WARN</span></td>
+              <td>QA review rejected, scheduling retry</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">79</span>
+                <span class="log-field-key">attempt</span>=<span class="log-field-value">2</span>
+                <span class="log-field-key">issues_found</span>=<span class="log-field-value" style="color: var(--status-danger);">1</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:26:08.890</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>issue completed successfully</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">79</span>
+                <span class="log-field-key">pr</span>=<span class="log-field-value">116</span>
+                <span class="log-field-key">retries</span>=<span class="log-field-value">2</span>
+                <span class="log-field-key">cost</span>=<span class="log-field-value">0.87</span>
+              </td>
+            </tr>
+
+            <!-- Show an error -->
+            <tr style="background: var(--status-danger-muted);">
+              <td class="text-muted">14:30:12.334</td>
+              <td><span class="log-level log-level--error">ERR</span></td>
+              <td>issue failed after max retries</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">81</span>
+                <span class="log-field-key">retries</span>=<span class="log-field-value">3</span>
+                <span class="log-field-key">reason</span>=<span class="log-field-value">QA rejected</span>
+              </td>
+            </tr>
+
+            <!-- Expanded row example (shows what clicking a row looks like) -->
+            <tr style="background: var(--bg-surface-2); cursor: pointer;">
+              <td class="text-muted">14:30:12.340</td>
+              <td><span class="log-level log-level--debug">DBG</span></td>
+              <td>agent session details</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">81</span>
+              </td>
+            </tr>
+            <!-- This shows the expanded structured JSON view -->
+            <tr class="log-detail-row">
+              <td colspan="4">
+                <div class="log-detail-content">
+                  <div class="log-json">{
+  <span class="json-key">"time"</span>: <span class="json-string">"2026-03-05T14:30:12.340Z"</span>,
+  <span class="json-key">"level"</span>: <span class="json-string">"DEBUG"</span>,
+  <span class="json-key">"msg"</span>: <span class="json-string">"agent session details"</span>,
+  <span class="json-key">"issue"</span>: <span class="json-number">81</span>,
+  <span class="json-key">"agent"</span>: <span class="json-string">"implement"</span>,
+  <span class="json-key">"session_id"</span>: <span class="json-string">"a3f8c2d1-9e4b-4f7a-b6c8-1d2e3f4a5b6c"</span>,
+  <span class="json-key">"tool_calls"</span>: <span class="json-number">24</span>,
+  <span class="json-key">"tokens_in"</span>: <span class="json-number">48231</span>,
+  <span class="json-key">"tokens_out"</span>: <span class="json-number">12847</span>,
+  <span class="json-key">"sandbox"</span>: <span class="json-bool">true</span>,
+  <span class="json-key">"exit_code"</span>: <span class="json-number">1</span>
+}</div>
+                </div>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:30:15.001</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>processing issue</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">82</span>
+                <span class="log-field-key">title</span>=<span class="log-field-value">Implement log viewer</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:32:46.789</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>issue completed with review needed</td>
+              <td>
+                <span class="log-field-key">issue</span>=<span class="log-field-value">82</span>
+                <span class="log-field-key">pr</span>=<span class="log-field-value">117</span>
+                <span class="log-field-key">verdict</span>=<span class="log-field-value" style="color: var(--status-warning);">needs-review</span>
+              </td>
+            </tr>
+
+            <tr>
+              <td class="text-muted">14:41:42.003</td>
+              <td><span class="log-level log-level--info">INFO</span></td>
+              <td>orchestrator finished</td>
+              <td>
+                <span class="log-field-key">total_issues</span>=<span class="log-field-value">9</span>
+                <span class="log-field-key">passed</span>=<span class="log-field-value" style="color: var(--status-success);">8</span>
+                <span class="log-field-key">failed</span>=<span class="log-field-value" style="color: var(--status-danger);">1</span>
+                <span class="log-field-key">cost</span>=<span class="log-field-value">4.23</span>
+              </td>
+            </tr>
+
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Load More -->
+      <!-- htmx: hx-get="/partials/logs?offset=25" hx-target="#log-body" hx-swap="beforeend" -->
+      <div class="load-more animate-in animate-in-3">
+        <button class="btn btn--ghost btn--sm">Load more (222 remaining)</button>
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/design/dashboard/run.html
+++ b/docs/design/dashboard/run.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>godark — Run #47</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .issue-row { display: grid; grid-template-columns: 1fr auto; gap: var(--space-4); align-items: start; }
+    .issue-row__main { display: flex; flex-direction: column; gap: var(--space-1); }
+    .issue-row__title { font-weight: 500; color: var(--text-primary); font-size: var(--text-md); }
+    .issue-row__meta { display: flex; align-items: center; gap: var(--space-3); font-size: var(--text-xs); color: var(--text-secondary); flex-wrap: wrap; }
+    .issue-row__right { display: flex; align-items: center; gap: var(--space-4); flex-shrink: 0; }
+    .issue-card { padding: var(--space-4); border-bottom: 1px solid var(--border-muted); transition: background var(--transition-fast); cursor: pointer; }
+    .issue-card:last-child { border-bottom: none; }
+    .issue-card:hover { background: var(--bg-surface-2); }
+    .retry-count { display: inline-flex; align-items: center; gap: 2px; font-size: var(--text-xs); color: var(--text-muted); }
+    .retry-count svg { width: 12px; height: 12px; }
+  </style>
+</head>
+<body>
+  <div class="shell">
+
+    <!-- Top Bar -->
+    <header class="topbar">
+      <div class="topbar__logo">
+        <span class="topbar__logo-mark"></span>
+        godark
+      </div>
+      <span class="topbar__sep"></span>
+      <nav class="breadcrumbs">
+        <a href="index.html">Runs</a>
+        <span class="breadcrumbs__sep">/</span>
+        <span class="breadcrumbs__current">Run #47</span>
+      </nav>
+      <div class="topbar__spacer"></div>
+      <div class="topbar__status">
+        <span class="topbar__dot"></span>
+        Watching
+      </div>
+    </header>
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar__section">
+        <div class="sidebar__label">Navigation</div>
+        <ul class="sidebar__nav">
+          <li>
+            <a href="index.html" class="sidebar__link sidebar__link--active">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 1.75V13.5h13V1.75H1.5zm-1.5 0A1.5 1.5 0 011.5.25h13A1.5 1.5 0 0116 1.75V13.5a1.5 1.5 0 01-1.5 1.5h-13A1.5 1.5 0 010 13.5V1.75zM6.5 8a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/></svg>
+              Runs
+            </a>
+          </li>
+          <li>
+            <a href="logs.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M2 1.75C2 .784 2.784 0 3.75 0h8.5C13.216 0 14 .784 14 1.75v12.5A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V1.75a.25.25 0 00-.25-.25h-8.5zM4.75 4h6.5v1.5h-6.5V4zm0 3h6.5v1.5h-6.5V7zm0 3h4v1.5h-4V10z"/></svg>
+              Logs
+            </a>
+          </li>
+          <li>
+            <a href="empty.html" class="sidebar__link">
+              <svg class="sidebar__icon" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></svg>
+              Empty States
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="sidebar__section">
+        <div class="sidebar__label">This Run</div>
+        <ul class="sidebar__nav">
+          <li><span class="sidebar__link" style="color: var(--text-muted);">phs/dark-factory</span></li>
+          <li><span class="sidebar__link" style="color: var(--text-muted);">v0.9 — Dashboard</span></li>
+        </ul>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="main">
+      <div class="page-header animate-in">
+        <div class="flex items-center gap-3" style="margin-bottom: var(--space-2);">
+          <h1 class="page-header__title">Run #47</h1>
+          <span class="badge badge--success"><span class="badge__dot"></span> Passed</span>
+        </div>
+        <p class="page-header__subtitle">
+          phs/dark-factory &middot; v0.9 — Dashboard &middot; Started Mar 5, 2026 at 14:23
+        </p>
+      </div>
+
+      <!-- Stats Row -->
+      <div class="stats-row animate-in animate-in-1">
+        <div class="stat-block">
+          <div class="stat-block__label">Issues</div>
+          <div class="stat-block__value">9</div>
+          <div class="stat-block__detail">8 passed, 1 failed</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Duration</div>
+          <div class="stat-block__value">18m 42s</div>
+          <div class="stat-block__detail">Sequential processing</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Retries</div>
+          <div class="stat-block__value stat-block__value--warning">3</div>
+          <div class="stat-block__detail">On 2 issues</div>
+        </div>
+        <div class="stat-block">
+          <div class="stat-block__label">Total Cost</div>
+          <div class="stat-block__value stat-block__value--accent">$4.23</div>
+          <div class="stat-block__detail">Avg $0.47/issue</div>
+        </div>
+      </div>
+
+      <!-- Quality Summary -->
+      <div class="card animate-in animate-in-2" style="margin-bottom: var(--space-6);">
+        <div class="card__header">
+          <span class="card__title">Quality Flags</span>
+          <div class="quality-flags">
+            <span class="quality-flag quality-flag--pass" data-tooltip="Build: pass" title="Build: pass">B</span>
+            <span class="quality-flag quality-flag--pass" data-tooltip="Test: pass" title="Test: pass">T</span>
+            <span class="quality-flag quality-flag--warn" data-tooltip="Lint: 3 warnings" title="Lint: 3 warnings">L</span>
+            <span class="quality-flag quality-flag--pass" data-tooltip="Vet: pass" title="Vet: pass">V</span>
+          </div>
+        </div>
+        <div class="card__body" style="padding: var(--space-3) var(--space-4);">
+          <div style="display: flex; gap: var(--space-8); font-size: var(--text-sm);">
+            <div>
+              <span class="text-muted">Build</span>
+              <span class="text-success" style="margin-left: var(--space-2);">PASS</span>
+              <span class="text-muted" style="margin-left: var(--space-2);">0 errors</span>
+            </div>
+            <div>
+              <span class="text-muted">Test</span>
+              <span class="text-success" style="margin-left: var(--space-2);">PASS</span>
+              <span class="text-muted" style="margin-left: var(--space-2);">47/47 passed</span>
+            </div>
+            <div>
+              <span class="text-muted">Lint</span>
+              <span class="text-warning" style="margin-left: var(--space-2);">WARN</span>
+              <span class="text-muted" style="margin-left: var(--space-2);">3 warnings</span>
+            </div>
+            <div>
+              <span class="text-muted">Vet</span>
+              <span class="text-success" style="margin-left: var(--space-2);">PASS</span>
+              <span class="text-muted" style="margin-left: var(--space-2);">0 findings</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Issues List -->
+      <div class="card animate-in animate-in-3">
+        <div class="card__header">
+          <span class="card__title">Issues (9)</span>
+          <div class="control-group">
+            <span class="filter-chip filter-chip--active">All</span>
+            <span class="filter-chip">Passed</span>
+            <span class="filter-chip">Failed</span>
+            <span class="filter-chip">Review</span>
+          </div>
+        </div>
+
+        <!-- Issue 1: Success -->
+        <div class="issue-card" onclick="location.href='issue.html'">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title">
+                <a href="issue.html" style="color: inherit;">#78 Add dashboard HTTP server with basic routing</a>
+              </div>
+              <div class="issue-row__meta">
+                <span class="badge badge--success"><span class="badge__dot"></span> Success</span>
+                <a href="#" class="pr-link">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
+                  PR #115
+                </a>
+                <span>2m 14s</span>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Build: pass" title="Build: pass" style="width: 16px; height: 16px; font-size: 9px;">B</span>
+                  <span class="quality-flag quality-flag--pass" data-tooltip="Test: pass" title="Test: pass" style="width: 16px; height: 16px; font-size: 9px;">T</span>
+                </div>
+              </div>
+            </div>
+            <div class="issue-row__right">
+              <span class="cost">0.52</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Issue 2: Success with retries -->
+        <div class="issue-card" onclick="location.href='issue.html'">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title">
+                <a href="issue.html" style="color: inherit;">#79 Implement run list page with htmx partials</a>
+              </div>
+              <div class="issue-row__meta">
+                <span class="badge badge--success"><span class="badge__dot"></span> Success</span>
+                <a href="#" class="pr-link">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
+                  PR #116
+                </a>
+                <span>3m 08s</span>
+                <span class="retry-count">
+                  <svg viewBox="0 0 16 16" fill="currentColor"><path d="M5.029 2.217a6.5 6.5 0 019.437 5.11c.106.636-.54.886-.92.395l-.148-.19a6.5 6.5 0 01-.537-.753.25.25 0 00-.331-.08 5 5 0 11-7.19-3.682.25.25 0 00.105-.337L5.108 2.2a.25.25 0 00-.079-.083z"/></svg>
+                  2 retries
+                </span>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--pass" style="width: 16px; height: 16px; font-size: 9px;">B</span>
+                  <span class="quality-flag quality-flag--pass" style="width: 16px; height: 16px; font-size: 9px;">T</span>
+                </div>
+              </div>
+            </div>
+            <div class="issue-row__right">
+              <span class="cost">0.87</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Issue 3: Failed -->
+        <div class="issue-card" onclick="location.href='issue.html'" style="border-left: 3px solid var(--status-danger);">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title">
+                <a href="issue.html" style="color: inherit;">#81 Add WebSocket live-update connection</a>
+              </div>
+              <div class="issue-row__meta">
+                <span class="badge badge--danger"><span class="badge__dot"></span> Failed</span>
+                <span class="text-danger" style="font-size: var(--text-xs);">QA review rejected after 3 attempts</span>
+                <span>4m 52s</span>
+                <span class="retry-count">
+                  <svg viewBox="0 0 16 16" fill="currentColor"><path d="M5.029 2.217a6.5 6.5 0 019.437 5.11c.106.636-.54.886-.92.395l-.148-.19a6.5 6.5 0 01-.537-.753.25.25 0 00-.331-.08 5 5 0 11-7.19-3.682.25.25 0 00.105-.337L5.108 2.2a.25.25 0 00-.079-.083z"/></svg>
+                  3 retries (max)
+                </span>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--fail" style="width: 16px; height: 16px; font-size: 9px;">B</span>
+                  <span class="quality-flag quality-flag--fail" style="width: 16px; height: 16px; font-size: 9px;">T</span>
+                </div>
+              </div>
+            </div>
+            <div class="issue-row__right">
+              <span class="cost">1.23</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Issue 4: Needs review -->
+        <div class="issue-card" onclick="location.href='issue.html'" style="border-left: 3px solid var(--status-warning);">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title">
+                <a href="issue.html" style="color: inherit;">#82 Implement log viewer with JSON parsing</a>
+              </div>
+              <div class="issue-row__meta">
+                <span class="badge badge--warning"><span class="badge__dot"></span> Review</span>
+                <a href="#" class="pr-link">
+                  <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg>
+                  PR #117
+                </a>
+                <span>2m 31s</span>
+                <div class="quality-flags">
+                  <span class="quality-flag quality-flag--pass" style="width: 16px; height: 16px; font-size: 9px;">B</span>
+                  <span class="quality-flag quality-flag--warn" style="width: 16px; height: 16px; font-size: 9px;">T</span>
+                </div>
+              </div>
+            </div>
+            <div class="issue-row__right">
+              <span class="cost">0.64</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Issues 5-9: more successes -->
+        <div class="issue-card" onclick="location.href='issue.html'">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title"><a href="issue.html" style="color: inherit;">#83 Add breadcrumb navigation component</a></div>
+              <div class="issue-row__meta">
+                <span class="badge badge--success"><span class="badge__dot"></span> Success</span>
+                <a href="#" class="pr-link"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg> PR #118</a>
+                <span>1m 03s</span>
+              </div>
+            </div>
+            <div class="issue-row__right"><span class="cost">0.21</span></div>
+          </div>
+        </div>
+
+        <div class="issue-card" onclick="location.href='issue.html'">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title"><a href="issue.html" style="color: inherit;">#84 Implement filter controls for run list</a></div>
+              <div class="issue-row__meta">
+                <span class="badge badge--success"><span class="badge__dot"></span> Success</span>
+                <a href="#" class="pr-link"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg> PR #119</a>
+                <span>1m 47s</span>
+              </div>
+            </div>
+            <div class="issue-row__right"><span class="cost">0.31</span></div>
+          </div>
+        </div>
+
+        <div class="issue-card" onclick="location.href='issue.html'">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title"><a href="issue.html" style="color: inherit;">#85 Add status badge component</a></div>
+              <div class="issue-row__meta">
+                <span class="badge badge--success"><span class="badge__dot"></span> Success</span>
+                <a href="#" class="pr-link"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg> PR #120</a>
+                <span>0m 54s</span>
+              </div>
+            </div>
+            <div class="issue-row__right"><span class="cost">0.18</span></div>
+          </div>
+        </div>
+
+        <div class="issue-card" onclick="location.href='issue.html'">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title"><a href="issue.html" style="color: inherit;">#86 Implement run detail page template</a></div>
+              <div class="issue-row__meta">
+                <span class="badge badge--success"><span class="badge__dot"></span> Success</span>
+                <a href="#" class="pr-link"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg> PR #121</a>
+                <span>1m 22s</span>
+              </div>
+            </div>
+            <div class="issue-row__right"><span class="cost">0.27</span></div>
+          </div>
+        </div>
+
+        <div class="issue-card" onclick="location.href='issue.html'">
+          <div class="issue-row">
+            <div class="issue-row__main">
+              <div class="issue-row__title"><a href="issue.html" style="color: inherit;">#87 Add cost tracking to dashboard views</a></div>
+              <div class="issue-row__meta">
+                <span class="badge badge--success"><span class="badge__dot"></span> Success</span>
+                <a href="#" class="pr-link"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M7.177 3.073L9.573.677A.25.25 0 0110 .854v4.792a.25.25 0 01-.427.177L7.177 3.427a.25.25 0 010-.354zM3.75 2.5a.75.75 0 100 1.5.75.75 0 000-1.5zm-2.25.75a2.25 2.25 0 113 2.122v5.256a2.251 2.251 0 11-1.5 0V5.372A2.25 2.25 0 011.5 3.25zM11 2.5h-1V4h1a1 1 0 011 1v5.628a2.251 2.251 0 101.5 0V5A2.5 2.5 0 0011 2.5zm1 10.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM3.75 12a.75.75 0 100 1.5.75.75 0 000-1.5z"/></svg> PR #122</a>
+                <span>1m 11s</span>
+              </div>
+            </div>
+            <div class="issue-row__right"><span class="cost">0.24</span></div>
+          </div>
+        </div>
+
+      </div>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/design/dashboard/styles.css
+++ b/docs/design/dashboard/styles.css
@@ -1,0 +1,1079 @@
+/* ================================================================
+   GODARK DASHBOARD — Design System
+   Aesthetic: "Control Room" — industrial, dark, precise
+   ================================================================ */
+
+/* --- Design Tokens --- */
+:root {
+  /* Backgrounds */
+  --bg-base: #06080c;
+  --bg-surface-1: #0d1117;
+  --bg-surface-2: #161b22;
+  --bg-surface-3: #21262d;
+  --bg-overlay: rgba(6, 8, 12, 0.85);
+
+  /* Borders */
+  --border-default: #30363d;
+  --border-muted: #21262d;
+  --border-emphasis: #484f58;
+
+  /* Text */
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #484f58;
+  --text-inverse: #06080c;
+
+  /* Accent — factory amber */
+  --accent: #f0883e;
+  --accent-emphasis: #db7c2e;
+  --accent-muted: rgba(240, 136, 62, 0.15);
+  --accent-subtle: rgba(240, 136, 62, 0.08);
+
+  /* Status — indicator lights */
+  --status-success: #3fb950;
+  --status-success-muted: rgba(63, 185, 80, 0.15);
+  --status-danger: #f85149;
+  --status-danger-muted: rgba(248, 81, 73, 0.15);
+  --status-warning: #d29922;
+  --status-warning-muted: rgba(210, 153, 34, 0.15);
+  --status-info: #58a6ff;
+  --status-info-muted: rgba(88, 166, 255, 0.15);
+  --status-quality: #bc8cff;
+  --status-quality-muted: rgba(188, 140, 255, 0.15);
+
+  /* Typography */
+  --font-mono: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
+  --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+
+  --text-xs: 0.6875rem;   /* 11px */
+  --text-sm: 0.75rem;     /* 12px */
+  --text-base: 0.8125rem; /* 13px */
+  --text-md: 0.875rem;    /* 14px */
+  --text-lg: 1rem;        /* 16px */
+  --text-xl: 1.25rem;     /* 20px */
+  --text-2xl: 1.5rem;     /* 24px */
+  --text-3xl: 2rem;       /* 32px */
+
+  /* Spacing scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* Radii */
+  --radius-sm: 3px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.6);
+  --shadow-glow-accent: 0 0 12px rgba(240, 136, 62, 0.2);
+  --shadow-glow-success: 0 0 8px rgba(63, 185, 80, 0.3);
+  --shadow-glow-danger: 0 0 8px rgba(248, 81, 73, 0.3);
+
+  /* Transitions */
+  --transition-fast: 120ms ease;
+  --transition-normal: 200ms ease;
+  --transition-slow: 350ms ease;
+}
+
+/* --- Reset & Base --- */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-primary);
+  background-color: var(--bg-base);
+  min-height: 100vh;
+}
+
+/* Subtle noise texture overlay */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 256px 256px;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+a:hover {
+  color: var(--text-primary);
+}
+
+/* --- Layout Shell --- */
+.shell {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: auto 1fr;
+  min-height: 100vh;
+}
+
+/* --- Top Bar --- */
+.topbar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-6);
+  background: var(--bg-surface-1);
+  border-bottom: 1px solid var(--border-default);
+  height: 48px;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.topbar__logo {
+  font-family: var(--font-mono);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.topbar__logo-mark {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background: var(--accent);
+  clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+}
+
+.topbar__sep {
+  width: 1px;
+  height: 20px;
+  background: var(--border-default);
+}
+
+/* Breadcrumbs */
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+.breadcrumbs a {
+  color: var(--text-secondary);
+}
+.breadcrumbs__sep {
+  color: var(--text-muted);
+  user-select: none;
+}
+.breadcrumbs__current {
+  color: var(--text-primary);
+}
+
+.topbar__spacer { flex: 1; }
+
+.topbar__status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.topbar__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--status-success);
+  box-shadow: var(--shadow-glow-success);
+  animation: pulse-dot 2s ease-in-out infinite;
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* --- Sidebar --- */
+.sidebar {
+  background: var(--bg-surface-1);
+  border-right: 1px solid var(--border-default);
+  padding: var(--space-4) 0;
+  overflow-y: auto;
+}
+
+.sidebar__section {
+  padding: 0 var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.sidebar__label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  padding: 0 var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.sidebar__nav {
+  list-style: none;
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  transition: all var(--transition-fast);
+  cursor: pointer;
+}
+.sidebar__link:hover {
+  background: var(--bg-surface-2);
+  color: var(--text-primary);
+}
+.sidebar__link--active {
+  background: var(--accent-muted);
+  color: var(--accent);
+}
+.sidebar__link--active:hover {
+  background: var(--accent-muted);
+  color: var(--accent);
+}
+
+.sidebar__icon {
+  width: 16px;
+  height: 16px;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+/* --- Main Content --- */
+.main {
+  padding: var(--space-6);
+  overflow-y: auto;
+  max-width: 1400px;
+}
+
+/* --- Page Header --- */
+.page-header {
+  margin-bottom: var(--space-6);
+}
+
+.page-header__title {
+  font-family: var(--font-sans);
+  font-size: var(--text-2xl);
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+  margin-bottom: var(--space-1);
+}
+
+.page-header__subtitle {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+/* --- Controls Bar --- */
+.controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.control-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* Filter / Select */
+.filter-select {
+  appearance: none;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-8) var(--space-2) var(--space-3);
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238b949e' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  transition: border-color var(--transition-fast);
+}
+.filter-select:hover {
+  border-color: var(--border-emphasis);
+}
+.filter-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
+}
+
+/* Search Input */
+.search-input {
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-3);
+  width: 240px;
+  transition: border-color var(--transition-fast);
+}
+.search-input::placeholder {
+  color: var(--text-muted);
+}
+.search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-muted);
+}
+
+/* Filter Chips */
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  border-radius: 100px;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface-2);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.filter-chip:hover {
+  border-color: var(--border-emphasis);
+  color: var(--text-primary);
+}
+.filter-chip--active {
+  background: var(--accent-muted);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* --- Data Table --- */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.data-table thead {
+  position: sticky;
+  top: 0;
+}
+
+.data-table th {
+  text-align: left;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-surface-1);
+  white-space: nowrap;
+}
+
+.data-table td {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border-muted);
+  vertical-align: middle;
+}
+
+.data-table tbody tr {
+  transition: background var(--transition-fast);
+}
+.data-table tbody tr:hover {
+  background: var(--bg-surface-2);
+}
+
+.data-table--clickable tbody tr {
+  cursor: pointer;
+}
+
+/* Numeric / right-aligned cells */
+.cell-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.cell-mono {
+  font-family: var(--font-mono);
+}
+
+/* --- Status Badges --- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.badge--success {
+  background: var(--status-success-muted);
+  color: var(--status-success);
+}
+.badge--danger {
+  background: var(--status-danger-muted);
+  color: var(--status-danger);
+}
+.badge--warning {
+  background: var(--status-warning-muted);
+  color: var(--status-warning);
+}
+.badge--info {
+  background: var(--status-info-muted);
+  color: var(--status-info);
+}
+.badge--quality {
+  background: var(--status-quality-muted);
+  color: var(--status-quality);
+}
+.badge--neutral {
+  background: var(--bg-surface-3);
+  color: var(--text-secondary);
+}
+
+/* Indicator dot inside badge */
+.badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.badge--success .badge__dot { background: var(--status-success); box-shadow: var(--shadow-glow-success); }
+.badge--danger .badge__dot { background: var(--status-danger); box-shadow: var(--shadow-glow-danger); }
+.badge--warning .badge__dot { background: var(--status-warning); }
+.badge--info .badge__dot { background: var(--status-info); }
+
+/* --- Quality Flag Indicators --- */
+.quality-flags {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.quality-flag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  cursor: default;
+  position: relative;
+}
+
+.quality-flag--pass {
+  background: var(--status-success-muted);
+  color: var(--status-success);
+}
+.quality-flag--fail {
+  background: var(--status-danger-muted);
+  color: var(--status-danger);
+}
+.quality-flag--warn {
+  background: var(--status-warning-muted);
+  color: var(--status-warning);
+}
+.quality-flag--skip {
+  background: var(--bg-surface-3);
+  color: var(--text-muted);
+}
+
+/* Quality flag tooltip (CSS-only) */
+.quality-flag[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: var(--space-1) var(--space-2);
+  background: var(--bg-surface-3);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  white-space: nowrap;
+  color: var(--text-primary);
+  z-index: 10;
+  pointer-events: none;
+}
+
+/* --- Cards --- */
+.card {
+  background: var(--bg-surface-1);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.card__title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.card__body {
+  padding: var(--space-4);
+}
+
+/* --- Stat Blocks --- */
+.stats-row {
+  display: flex;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.stat-block {
+  background: var(--bg-surface-1);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  flex: 1;
+  min-width: 0;
+}
+
+.stat-block__label {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: var(--space-1);
+}
+
+.stat-block__value {
+  font-size: var(--text-xl);
+  font-weight: 700;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-block__value--success { color: var(--status-success); }
+.stat-block__value--danger { color: var(--status-danger); }
+.stat-block__value--warning { color: var(--status-warning); }
+.stat-block__value--accent { color: var(--accent); }
+
+.stat-block__detail {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  margin-top: var(--space-1);
+}
+
+/* --- Timeline --- */
+.timeline {
+  position: relative;
+  padding-left: var(--space-8);
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 11px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border-default);
+}
+
+.timeline__item {
+  position: relative;
+  padding-bottom: var(--space-6);
+}
+.timeline__item:last-child {
+  padding-bottom: 0;
+}
+
+.timeline__marker {
+  position: absolute;
+  left: calc(-1 * var(--space-8) + 4px);
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--border-default);
+  background: var(--bg-base);
+  z-index: 1;
+}
+
+.timeline__marker--success {
+  border-color: var(--status-success);
+  background: var(--status-success-muted);
+}
+.timeline__marker--danger {
+  border-color: var(--status-danger);
+  background: var(--status-danger-muted);
+}
+.timeline__marker--warning {
+  border-color: var(--status-warning);
+  background: var(--status-warning-muted);
+}
+.timeline__marker--info {
+  border-color: var(--status-info);
+  background: var(--status-info-muted);
+}
+.timeline__marker--active {
+  border-color: var(--accent);
+  background: var(--accent-muted);
+  box-shadow: var(--shadow-glow-accent);
+}
+
+.timeline__content {
+  background: var(--bg-surface-1);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+}
+
+.timeline__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-2);
+}
+
+.timeline__title {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.timeline__meta {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  display: flex;
+  gap: var(--space-3);
+}
+
+.timeline__body {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* --- Expandable Sections --- */
+.expandable {
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-md);
+  margin-top: var(--space-3);
+  overflow: hidden;
+}
+
+.expandable__trigger {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-surface-2);
+  border: none;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-align: left;
+}
+.expandable__trigger:hover {
+  background: var(--bg-surface-3);
+  color: var(--text-primary);
+}
+
+.expandable__arrow {
+  display: inline-block;
+  transition: transform var(--transition-normal);
+  font-size: 10px;
+  line-height: 1;
+}
+
+/* Toggle via hidden checkbox */
+.expandable__toggle {
+  display: none;
+}
+.expandable__toggle:checked ~ .expandable__content {
+  display: block;
+}
+.expandable__toggle:checked ~ .expandable__trigger .expandable__arrow {
+  transform: rotate(90deg);
+}
+
+.expandable__content {
+  display: none;
+  padding: var(--space-3);
+  background: var(--bg-surface-1);
+  border-top: 1px solid var(--border-muted);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+/* --- Code / Log Blocks --- */
+.code-block {
+  background: var(--bg-base);
+  border: 1px solid var(--border-muted);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: 1.7;
+  overflow-x: auto;
+  color: var(--text-secondary);
+}
+
+.code-block .line-num {
+  color: var(--text-muted);
+  user-select: none;
+  display: inline-block;
+  width: 3ch;
+  text-align: right;
+  margin-right: var(--space-3);
+}
+
+/* --- Log Table --- */
+.log-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+}
+
+.log-table th {
+  text-align: left;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-surface-1);
+  position: sticky;
+  top: 0;
+  white-space: nowrap;
+}
+
+.log-table td {
+  padding: var(--space-1) var(--space-3);
+  border-bottom: 1px solid var(--border-muted);
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.log-table td:last-child {
+  white-space: normal;
+  word-break: break-word;
+}
+
+.log-table tbody tr {
+  transition: background var(--transition-fast);
+}
+.log-table tbody tr:hover {
+  background: var(--bg-surface-2);
+}
+
+/* Log level colors */
+.log-level { font-weight: 600; }
+.log-level--info { color: var(--status-info); }
+.log-level--warn { color: var(--status-warning); }
+.log-level--error { color: var(--status-danger); }
+.log-level--debug { color: var(--text-muted); }
+
+/* Log structured fields */
+.log-fields {
+  display: inline;
+  color: var(--text-muted);
+}
+.log-field-key {
+  color: var(--status-quality);
+}
+.log-field-value {
+  color: var(--text-secondary);
+}
+
+/* --- Progress Bar --- */
+.progress-bar {
+  height: 4px;
+  background: var(--bg-surface-3);
+  border-radius: 2px;
+  overflow: hidden;
+  display: flex;
+}
+
+.progress-bar__segment {
+  height: 100%;
+  transition: width var(--transition-slow);
+}
+.progress-bar__segment--success { background: var(--status-success); }
+.progress-bar__segment--danger { background: var(--status-danger); }
+.progress-bar__segment--warning { background: var(--status-warning); }
+.progress-bar__segment--pending { background: var(--text-muted); }
+
+/* --- Empty States --- */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-16) var(--space-8);
+  text-align: center;
+}
+
+.empty-state__icon {
+  width: 64px;
+  height: 64px;
+  margin-bottom: var(--space-6);
+  opacity: 0.15;
+}
+
+.empty-state__title {
+  font-family: var(--font-sans);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-2);
+}
+
+.empty-state__description {
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  max-width: 400px;
+  line-height: 1.6;
+}
+
+.empty-state__action {
+  margin-top: var(--space-6);
+}
+
+/* --- Buttons --- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-decoration: none;
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: var(--text-inverse);
+  border-color: var(--accent);
+}
+.btn--primary:hover {
+  background: var(--accent-emphasis);
+  border-color: var(--accent-emphasis);
+  color: var(--text-inverse);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+.btn--ghost:hover {
+  background: var(--bg-surface-2);
+  color: var(--text-primary);
+  border-color: var(--border-emphasis);
+}
+
+.btn--sm {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+}
+
+/* --- Utility --- */
+.text-success { color: var(--status-success); }
+.text-danger { color: var(--status-danger); }
+.text-warning { color: var(--status-warning); }
+.text-info { color: var(--status-info); }
+.text-quality { color: var(--status-quality); }
+.text-muted { color: var(--text-muted); }
+.text-secondary { color: var(--text-secondary); }
+.text-accent { color: var(--accent); }
+
+.font-sans { font-family: var(--font-sans); }
+.font-mono { font-family: var(--font-mono); }
+
+.mt-2 { margin-top: var(--space-2); }
+.mt-4 { margin-top: var(--space-4); }
+.mt-6 { margin-top: var(--space-6); }
+.mb-2 { margin-bottom: var(--space-2); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mr-2 { margin-right: var(--space-2); }
+
+.flex { display: flex; }
+.flex-col { flex-direction: column; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.gap-2 { gap: var(--space-2); }
+.gap-3 { gap: var(--space-3); }
+.gap-4 { gap: var(--space-4); }
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Pass/Fail Summary Bar --- */
+.pass-fail-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+}
+
+.pass-fail-bar__bar {
+  flex: 1;
+  height: 4px;
+  background: var(--bg-surface-3);
+  border-radius: 2px;
+  overflow: hidden;
+  display: flex;
+  min-width: 60px;
+}
+
+/* --- Scrollbar --- */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--bg-surface-3);
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border-default);
+}
+
+/* --- Animations (entry) --- */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-in {
+  animation: fade-in-up 0.3s ease both;
+}
+.animate-in-1 { animation-delay: 0.05s; }
+.animate-in-2 { animation-delay: 0.1s; }
+.animate-in-3 { animation-delay: 0.15s; }
+.animate-in-4 { animation-delay: 0.2s; }
+.animate-in-5 { animation-delay: 0.25s; }
+
+/* --- Cost display --- */
+.cost {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+}
+.cost::before {
+  content: "$";
+  opacity: 0.5;
+}
+
+/* --- PR link --- */
+.pr-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--status-info);
+  font-size: var(--text-sm);
+}
+.pr-link:hover {
+  color: var(--text-primary);
+}
+
+/* --- Tooltip-style hover on rows --- */
+.data-table tbody tr:hover .hover-reveal {
+  opacity: 1;
+}
+.hover-reveal {
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+/* --- Load more button --- */
+.load-more {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-4);
+}


### PR DESCRIPTION
## Summary

- Static HTML/CSS prototype of the godark dashboard with all 5 views: run list, run detail, issue detail (timeline), log viewer, and empty states
- "Control Room" dark theme with industrial amber accents, indicator-light status colors, and monospace-heavy typography
- Design tokens (colors, typography, spacing), reusable component patterns (badges, quality flags, expandable sections, timelines), and htmx/Alpine.js integration annotations

Closes #80

## Test plan

- [ ] Open `docs/design/dashboard/index.html` in a browser — renders without external dependencies
- [ ] Navigate between all views via sidebar links and breadcrumbs
- [ ] Verify consistent design system across all 5 views (colors, fonts, spacing)
- [ ] Check status indicators: success (green), failure (red), needs-review (amber) are visually distinct
- [ ] Confirm quality flag indicators (B/T/L/V) show tooltips on hover
- [ ] Test expandable sections on issue detail page (checkbox-based CSS toggle)
- [ ] Views render correctly at 1280px–1920px widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)