### PR TITLE
fix: punchlist agent docker image and quality trace test command

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -361,7 +361,7 @@ func computeReviewFlags(result *Result, cfg *config.Config, checkTestExecution b
 		flags = append(flags, *f)
 	}
 
-	flags = append(flags, quality.CheckToolTrace(result.ToolTrace)...)
+	flags = append(flags, quality.CheckToolTrace(result.ToolTrace, cfg.TestCommand)...)
 
 	if checkTestExecution {
 		flags = append(flags, quality.CheckReviewTestExecution(result.ToolTrace, cfg.ReviewDir, cfg.TestCommand)...)

--- a/internal/agent/punchlist.go
+++ b/internal/agent/punchlist.go
@@ -68,6 +68,7 @@ func GenerateAcceptanceTests(ctx context.Context, entry punchlist.Entry, prompts
 		Prompt:  buf.String(),
 		Role:    "punchlist",
 		Env:     authEnv,
+		Image:   cfg.Docker.Image,
 		Timeout: timeout,
 	}
 

--- a/internal/quality/quality.go
+++ b/internal/quality/quality.go
@@ -44,18 +44,19 @@ func CheckDuration(duration time.Duration, threshold time.Duration) *Flag {
 
 // CheckToolTrace inspects the tool trace for evidence of a diff read and test run.
 // Returns no_diff_read if no Read or "gh pr diff" call is found.
-// Returns no_tests_run if no "go test" or "npm test" call is found.
-func CheckToolTrace(toolTrace []string) []Flag {
+// Returns no_tests_run if testCommand is not found in the trace.
+// If testCommand is empty, the test run check is skipped.
+func CheckToolTrace(toolTrace []string, testCommand string) []Flag {
 	var flags []Flag
 
 	diffRead := false
-	testsRun := false
+	testsRun := testCommand == ""
 
 	for _, entry := range toolTrace {
 		if strings.Contains(entry, "Read") || strings.Contains(entry, "gh pr diff") {
 			diffRead = true
 		}
-		if strings.Contains(entry, "go test") || strings.Contains(entry, "npm test") {
+		if !testsRun && strings.Contains(entry, testCommand) {
 			testsRun = true
 		}
 	}
@@ -69,7 +70,7 @@ func CheckToolTrace(toolTrace []string) []Flag {
 	if !testsRun {
 		flags = append(flags, Flag{
 			Code:    "no_tests_run",
-			Message: "no test run detected in tool trace (expected go test or npm test)",
+			Message: fmt.Sprintf("no test run detected in tool trace (expected %q)", testCommand),
 		})
 	}
 

--- a/internal/quality/quality_test.go
+++ b/internal/quality/quality_test.go
@@ -117,45 +117,58 @@ func TestCheckDuration(t *testing.T) {
 
 func TestCheckToolTrace(t *testing.T) {
 	tests := []struct {
-		name      string
-		trace     []string
-		wantCodes []string
+		name        string
+		trace       []string
+		testCommand string
+		wantCodes   []string
 	}{
 		{
-			name:      "no diff read",
-			trace:     []string{"Bash: go build ./...", "Bash: go test ./..."},
-			wantCodes: []string{"no_diff_read"},
+			name:        "no diff read",
+			trace:       []string{"Bash: go build ./...", "Bash: go test ./..."},
+			testCommand: "go test",
+			wantCodes:   []string{"no_diff_read"},
 		},
 		{
-			name:      "no tests run",
-			trace:     []string{"Read: main.go", "gh pr diff 42"},
-			wantCodes: []string{"no_tests_run"},
+			name:        "no tests run",
+			trace:       []string{"Read: main.go", "gh pr diff 42"},
+			testCommand: "go test",
+			wantCodes:   []string{"no_tests_run"},
 		},
 		{
-			name:      "normal trace with Read and go test",
-			trace:     []string{"Read: main.go", "Bash: go test ./..."},
-			wantCodes: nil,
+			name:        "normal trace with Read and go test",
+			trace:       []string{"Read: main.go", "Bash: go test ./..."},
+			testCommand: "go test",
+			wantCodes:   nil,
 		},
 		{
-			name:      "normal trace with gh pr diff and npm test",
-			trace:     []string{"Bash: gh pr diff 42", "Bash: npm test"},
-			wantCodes: nil,
+			name:        "normal trace with gh pr diff and npm test",
+			trace:       []string{"Bash: gh pr diff 42", "Bash: npm test"},
+			testCommand: "npm test",
+			wantCodes:   nil,
 		},
 		{
-			name:      "empty trace produces both flags",
-			trace:     []string{},
-			wantCodes: []string{"no_diff_read", "no_tests_run"},
+			name:        "empty trace produces both flags",
+			trace:       []string{},
+			testCommand: "go test",
+			wantCodes:   []string{"no_diff_read", "no_tests_run"},
 		},
 		{
-			name:      "nil trace produces both flags",
-			trace:     nil,
-			wantCodes: []string{"no_diff_read", "no_tests_run"},
+			name:        "nil trace produces both flags",
+			trace:       nil,
+			testCommand: "go test",
+			wantCodes:   []string{"no_diff_read", "no_tests_run"},
+		},
+		{
+			name:        "empty test command skips test check",
+			trace:       []string{"Read: main.go"},
+			testCommand: "",
+			wantCodes:   nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CheckToolTrace(tt.trace)
+			got := CheckToolTrace(tt.trace, tt.testCommand)
 			gotCodes := flagCodes(got)
 			if !codesEqual(gotCodes, tt.wantCodes) {
 				t.Errorf("got flags %v, want %v", gotCodes, tt.wantCodes)


### PR DESCRIPTION
## Summary

- **Punchlist crash fix**: `RunOpts.Image` was empty in `GenerateAcceptanceTests`, causing `docker create` to fail with "invalid reference format". Now passes `cfg.Docker.Image`.
- **Quality flag fix**: `CheckToolTrace` was hardcoded to check for `"go test" || "npm test"` regardless of project type, producing confusing messages about Node.js. Now uses the project's configured `testCommand` from config. Skips the check if no test command is configured.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] New test case for empty test command skipping the check

🤖 Generated with [Claude Code](https://claude.com/claude-code)