### PR TITLE
feat: add godark new command for greenfield project scaffolding

### DIFF
--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -86,7 +86,11 @@ func runNew(cmd *cobra.Command, projectName, repo string) error {
 	if err := os.Chdir(absProjectDir); err != nil {
 		return fmt.Errorf("changing to project directory: %w", err)
 	}
-	defer os.Chdir(origDir) //nolint:errcheck
+	defer func() {
+		if err := os.Chdir(origDir); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not restore working directory: %v\n", err)
+		}
+	}()
 
 	// Write skill files (reuses the shared helper from init.go).
 	if err := writeSkillFiles(cmd); err != nil {
@@ -117,7 +121,8 @@ func runNew(cmd *cobra.Command, projectName, repo string) error {
 func writeNewProjectConfig(cmd *cobra.Command, repo string) error {
 	config := defaultConfig
 	if repo != "" {
-		config = strings.Replace(config, `repo: ""`, fmt.Sprintf("repo: %s", repo), 1)
+		safe := strings.ReplaceAll(repo, `"`, `\"`)
+		config = strings.Replace(config, `repo: ""`, fmt.Sprintf(`repo: "%s"`, safe), 1)
 	}
 	if err := os.WriteFile("godark.yaml", []byte(config), 0o644); err != nil {
 		return fmt.Errorf("writing godark.yaml: %w", err)

--- a/internal/cmd/new_test.go
+++ b/internal/cmd/new_test.go
@@ -165,8 +165,8 @@ func TestNewRepoFlag(t *testing.T) {
 		t.Fatalf("reading testproject/godark.yaml: %v", err)
 	}
 
-	if !strings.Contains(string(data), "repo: owner/repo") {
-		t.Errorf("godark.yaml missing repo: owner/repo; got:\n%s", data)
+	if !strings.Contains(string(data), `repo: "owner/repo"`) {
+		t.Errorf(`godark.yaml missing repo: "owner/repo"; got:\n%s`, data)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `godark new <project-name>` command that creates a new directory with all harness files for a greenfield project
- Writes `CLAUDE.md` and `.gitignore` from embedded templates (files `init` does not create)
- Runs `git init` via a replaceable `gitRunner` variable (testable without requiring git)
- Calls shared `writeSkillFiles` from `init.go`, then scaffolds godark.yaml and all harness docs in the new directory
- `--repo` flag pre-populates `repo:` in godark.yaml by substituting into the `defaultConfig` template
- Prints a summary of all created files and next-steps guidance

## Test plan

- [ ] `TestNewCommandRegistered` — `new` subcommand appears in `rootCmd`
- [ ] `TestNewCreatesAllFiles` — all expected files and directories exist after `new testproject`
- [ ] `TestNewClaudeMDHeaders` — CLAUDE.md contains all required section headers (Project, Build and Test, Architecture, Principles, Protected Paths, Git Workflow, Definition of Done)
- [ ] `TestNewGitInitialized` — `.git/` directory exists (git runner stubbed via `gitRunner` variable)
- [ ] `TestNewRepoFlag` — `godark.yaml` contains `repo: owner/repo` when `--repo owner/repo` is passed
- [ ] `TestNewExistingDirError` — returns error mentioning "already exists" when directory pre-exists
- [ ] `TestNewNoArgError` — arg validator returns error for zero arguments

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)