### PR TITLE
fix: make reviewer test-writing mandatory and conditional on scenario spec

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -82,16 +82,17 @@ func BranchName(issueNumber int, slug string) string {
 
 func newPromptData(issue github.Issue, cfg *config.Config, slug string) PromptData {
 	return PromptData{
-		IssueNumber:    issue.Number,
-		IssueTitle:     issue.Title,
-		IssueBody:      issue.Body,
-		Slug:           slug,
-		Repo:           cfg.Repo,
-		BuildCommand:   cfg.BuildCommand,
-		TestCommand:    cfg.TestCommand,
-		ProtectedPaths: strings.Join(cfg.ProtectedPaths, ", "),
-		ScenarioDir:    cfg.ScenarioDir,
-		ReviewDir:      cfg.ReviewDir,
+		IssueNumber:     issue.Number,
+		IssueTitle:      issue.Title,
+		IssueBody:       issue.Body,
+		Slug:            slug,
+		Repo:            cfg.Repo,
+		BuildCommand:    cfg.BuildCommand,
+		TestCommand:     cfg.TestCommand,
+		ProtectedPaths:  strings.Join(cfg.ProtectedPaths, ", "),
+		ScenarioDir:     cfg.ScenarioDir,
+		ReviewDir:       cfg.ReviewDir,
+		HasScenarioSpec: HasScenarioSpec(cfg.ScenarioDir, issue.Number),
 	}
 }
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -115,6 +115,10 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 
 	_ = WarnMissingScenario(cfg.Repo, prNum, issue.Number, cfg.ScenarioDir, logger)
 
+	// Determine whether a scenario spec exists for this issue. Used by the
+	// functional reviewer's quality check: tests are only expected when a spec exists.
+	hasSpec := HasScenarioSpec(cfg.ScenarioDir, issue.Number)
+
 	// Step 4: Quality review gate (if prompt is configured).
 	if prompts.QualityReviewer != "" {
 		qualityMaxAttempts := cfg.MaxRetries + 1
@@ -133,7 +137,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				return outcome
 			}
 			// Quality reviewer is exempt from CheckReviewTestExecution.
-			qFlags := computeReviewFlags(qResult.AgentResult, cfg, false)
+			qFlags := computeReviewFlags(qResult.AgentResult, cfg, false, false)
 			qRDFlags := logAndRecordFlags(qFlags, logger, issue.Number)
 			if hook != nil {
 				qStep := ResultToStep(qResult.AgentResult)
@@ -230,7 +234,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			return outcome
 		}
 		// Functional reviewer is subject to all quality checks including CheckReviewTestExecution.
-		fFlags := computeReviewFlags(reviewResult.AgentResult, cfg, true)
+		fFlags := computeReviewFlags(reviewResult.AgentResult, cfg, true, hasSpec)
 		fRDFlags := logAndRecordFlags(fFlags, logger, issue.Number)
 		if hook != nil {
 			fStep := ResultToStep(reviewResult.AgentResult)
@@ -349,7 +353,7 @@ func trimOutput(b []byte) string {
 // computeReviewFlags runs quality analysis on an agent Result and returns any flags found.
 // If checkTestExecution is false, CheckReviewTestExecution is skipped (used for the
 // quality reviewer, which is exempt from that check).
-func computeReviewFlags(result *Result, cfg *config.Config, checkTestExecution bool) []quality.Flag {
+func computeReviewFlags(result *Result, cfg *config.Config, checkTestExecution bool, hasScenarioSpec bool) []quality.Flag {
 	var flags []quality.Flag
 
 	if f := quality.CheckCostFloor(result.CostUSD, cfg.Quality.MinReviewCostUSD); f != nil {
@@ -365,7 +369,7 @@ func computeReviewFlags(result *Result, cfg *config.Config, checkTestExecution b
 	flags = append(flags, quality.CheckToolTrace(result.ToolTrace, cfg.TestCommand)...)
 
 	if checkTestExecution {
-		flags = append(flags, quality.CheckReviewTestExecution(result.ToolTrace, cfg.ReviewDir, cfg.TestCommand)...)
+		flags = append(flags, quality.CheckReviewTestExecution(result.ToolTrace, cfg.ReviewDir, cfg.TestCommand, hasScenarioSpec)...)
 	}
 
 	return flags

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -988,7 +990,7 @@ func TestComputeReviewFlags_QualityReviewerExemptFromTestExecution(t *testing.T)
 	}
 
 	// Quality reviewer (checkTestExecution=false): should NOT produce test-execution flags.
-	qFlags := computeReviewFlags(result, cfg, false)
+	qFlags := computeReviewFlags(result, cfg, false, false)
 	for _, f := range qFlags {
 		if f.Code == "no_review_tests_written" || f.Code == "no_review_tests_run" {
 			t.Errorf("quality reviewer should be exempt from %q, got flag: %+v", f.Code, f)
@@ -996,7 +998,7 @@ func TestComputeReviewFlags_QualityReviewerExemptFromTestExecution(t *testing.T)
 	}
 
 	// Functional reviewer (checkTestExecution=true): SHOULD produce test-execution flags.
-	fFlags := computeReviewFlags(result, cfg, true)
+	fFlags := computeReviewFlags(result, cfg, true, true)
 	var hasTestFlag bool
 	for _, f := range fFlags {
 		if f.Code == "no_review_tests_written" || f.Code == "no_review_tests_run" {
@@ -1018,7 +1020,7 @@ func TestComputeReviewFlags_CostFloorFlag(t *testing.T) {
 		Quality: config.Quality{MinReviewCostUSD: 0.10},
 	}
 
-	flags := computeReviewFlags(result, cfg, false)
+	flags := computeReviewFlags(result, cfg, false, false)
 
 	var found bool
 	for _, f := range flags {
@@ -1042,7 +1044,7 @@ func TestComputeReviewFlags_DisabledWhenZeroThreshold(t *testing.T) {
 		Quality: config.Quality{MinReviewCostUSD: 0, MinReviewDurationSeconds: 0},
 	}
 
-	flags := computeReviewFlags(result, cfg, false)
+	flags := computeReviewFlags(result, cfg, false, false)
 	for _, f := range flags {
 		if f.Code == "low_cost" || f.Code == "short_duration" {
 			t.Errorf("cost/duration flags should be disabled when threshold is 0, got: %+v", f)
@@ -1115,9 +1117,17 @@ func TestProcessIssue_FlagsIncludedInHookStepResult(t *testing.T) {
 func TestProcessIssue_QualityReviewerExemptInLoop(t *testing.T) {
 	// Set a non-empty TestCommand and ReviewDir so CheckReviewTestExecution would
 	// produce flags — but only for the functional reviewer, not the quality reviewer.
+	// Create a scenario dir with a spec for issue #5 so hasScenarioSpec=true and
+	// test-execution flags are expected from the functional reviewer.
+	scenarioDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(scenarioDir, "spec.md"), []byte("Relates to: Issue #5\n"), 0600); err != nil {
+		t.Fatalf("failed to write scenario spec: %v", err)
+	}
+
 	cfg := loopConfig()
 	cfg.TestCommand = "go test ./..."
 	cfg.ReviewDir = "tests/review/"
+	cfg.ScenarioDir = scenarioDir
 
 	hook := newCaptureHook()
 

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -39,6 +39,7 @@ type PromptData struct {
 	StrictnessDirective string
 	ArchitectureDoc     string
 	ConventionsDoc      string
+	HasScenarioSpec     bool
 }
 
 // loadPromptFile reads a prompt from the config path if set, otherwise from

--- a/internal/quality/quality.go
+++ b/internal/quality/quality.go
@@ -79,9 +79,14 @@ func CheckToolTrace(toolTrace []string, testCommand string) []Flag {
 
 // CheckReviewTestExecution inspects the tool trace for evidence that review tests
 // were written to reviewDir and executed via testCommand.
-// Returns no_review_tests_written if no Write to reviewDir is found.
-// Returns no_review_tests_run if testCommand is not found in the trace.
-func CheckReviewTestExecution(toolTrace []string, reviewDir, testCommand string) []Flag {
+// Returns no_review_tests_written if no Write to reviewDir is found and hasScenarioSpec is true.
+// Returns no_review_tests_run if testCommand is not found in the trace and hasScenarioSpec is true.
+// When hasScenarioSpec is false, both checks are skipped (no scenario spec means no tests expected).
+func CheckReviewTestExecution(toolTrace []string, reviewDir, testCommand string, hasScenarioSpec bool) []Flag {
+	if !hasScenarioSpec {
+		return nil
+	}
+
 	var flags []Flag
 
 	testsWritten := reviewDir == ""

--- a/internal/quality/quality_test.go
+++ b/internal/quality/quality_test.go
@@ -182,52 +182,74 @@ func TestCheckReviewTestExecution(t *testing.T) {
 	testCmd := "go test ./tests/review/..."
 
 	tests := []struct {
-		name        string
-		trace       []string
-		reviewDir   string
-		testCommand string
-		wantCodes   []string
+		name            string
+		trace           []string
+		reviewDir       string
+		testCommand     string
+		hasScenarioSpec bool
+		wantCodes       []string
 	}{
 		{
-			name:        "tests written and run",
-			trace:       []string{"Write: tests/review/foo_test.go", "Bash: go test ./tests/review/..."},
-			reviewDir:   reviewDir,
-			testCommand: testCmd,
-			wantCodes:   nil,
+			name:            "tests written and run",
+			trace:           []string{"Write: tests/review/foo_test.go", "Bash: go test ./tests/review/..."},
+			reviewDir:       reviewDir,
+			testCommand:     testCmd,
+			hasScenarioSpec: true,
+			wantCodes:       nil,
 		},
 		{
-			name:        "neither written nor run",
-			trace:       []string{},
-			reviewDir:   reviewDir,
-			testCommand: testCmd,
-			wantCodes:   []string{"no_review_tests_written", "no_review_tests_run"},
+			name:            "neither written nor run",
+			trace:           []string{},
+			reviewDir:       reviewDir,
+			testCommand:     testCmd,
+			hasScenarioSpec: true,
+			wantCodes:       []string{"no_review_tests_written", "no_review_tests_run"},
 		},
 		{
-			name:        "written but not run",
-			trace:       []string{"Write: tests/review/foo_test.go"},
-			reviewDir:   reviewDir,
-			testCommand: testCmd,
-			wantCodes:   []string{"no_review_tests_run"},
+			name:            "written but not run",
+			trace:           []string{"Write: tests/review/foo_test.go"},
+			reviewDir:       reviewDir,
+			testCommand:     testCmd,
+			hasScenarioSpec: true,
+			wantCodes:       []string{"no_review_tests_run"},
 		},
 		{
-			name:        "run but not written",
-			trace:       []string{"Bash: go test ./tests/review/..."},
-			reviewDir:   reviewDir,
-			testCommand: testCmd,
-			wantCodes:   []string{"no_review_tests_written"},
+			name:            "run but not written",
+			trace:           []string{"Bash: go test ./tests/review/..."},
+			reviewDir:       reviewDir,
+			testCommand:     testCmd,
+			hasScenarioSpec: true,
+			wantCodes:       []string{"no_review_tests_written"},
 		},
 		{
-			name:        "write to different dir not counted",
-			trace:       []string{"Write: src/foo.go", "Bash: go test ./tests/review/..."},
-			reviewDir:   reviewDir,
-			testCommand: testCmd,
-			wantCodes:   []string{"no_review_tests_written"},
+			name:            "write to different dir not counted",
+			trace:           []string{"Write: src/foo.go", "Bash: go test ./tests/review/..."},
+			reviewDir:       reviewDir,
+			testCommand:     testCmd,
+			hasScenarioSpec: true,
+			wantCodes:       []string{"no_review_tests_written"},
+		},
+		{
+			name:            "no scenario spec skips all checks",
+			trace:           []string{},
+			reviewDir:       reviewDir,
+			testCommand:     testCmd,
+			hasScenarioSpec: false,
+			wantCodes:       nil,
+		},
+		{
+			name:            "no scenario spec skips checks even when tests not written",
+			trace:           []string{"Read: main.go"},
+			reviewDir:       reviewDir,
+			testCommand:     testCmd,
+			hasScenarioSpec: false,
+			wantCodes:       nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CheckReviewTestExecution(tt.trace, tt.reviewDir, tt.testCommand)
+			got := CheckReviewTestExecution(tt.trace, tt.reviewDir, tt.testCommand, tt.hasScenarioSpec)
 			gotCodes := flagCodes(got)
 			if !codesEqual(gotCodes, tt.wantCodes) {
 				t.Errorf("got flags %v, want %v", gotCodes, tt.wantCodes)

--- a/prompts/reviewer.txt
+++ b/prompts/reviewer.txt
@@ -19,12 +19,20 @@ Steps:
 {{- if .BuildCommand}}
 8. Verify build: {{.BuildCommand}}
 {{- end}}
-9. Generate integration tests in {{.ReviewDir}} that validate the behaviors described in the scenario spec
-10. Run your integration tests (use the appropriate test runner for the project language, or fall back to {{.TestCommand}})
+{{- if .HasScenarioSpec}}
+9. MANDATORY: Generate integration tests in {{.ReviewDir}} that validate each behavior described in the scenario spec. You MUST write at least one test file to {{.ReviewDir}} before proceeding. Do not skip this step.
+10. MANDATORY: Run your integration tests (use the appropriate test runner for the project language, or fall back to {{.TestCommand}}). Do not skip this step.
+{{- else}}
+9. No scenario spec exists for this issue. Document why integration tests are not applicable in your review comment and proceed to the verdict.
+{{- end}}
 
 CRITICAL RULES:
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
 - Do NOT modify files in {{.ScenarioDir}}
+{{- if .HasScenarioSpec}}
+- You MUST write integration tests to {{.ReviewDir}} (step 9) before making your verdict. This is non-negotiable.
+- After running tests, delete the {{.ReviewDir}} directory before finishing.
+{{- end}}
 
 Based on your findings:
 - If ALL tests pass and the implementation meets acceptance criteria:


### PR DESCRIPTION
## Summary

- Strengthen `prompts/reviewer.txt` so steps 9-10 (test generation/execution) use MANDATORY language when a scenario spec exists, and add an explicit CRITICAL RULE requiring test writes before the verdict
- Add `HasScenarioSpec bool` to `PromptData` (populated via the existing `HasScenarioSpec()` helper in `newPromptData`) so the prompt template can branch on spec presence
- Update `CheckReviewTestExecution` to accept `hasScenarioSpec bool`; when `false`, both `no_review_tests_written` and `no_review_tests_run` are suppressed (intentional skip — no spec means no integration tests expected)
- Thread `hasScenarioSpec` through `computeReviewFlags` in the `ProcessIssue` loop

Closes #141

## Implementation Notes

### Approach
Two root causes drove the 100% flag rate. First, the reviewer prompt buried steps 9-10 after optional steps with no strong language — Claude treated the code review (step 5) as sufficient and skipped test generation. Second, the quality check `CheckReviewTestExecution` fired unconditionally even when no scenario spec existed (Phase 8 was mostly template files, so the agent's judgement to skip tests was actually correct, but the flag fired anyway).

The fix attacks both causes: stronger prompt language for the spec-exists case, and a conditional quality check that only fires when tests are actually expected.

### Key Decisions
- **Skip vs. different flag code**: The acceptance criteria says the flag should "reflect" intentional skips. I chose to suppress both flags entirely when no spec exists, because the absence of the flag *is* the reflection — the flag firing implies "a spec existed but tests weren't written," which is the actionable case.
- **Prompt conditionality via `HasScenarioSpec`**: Adding `HasScenarioSpec` to `PromptData` lets the template emit different instructions based on whether the spec exists, rather than putting all that logic in the prompt text unconditionally.
- **`newPromptData` calls `HasScenarioSpec()`**: This centralises the lookup so all prompt types (implementer, reviewer, retry) automatically get the correct value without changes to individual agent runners.

### Known Limitations
- The prompt change only affects future runs; it does not retroactively fix Phase 8 data.
- `HasScenarioSpec` uses file I/O at prompt-render time. This is fast and matches the existing pattern used in `ProcessIssue`, but does add a filesystem call per agent invocation.

### Architecture
- **`prompts/`**: Prompt text (leaf layer, no Go dependencies).
- **`internal/agent/`**: `prompt.go` (PromptData struct), `implementer.go` (newPromptData), `loop.go` (ProcessIssue lifecycle and computeReviewFlags). These are the agent coordination layer.
- **`internal/quality/`**: Pure detection logic, no agent dependencies. `CheckReviewTestExecution` signature change is backward-compatible in spirit (caller passes the boolean).
- No new external dependencies introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)