### PR TITLE
docs: add internal/dialogue/ to domain layer in architecture definitions

### DIFF
--- a/docs/architecture.json
+++ b/docs/architecture.json
@@ -31,7 +31,7 @@
     {
       "name": "domain",
       "description": "Pure business logic, models, and rules. No external service dependencies.",
-      "paths": ["internal/detect/", "internal/doctor/", "internal/patterns/", "internal/punchlist/", "internal/quality/", "internal/rundata/"],
+      "paths": ["internal/detect/", "internal/dialogue/", "internal/doctor/", "internal/patterns/", "internal/punchlist/", "internal/quality/", "internal/rundata/"],
       "may_depend_on": ["foundation", "content"],
       "must_not_depend_on": ["cmd", "orchestration", "service", "infrastructure", "presentation"]
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,8 +72,9 @@ display but does not orchestrate workflows or call external services directly.
 
 ### domain
 
-**Paths:** `internal/detect/`, `internal/doctor/`, `internal/patterns/`,
-`internal/punchlist/`, `internal/quality/`, `internal/rundata/`
+**Paths:** `internal/detect/`, `internal/dialogue/`, `internal/doctor/`,
+`internal/patterns/`, `internal/punchlist/`, `internal/quality/`,
+`internal/rundata/`
 
 **Purpose:** Pure business logic, data models, and validation rules. These
 packages define the core concepts of the system without depending on external


### PR DESCRIPTION
## Summary

- Add `"internal/dialogue/"` to the domain layer's `paths` array in `docs/architecture.json`
- Add `internal/dialogue/` to the domain layer's **Paths** list in `docs/architecture.md`

Closes #146

## Implementation Notes

### Approach
Added `internal/dialogue/` to the domain layer in both the JSON and Markdown architecture definition files. The paths list in both files is kept in alphabetical order, so `internal/dialogue/` is inserted between `internal/detect/` and `internal/doctor/`.

### Key Decisions
- Placed `internal/dialogue/` in the **domain** layer because dialogue parsing is pure business logic with no external service dependencies — consistent with the domain layer's purpose.
- Kept paths in alphabetical order within the array for readability and consistency with existing entries.
- No code changes required — this is a pure documentation/metadata update.

### Known Limitations
None. The `internal/dialogue/` package does not exist yet; this change prepares the architecture definition for the package introduced in the next issue.

### Architecture
Only the `docs/` directory (architecture definition files) was touched. No Go source files were modified. No layer dependency rules were changed — only a new path was registered under the existing domain layer. No cycles are introduced.

## Test plan
- [ ] `docs/architecture.json` parses without errors (valid JSON)
- [ ] Domain layer `paths` array in `docs/architecture.json` contains `"internal/dialogue/"`
- [ ] Domain layer **Paths** in `docs/architecture.md` lists `internal/dialogue/`
- [ ] `godark vet architecture` produces no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)