### PR TITLE
feat: add godark vet architecture subcommand

### DIFF
--- a/internal/cmd/vet_architecture.go
+++ b/internal/cmd/vet_architecture.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/phs/dark-factory/internal/harness/layers"
+	"github.com/phs/dark-factory/internal/vet"
+	"github.com/spf13/cobra"
+)
+
+var vetArchitectureCmd = &cobra.Command{
+	Use:   "architecture",
+	Short: "Validate architecture layer definitions for DAG correctness",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		archFile, _ := cmd.Flags().GetString("architecture-file")
+		asJSON, _ := cmd.Flags().GetBool("json")
+
+		def, err := layers.ParseFile(archFile)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				fmt.Fprintf(cmd.OutOrStdout(), "info: architecture file %q not found — skipping (harnesses are opt-in)\n", archFile)
+				return nil
+			}
+			return fmt.Errorf("parsing architecture file: %w", err)
+		}
+
+		report := vet.ValidateArchitecture(def)
+		printReport(cmd, report, asJSON)
+		return nil
+	},
+}
+
+func init() {
+	f := vetArchitectureCmd.Flags()
+	f.String("architecture-file", "docs/architecture.json", "Path to architecture JSON file")
+	f.Bool("json", false, "Output findings as JSON")
+	vetCmd.AddCommand(vetArchitectureCmd)
+}

--- a/internal/cmd/vet_test.go
+++ b/internal/cmd/vet_test.go
@@ -7,7 +7,7 @@ func TestVetCommandHasSubcommands(t *testing.T) {
 	for _, sub := range vetCmd.Commands() {
 		names[sub.Name()] = true
 	}
-	for _, want := range []string{"issues", "scenarios", "roadmap"} {
+	for _, want := range []string{"issues", "scenarios", "roadmap", "architecture"} {
 		if !names[want] {
 			t.Errorf("vet missing subcommand %q", want)
 		}
@@ -34,6 +34,14 @@ func TestVetRoadmapFlags(t *testing.T) {
 	for _, name := range []string{"repo", "milestone", "json", "planning-dir"} {
 		if vetRoadmapCmd.Flags().Lookup(name) == nil {
 			t.Errorf("vet roadmap missing flag --%s", name)
+		}
+	}
+}
+
+func TestVetArchitectureFlags(t *testing.T) {
+	for _, name := range []string{"architecture-file", "json"} {
+		if vetArchitectureCmd.Flags().Lookup(name) == nil {
+			t.Errorf("vet architecture missing flag --%s", name)
 		}
 	}
 }

--- a/internal/vet/architecture.go
+++ b/internal/vet/architecture.go
@@ -1,0 +1,83 @@
+package vet
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/phs/dark-factory/internal/harness/layers"
+)
+
+// ValidateArchitecture checks a layer Definition for structural correctness.
+// It detects cycles in the dependency graph and reports all affected layers.
+func ValidateArchitecture(def *layers.Definition) *Report {
+	r := &Report{}
+	detectCycles(def, r)
+	return r
+}
+
+// detectCycles uses recursive DFS with gray/black coloring to find all cycles
+// in the layer dependency graph. Each unique cycle is reported once as an
+// Error finding. The cycle display includes the full path and the closing edge
+// (e.g. "A → B → A").
+func detectCycles(def *layers.Definition, r *Report) {
+	adj := make(map[string][]string, len(def.Layers))
+	for _, l := range def.Layers {
+		adj[l.Name] = l.Imports
+	}
+
+	// 0 = unvisited (white), 1 = in-progress (gray), 2 = done (black)
+	color := make(map[string]int, len(def.Layers))
+	reported := make(map[string]bool)
+
+	var dfs func(node string, path []string)
+	dfs = func(node string, path []string) {
+		color[node] = 1
+		path = append(path, node)
+
+		for _, dep := range adj[node] {
+			switch color[dep] {
+			case 1:
+				// Back edge: dep is already in the current DFS path — cycle found.
+				cycleStart := -1
+				for i, p := range path {
+					if p == dep {
+						cycleStart = i
+						break
+					}
+				}
+				cycle := path[cycleStart:]
+				key := canonicalCycleKey(cycle)
+				if !reported[key] {
+					reported[key] = true
+					cycleStr := strings.Join(cycle, " → ") + " → " + dep
+					r.Add(Finding{
+						Severity: Error,
+						Location: "architecture",
+						Message:  fmt.Sprintf("cycle detected: %s", cycleStr),
+					})
+				}
+			case 0:
+				dfs(dep, path)
+			}
+		}
+
+		color[node] = 2
+	}
+
+	// Visit all nodes in definition order for deterministic output.
+	for _, l := range def.Layers {
+		if color[l.Name] == 0 {
+			dfs(l.Name, nil)
+		}
+	}
+}
+
+// canonicalCycleKey returns a sorted, comma-joined key used to deduplicate
+// equivalent cycles found via different DFS starting points.
+func canonicalCycleKey(cycle []string) string {
+	sorted := make([]string, len(cycle))
+	copy(sorted, cycle)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ",")
+}

--- a/internal/vet/architecture_test.go
+++ b/internal/vet/architecture_test.go
@@ -1,0 +1,150 @@
+package vet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/harness/layers"
+)
+
+// parseDef is a test helper that parses a JSON layer definition, failing on error.
+func parseDef(t *testing.T, json string) *layers.Definition {
+	t.Helper()
+	def, err := layers.Parse(strings.NewReader(json))
+	if err != nil {
+		t.Fatalf("parse layers: %v", err)
+	}
+	return def
+}
+
+func TestValidateArchitecture_NoCycles(t *testing.T) {
+	def := parseDef(t, `{
+		"layers": [
+			{"name": "A", "dir": "a/", "imports": []},
+			{"name": "B", "dir": "b/", "imports": ["A"]}
+		]
+	}`)
+	report := ValidateArchitecture(def)
+	if got := report.ExitCode(); got != 0 {
+		t.Errorf("expected exit code 0 for valid DAG, got %d; findings: %v", got, report.Findings())
+	}
+}
+
+func TestValidateArchitecture_SimpleCycle(t *testing.T) {
+	// A→B→A
+	def := parseDef(t, `{
+		"layers": [
+			{"name": "A", "dir": "a/", "imports": ["B"]},
+			{"name": "B", "dir": "b/", "imports": ["A"]}
+		]
+	}`)
+	report := ValidateArchitecture(def)
+	if report.ExitCode() == 0 {
+		t.Fatal("expected non-zero exit code for cycle A→B→A")
+	}
+	findings := report.Findings()
+	if len(findings) == 0 {
+		t.Fatal("expected at least one finding")
+	}
+	combined := findings[0].Message + " " + findings[0].Location
+	if !strings.Contains(combined, "A") || !strings.Contains(combined, "B") {
+		t.Errorf("expected finding to name both A and B, got: %q", combined)
+	}
+}
+
+func TestValidateArchitecture_TransitiveCycle(t *testing.T) {
+	// A→B→C→A
+	def := parseDef(t, `{
+		"layers": [
+			{"name": "A", "dir": "a/", "imports": ["B"]},
+			{"name": "B", "dir": "b/", "imports": ["C"]},
+			{"name": "C", "dir": "c/", "imports": ["A"]}
+		]
+	}`)
+	report := ValidateArchitecture(def)
+	if report.ExitCode() == 0 {
+		t.Fatal("expected non-zero exit code for cycle A→B→C→A")
+	}
+	findings := report.Findings()
+	if len(findings) == 0 {
+		t.Fatal("expected at least one finding")
+	}
+	combined := findings[0].Message + " " + findings[0].Location
+	for _, layer := range []string{"A", "B", "C"} {
+		if !strings.Contains(combined, layer) {
+			t.Errorf("expected finding to name layer %q, got: %q", layer, combined)
+		}
+	}
+}
+
+func TestValidateArchitecture_SelfImport(t *testing.T) {
+	// A imports A
+	def := parseDef(t, `{
+		"layers": [
+			{"name": "A", "dir": "a/", "imports": ["A"]}
+		]
+	}`)
+	report := ValidateArchitecture(def)
+	if report.ExitCode() == 0 {
+		t.Fatal("expected non-zero exit code for self-import A→A")
+	}
+	findings := report.Findings()
+	if len(findings) == 0 {
+		t.Fatal("expected at least one finding")
+	}
+	if !strings.Contains(findings[0].Message, "A") {
+		t.Errorf("expected finding to name layer A, got: %q", findings[0].Message)
+	}
+}
+
+func TestValidateArchitecture_CleanArchitecture(t *testing.T) {
+	// Well-structured 5-layer DAG — no cycles.
+	def := parseDef(t, `{
+		"layers": [
+			{"name": "types",        "dir": "internal/types/",        "imports": []},
+			{"name": "config",       "dir": "internal/config/",       "imports": ["types"]},
+			{"name": "deps",         "dir": "internal/deps/",         "imports": ["types", "config"]},
+			{"name": "github",       "dir": "internal/github/",       "imports": ["types"]},
+			{"name": "orchestrator", "dir": "internal/orchestrator/", "imports": ["types", "config", "deps", "github"]}
+		]
+	}`)
+	report := ValidateArchitecture(def)
+	if got := report.ExitCode(); got != 0 {
+		t.Errorf("expected exit code 0 for clean architecture, got %d; findings: %v", got, report.Findings())
+	}
+}
+
+func TestValidateArchitecture_NoDuplicateCycleReports(t *testing.T) {
+	// A→B→A: should produce exactly one finding, not two.
+	def := parseDef(t, `{
+		"layers": [
+			{"name": "A", "dir": "a/", "imports": ["B"]},
+			{"name": "B", "dir": "b/", "imports": ["A"]}
+		]
+	}`)
+	report := ValidateArchitecture(def)
+	findings := report.Findings()
+	if len(findings) != 1 {
+		t.Errorf("expected exactly 1 finding for A→B→A, got %d: %v", len(findings), findings)
+	}
+}
+
+func TestValidateArchitecture_DisconnectedCycles(t *testing.T) {
+	// Two independent cycles: A→B→A and C→D→C.
+	def := parseDef(t, `{
+		"layers": [
+			{"name": "A", "dir": "a/", "imports": ["B"]},
+			{"name": "B", "dir": "b/", "imports": ["A"]},
+			{"name": "C", "dir": "c/", "imports": ["D"]},
+			{"name": "D", "dir": "d/", "imports": ["C"]}
+		]
+	}`)
+	report := ValidateArchitecture(def)
+	if report.ExitCode() == 0 {
+		t.Fatal("expected non-zero exit code for two independent cycles")
+	}
+	findings := report.Findings()
+	if len(findings) != 2 {
+		t.Errorf("expected 2 findings for two independent cycles, got %d: %v", len(findings), findings)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `godark vet architecture` subcommand that validates `docs/architecture.json` (or a custom path via `--architecture-file`) for DAG correctness
- `internal/vet/architecture.go`: `ValidateArchitecture` uses DFS with gray/black coloring to detect all cycles, reporting each as an Error with the full cycle path (e.g. `A → B → C → A`)
- `internal/cmd/vet_architecture.go`: subcommand of `vetCmd`; exits 0 with an info message when the architecture file is absent (harnesses are opt-in); `--json` flag supported via existing `printReport` helper

## Test plan

- [x] No cycles → exit 0, no findings
- [x] Simple cycle A→B→A → Error naming both layers
- [x] Transitive cycle A→B→C→A → Error naming all three layers
- [x] Self-import A→A → Error naming layer A
- [x] Clean 5-layer architecture → exit 0
- [x] Duplicate cycle suppression (A→B→A reported once, not twice)
- [x] Two independent cycles → two separate findings
- [x] `--architecture-file` and `--json` flags registered
- [x] `godark vet architecture` appears in `vetCmd.Commands()`
- [x] All 23 packages pass `go test ./...` and `go vet ./...`

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)