### PR TITLE
fix: resume HTMX polling when tab regains focus

### DIFF
--- a/internal/dashboard/templates/index.html
+++ b/internal/dashboard/templates/index.html
@@ -107,7 +107,7 @@
           </thead>
           <tbody id="runs-tbody"
                  hx-get="/partials/runs-table"
-                 hx-trigger="every 5s"
+                 hx-trigger="every 5s, visibilitychange[document.visibilityState==='visible'] from:document"
                  hx-swap="innerHTML"
                  hx-include="[name='repo']">
             {{template "runs-rows" .Runs}}

--- a/internal/dashboard/templates/log-viewer.html
+++ b/internal/dashboard/templates/log-viewer.html
@@ -107,7 +107,7 @@
           </thead>
           <tbody id="log-entries-tbody"
                  hx-get="{{.LogsURL}}/entries"
-                 hx-trigger="every 5s"
+                 hx-trigger="every 5s, visibilitychange[document.visibilityState==='visible'] from:document"
                  hx-swap="innerHTML"
                  hx-include="[name='level'], [name='search']">
             {{template "log-entries" .}}

--- a/internal/dashboard/templates/run-detail.html
+++ b/internal/dashboard/templates/run-detail.html
@@ -80,7 +80,7 @@
           </thead>
           <tbody id="issues-tbody"
                  hx-get="{{.RunURL}}/issues-table"
-                 hx-trigger="every 5s"
+                 hx-trigger="every 5s, visibilitychange[document.visibilityState==='visible'] from:document"
                  hx-swap="innerHTML">
             {{template "issues-rows" .Issues}}
           </tbody>


### PR DESCRIPTION
HTMX pauses `every Ns` polling when the page is hidden. Add a visibilitychange trigger so dashboard pages catch up immediately when the user switches back to the tab.