### PR TITLE
feat: add agent dialogue and architecture reference prompt templates

### DIFF
--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -37,6 +37,8 @@ type PromptData struct {
 	ReviewDir      string
 	BranchExists        bool
 	StrictnessDirective string
+	ArchitectureDoc     string
+	ConventionsDoc      string
 }
 
 // loadPromptFile reads a prompt from the config path if set, otherwise from

--- a/internal/harness/templates/prompts/implementer.txt
+++ b/internal/harness/templates/prompts/implementer.txt
@@ -8,10 +8,13 @@ Issue body:
 Before writing any code:
 1. Read the full issue body carefully, including any ## Test cases section
 {{- if .ArchitectureDoc}}
-2. Read the architecture document at {{.ArchitectureDoc}} to understand layer boundaries and dependency rules
+2. Read `{{.ArchitectureDoc}}` for dependency layer rules
 {{- end}}
-3. Identify every file you expect to create or modify
-4. Post a brief implementation plan as a comment on the issue
+{{- if .ConventionsDoc}}
+3. Read `{{.ConventionsDoc}}` for coding conventions
+{{- end}}
+4. Identify every file you expect to create or modify
+5. Post a brief implementation plan as a comment on the issue
 
 CRITICAL RULES:
 {{- if .BranchExists}}

--- a/internal/harness/templates/prompts/reviewer.txt
+++ b/internal/harness/templates/prompts/reviewer.txt
@@ -10,8 +10,9 @@ Steps:
 3. Read the issue body for acceptance criteria
 4. Read the implementer's ## Implementation Notes PR comment for context on their approach
 5. Review the code changes: gh pr diff {{.PRNumber}} --repo {{.Repo}}
-6. Check architecture compliance: compare changed files against layer definitions in {{.ArchitectureDoc}}
-   and verify that no layer boundary violations were introduced
+{{- if .ArchitectureDoc}}
+6. Check that imports respect the dependency layers in `{{.ArchitectureDoc}}` and verify that no layer boundary violations were introduced
+{{- end}}
 {{- if .TestCommand}}
 7. Run unit tests: {{.TestCommand}}
 {{- end}}

--- a/internal/harness/templates/templates_test.go
+++ b/internal/harness/templates/templates_test.go
@@ -126,6 +126,28 @@ func TestImplementerPromptHasArchitectureReference(t *testing.T) {
 	}
 }
 
+func TestImplementerPromptHasConventionsReference(t *testing.T) {
+	data, err := templates.FS.ReadFile("prompts/implementer.txt")
+	if err != nil {
+		t.Fatalf("reading implementer prompt: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "{{.ConventionsDoc}}") {
+		t.Error("implementer prompt does not reference conventions doc via {{.ConventionsDoc}} template variable")
+	}
+}
+
+func TestImplementerPromptHasArchitectureConditional(t *testing.T) {
+	data, err := templates.FS.ReadFile("prompts/implementer.txt")
+	if err != nil {
+		t.Fatalf("reading implementer prompt: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "{{if .ArchitectureDoc}}") && !strings.Contains(content, "{{- if .ArchitectureDoc}}") {
+		t.Error("implementer prompt does not guard {{.ArchitectureDoc}} with a conditional")
+	}
+}
+
 func TestRetryPromptReferencesImplementationNotes(t *testing.T) {
 	data, err := templates.FS.ReadFile("prompts/implementer_retry.txt")
 	if err != nil {

--- a/prompts/implementer.txt
+++ b/prompts/implementer.txt
@@ -7,8 +7,14 @@ Issue body:
 
 Before writing any code:
 1. Read the full issue body carefully, including any ## Test cases section
-2. Identify every file you expect to create or modify
-3. Post a brief implementation plan as a comment on the issue
+{{- if .ArchitectureDoc}}
+2. Read `{{.ArchitectureDoc}}` for dependency layer rules
+{{- end}}
+{{- if .ConventionsDoc}}
+3. Read `{{.ConventionsDoc}}` for coding conventions
+{{- end}}
+4. Identify every file you expect to create or modify
+5. Post a brief implementation plan as a comment on the issue
 
 CRITICAL RULES:
 {{- if .BranchExists}}
@@ -21,7 +27,7 @@ CRITICAL RULES:
 - Do NOT modify files in {{.ScenarioDir}} or {{.ReviewDir}}
 
 Implementation steps:
-1. Write the implementation code
+1. Write the implementation code{{if .ArchitectureDoc}}, respecting layer boundaries from {{.ArchitectureDoc}}{{end}}
 2. Write unit tests alongside the implementation
 {{- if .BuildCommand}}
 3. Run build: {{.BuildCommand}}
@@ -31,3 +37,20 @@ Implementation steps:
 {{- end}}
 5. Commit with message including "Closes #{{.IssueNumber}}"
 6. Push the branch and open a pull request
+
+When opening the pull request, post a PR comment with the following format so
+the reviewer agent can find your notes:
+
+## Implementation Notes
+
+### Approach
+Describe what approach you took and why.
+
+### Key Decisions
+List any non-obvious decisions or trade-offs made during implementation.
+
+### Known Limitations
+Note anything incomplete, deferred, or that the reviewer should be aware of.
+
+### Architecture
+Describe which layers were touched and how dependencies were respected{{if .ArchitectureDoc}} (see {{.ArchitectureDoc}}){{end}}.

--- a/prompts/implementer_retry.txt
+++ b/prompts/implementer_retry.txt
@@ -6,9 +6,15 @@ Issue body:
 
 Steps:
 1. Check out the PR branch: gh pr checkout {{.PRNumber}} --repo {{.Repo}}
-2. Read review comments: gh pr view {{.PRNumber}} --repo {{.Repo}} --comments
-3. Read the issue body for original requirements
-4. Fix the issues described in the review comments
+2. Read all PR comments to find the reviewer's feedback:
+   gh pr view {{.PRNumber}} --repo {{.Repo}} --comments
+3. Locate the reviewer's ## Review Notes section — it contains the specific
+   challenges and required changes you must address
+4. Also read your prior ## Implementation Notes comment to understand what
+   you already tried and why
+5. Read the issue body for original requirements
+6. Fix the issues described in the review comments, addressing each reviewer
+   challenge explicitly
 
 CRITICAL RULES:
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
@@ -21,5 +27,7 @@ After fixing:
 {{- if .BuildCommand}}
 2. Run build: {{.BuildCommand}}
 {{- end}}
-3. Commit your fixes
+3. Commit your fixes with a message referencing the PR (e.g. "Address review feedback on PR #{{.PRNumber}}")
 4. Push to the PR branch
+5. Post a new PR comment explaining what you changed and how you addressed
+   each reviewer challenge, using the ## Implementation Notes format

--- a/prompts/reviewer.txt
+++ b/prompts/reviewer.txt
@@ -8,15 +8,19 @@ Steps:
 1. Check out the PR: gh pr checkout {{.PRNumber}} --repo {{.Repo}}
 2. Read scenario spec files in {{.ScenarioDir}} that relate to issue #{{.IssueNumber}}
 3. Read the issue body for acceptance criteria
-4. Review the code changes: gh pr diff {{.PRNumber}} --repo {{.Repo}}
+4. Read the implementer's ## Implementation Notes PR comment for context on their approach
+5. Review the code changes: gh pr diff {{.PRNumber}} --repo {{.Repo}}
+{{- if .ArchitectureDoc}}
+6. Check that imports respect the dependency layers in `{{.ArchitectureDoc}}` and verify that no layer boundary violations were introduced
+{{- end}}
 {{- if .TestCommand}}
-5. Run unit tests: {{.TestCommand}}
+7. Run unit tests: {{.TestCommand}}
 {{- end}}
 {{- if .BuildCommand}}
-6. Verify build: {{.BuildCommand}}
+8. Verify build: {{.BuildCommand}}
 {{- end}}
-7. Generate integration tests in {{.ReviewDir}} that validate the behaviors described in the scenario spec
-8. Run your integration tests (use the appropriate test runner for the project language, or fall back to {{.TestCommand}})
+9. Generate integration tests in {{.ReviewDir}} that validate the behaviors described in the scenario spec
+10. Run your integration tests (use the appropriate test runner for the project language, or fall back to {{.TestCommand}})
 
 CRITICAL RULES:
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
@@ -27,6 +31,22 @@ Based on your findings:
   Delete the {{.ReviewDir}} directory, approve the PR, and print REVIEW_RESULT=APPROVED
 - If ANY tests fail or acceptance criteria are not met:
   Delete the {{.ReviewDir}} directory, request changes on the PR with specific feedback, and print REVIEW_RESULT=CHANGES_REQUESTED
+
+When requesting changes, post a PR comment with the following format so the
+implementer agent can find your challenges:
+
+## Review Notes
+
+### Approved / Changes Requested
+State whether the PR is approved or changes are requested, with a brief summary.
+
+### Architecture Compliance
+Describe any architecture compliance violations found{{if .ArchitectureDoc}} (checked against {{.ArchitectureDoc}}){{end}},
+or confirm that no violations were found.
+
+List each specific issue that must be fixed. For each issue: describe what is
+wrong, what the correct behavior should be, and which acceptance criterion or
+scenario it violates.
 
 CRITICAL: You MUST print exactly one of these lines:
   REVIEW_RESULT=APPROVED


### PR DESCRIPTION
## Summary

- Add `{{.ConventionsDoc}}` conditional step to embedded `implementer.txt` ("Read `{{.ConventionsDoc}}` for coding conventions")
- Add `{{if .ArchitectureDoc}}` conditional guard to the architecture compliance step in embedded `reviewer.txt`
- Add `ArchitectureDoc` and `ConventionsDoc` fields to `PromptData` struct so templates can render without error
- Sync dark-factory's own `prompts/implementer.txt` with embedded template (adds ArchitectureDoc/ConventionsDoc steps, Implementation Notes PR comment format)
- Sync `prompts/implementer_retry.txt` (adds Review Notes reading and Implementation Notes posting steps)
- Sync `prompts/reviewer.txt` (adds Implementation Notes reading step, conditional architecture check, Review Notes format)
- Add `TestImplementerPromptHasConventionsReference` and `TestImplementerPromptHasArchitectureConditional` tests

## Test plan

- [ ] `go test ./...` passes (all existing + new tests green)
- [ ] `go vet ./...` passes
- [ ] `internal/harness/templates/prompts/implementer.txt` contains `{{.ConventionsDoc}}` with `{{if .ConventionsDoc}}` guard
- [ ] `internal/harness/templates/prompts/reviewer.txt` contains `{{if .ArchitectureDoc}}` guard on architecture step
- [ ] `prompts/implementer.txt` matches embedded template content (ArchitectureDoc, ConventionsDoc, Implementation Notes)
- [ ] `prompts/implementer_retry.txt` includes Review Notes reading and Implementation Notes posting
- [ ] `prompts/reviewer.txt` includes Implementation Notes reading and Review Notes format

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)