### PR TITLE
feat: add internal/harness/layers package for architecture JSON parsing

### DIFF
--- a/internal/harness/layers/layers.go
+++ b/internal/harness/layers/layers.go
@@ -1,0 +1,73 @@
+// Package layers parses layer definitions from architecture.json and returns
+// a directed graph of layer dependencies.
+package layers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Layer represents a single architectural layer with its directory and imports.
+type Layer struct {
+	Name    string   `json:"name"`
+	Dir     string   `json:"dir"`
+	Imports []string `json:"imports"`
+}
+
+// Definition holds the full set of layers parsed from architecture.json.
+type Definition struct {
+	Layers []Layer `json:"layers"`
+}
+
+// Parse decodes a layer definition from r. Returns an error on invalid JSON,
+// empty layers slice, duplicate names, empty name/dir, or imports referencing
+// non-existent layers. Cycle detection is left to the vet package.
+func Parse(r io.Reader) (*Definition, error) {
+	var def Definition
+	if err := json.NewDecoder(r).Decode(&def); err != nil {
+		return nil, fmt.Errorf("layers: decode JSON: %w", err)
+	}
+
+	if len(def.Layers) == 0 {
+		return nil, fmt.Errorf("layers: definition must contain at least one layer")
+	}
+
+	// First pass: validate names and dirs, build name set.
+	names := make(map[string]struct{}, len(def.Layers))
+	for i, l := range def.Layers {
+		if l.Name == "" {
+			return nil, fmt.Errorf("layers: layer[%d] has empty name", i)
+		}
+		if l.Dir == "" {
+			return nil, fmt.Errorf("layers: layer %q has empty dir", l.Name)
+		}
+		if _, dup := names[l.Name]; dup {
+			return nil, fmt.Errorf("layers: duplicate layer name %q", l.Name)
+		}
+		names[l.Name] = struct{}{}
+	}
+
+	// Second pass: validate imports reference known layers.
+	for _, l := range def.Layers {
+		for _, imp := range l.Imports {
+			if _, ok := names[imp]; !ok {
+				return nil, fmt.Errorf("layers: layer %q imports unknown layer %q", l.Name, imp)
+			}
+		}
+	}
+
+	return &def, nil
+}
+
+// ParseFile opens the file at path and calls Parse.
+func ParseFile(path string) (*Definition, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("layers: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	return Parse(f)
+}

--- a/internal/harness/layers/layers_test.go
+++ b/internal/harness/layers/layers_test.go
@@ -1,0 +1,154 @@
+package layers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParse_ValidJSON(t *testing.T) {
+	input := `{
+		"layers": [
+			{"name": "types",        "dir": "internal/types/",        "imports": []},
+			{"name": "config",       "dir": "internal/config/",       "imports": ["types"]},
+			{"name": "deps",         "dir": "internal/deps/",         "imports": ["types", "config"]},
+			{"name": "github",       "dir": "internal/github/",       "imports": ["types"]},
+			{"name": "orchestrator", "dir": "internal/orchestrator/", "imports": ["types", "config", "deps", "github"]}
+		]
+	}`
+
+	def, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(def.Layers) != 5 {
+		t.Fatalf("want 5 layers, got %d", len(def.Layers))
+	}
+	if def.Layers[0].Name != "types" {
+		t.Errorf("want first layer name %q, got %q", "types", def.Layers[0].Name)
+	}
+	if def.Layers[1].Dir != "internal/config/" {
+		t.Errorf("want second layer dir %q, got %q", "internal/config/", def.Layers[1].Dir)
+	}
+	if len(def.Layers[4].Imports) != 4 {
+		t.Errorf("want 4 imports for orchestrator, got %d", len(def.Layers[4].Imports))
+	}
+}
+
+func TestParse_EmptyLayers(t *testing.T) {
+	input := `{"layers": []}`
+	_, err := Parse(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("want error for empty layers, got nil")
+	}
+}
+
+func TestParse_DuplicateNames(t *testing.T) {
+	input := `{
+		"layers": [
+			{"name": "config", "dir": "internal/config/", "imports": []},
+			{"name": "config", "dir": "internal/config2/", "imports": []}
+		]
+	}`
+	_, err := Parse(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("want error for duplicate layer names, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("want error mentioning duplicate, got: %v", err)
+	}
+}
+
+func TestParse_BadImportReference(t *testing.T) {
+	input := `{
+		"layers": [
+			{"name": "config", "dir": "internal/config/", "imports": ["nonexistent"]}
+		]
+	}`
+	_, err := Parse(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("want error for bad import reference, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("want error mentioning nonexistent, got: %v", err)
+	}
+}
+
+func TestParse_EmptyName(t *testing.T) {
+	input := `{
+		"layers": [
+			{"name": "", "dir": "internal/types/", "imports": []}
+		]
+	}`
+	_, err := Parse(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("want error for empty layer name, got nil")
+	}
+}
+
+func TestParse_EmptyDir(t *testing.T) {
+	input := `{
+		"layers": [
+			{"name": "types", "dir": "", "imports": []}
+		]
+	}`
+	_, err := Parse(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("want error for empty layer dir, got nil")
+	}
+}
+
+func TestParse_InvalidJSON(t *testing.T) {
+	input := `{not valid json`
+	_, err := Parse(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("want error for invalid JSON, got nil")
+	}
+}
+
+func TestParse_NoImportsField(t *testing.T) {
+	input := `{
+		"layers": [
+			{"name": "types", "dir": "internal/types/"}
+		]
+	}`
+	def, err := Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if def.Layers[0].Imports == nil {
+		// nil slice is acceptable for missing field
+		return
+	}
+	if len(def.Layers[0].Imports) != 0 {
+		t.Errorf("want empty imports, got %v", def.Layers[0].Imports)
+	}
+}
+
+func TestParseFile_Valid(t *testing.T) {
+	content := `{
+		"layers": [
+			{"name": "types", "dir": "internal/types/", "imports": []}
+		]
+	}`
+	tmp := filepath.Join(t.TempDir(), "architecture.json")
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	def, err := ParseFile(tmp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(def.Layers) != 1 {
+		t.Fatalf("want 1 layer, got %d", len(def.Layers))
+	}
+}
+
+func TestParseFile_NotFound(t *testing.T) {
+	_, err := ParseFile("/nonexistent/path/architecture.json")
+	if err == nil {
+		t.Fatal("want error for missing file, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds new `internal/harness/layers/` package with `Layer` and `Definition` types
- Implements `Parse(io.Reader)` and `ParseFile(path)` with full validation
- Validates: non-empty/unique layer names, non-empty dirs, imports reference existing layers
- 10 unit tests covering all acceptance criteria cases from the issue

## Test plan
- [x] `Parse` decodes valid 5-layer JSON correctly
- [x] `{"layers": []}` returns an error
- [x] Duplicate layer names return an error
- [x] Import referencing non-existent layer returns an error
- [x] Empty layer name returns an error
- [x] Empty layer dir returns an error
- [x] Invalid JSON returns a parse error
- [x] Layer without `"imports"` key parses with empty imports
- [x] `ParseFile` reads from disk and parses correctly
- [x] `ParseFile` returns error for missing file
- [x] All existing tests still pass (`go test ./...`)
- [x] `go vet ./...` clean

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)