### PR TITLE
feat: add internal/dialogue package for structured PR comment parsing

### DIFF
--- a/internal/dialogue/dialogue.go
+++ b/internal/dialogue/dialogue.go
@@ -1,0 +1,128 @@
+package dialogue
+
+import (
+	"bufio"
+	"strings"
+)
+
+// ImplementationNotes holds the structured content from an "## Implementation Notes"
+// PR comment posted by the implementer agent.
+type ImplementationNotes struct {
+	Approach         string
+	KeyDecisions     string
+	KnownLimitations string
+	Architecture     string
+	Raw              string // full comment text
+}
+
+// ReviewNotes holds the structured content from a "## Review Notes"
+// PR comment posted by the reviewer agent.
+type ReviewNotes struct {
+	Approved               string
+	ChangesRequested       string
+	ArchitectureCompliance string
+	Raw                    string // full comment text
+}
+
+// ParseImplementationNotes extracts Implementation Notes sections from a PR
+// comment body. Returns nil if the comment does not contain an
+// "## Implementation Notes" header.
+func ParseImplementationNotes(body string) *ImplementationNotes {
+	sections := parseSections(body, "## Implementation Notes")
+	if sections == nil {
+		return nil
+	}
+	return &ImplementationNotes{
+		Approach:         sections["### Approach"],
+		KeyDecisions:     sections["### Key Decisions"],
+		KnownLimitations: sections["### Known Limitations"],
+		Architecture:     sections["### Architecture"],
+		Raw:              body,
+	}
+}
+
+// ParseReviewNotes extracts Review Notes sections from a PR comment body.
+// Returns nil if the comment does not contain a "## Review Notes" header.
+func ParseReviewNotes(body string) *ReviewNotes {
+	sections := parseSections(body, "## Review Notes")
+	if sections == nil {
+		return nil
+	}
+	return &ReviewNotes{
+		Approved:               sections["### Approved"],
+		ChangesRequested:       sections["### Changes Requested"],
+		ArchitectureCompliance: sections["### Architecture Compliance"],
+		Raw:                    body,
+	}
+}
+
+// ParseComments scans a slice of comment bodies and returns all implementation
+// notes and review notes found, in order.
+func ParseComments(bodies []string) ([]ImplementationNotes, []ReviewNotes) {
+	var implNotes []ImplementationNotes
+	var reviewNotes []ReviewNotes
+	for _, body := range bodies {
+		if n := ParseImplementationNotes(body); n != nil {
+			implNotes = append(implNotes, *n)
+		}
+		if n := ParseReviewNotes(body); n != nil {
+			reviewNotes = append(reviewNotes, *n)
+		}
+	}
+	return implNotes, reviewNotes
+}
+
+// parseSections scans body for the given top-level header and returns a map of
+// subsection header → trimmed content. Returns nil if the top-level header is
+// not found.
+func parseSections(body, topHeader string) map[string]string {
+	scanner := bufio.NewScanner(strings.NewReader(body))
+
+	// Advance until we find the top-level header.
+	found := false
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == topHeader {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+
+	sections := make(map[string]string)
+	var currentKey string
+	var buf strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		// Stop at any new top-level (##) header that is not a subsection (###).
+		if strings.HasPrefix(trimmed, "## ") && !strings.HasPrefix(trimmed, "### ") {
+			break
+		}
+
+		if strings.HasPrefix(trimmed, "### ") {
+			// Save previous subsection.
+			if currentKey != "" {
+				sections[currentKey] = strings.TrimSpace(buf.String())
+			}
+			currentKey = trimmed
+			buf.Reset()
+			continue
+		}
+
+		if currentKey != "" {
+			buf.WriteString(line)
+			buf.WriteByte('\n')
+		}
+	}
+
+	// Save the last subsection.
+	if currentKey != "" {
+		sections[currentKey] = strings.TrimSpace(buf.String())
+	}
+
+	return sections
+}

--- a/internal/dialogue/dialogue_test.go
+++ b/internal/dialogue/dialogue_test.go
@@ -1,0 +1,244 @@
+package dialogue
+
+import "testing"
+
+const fullImplComment = `## Implementation Notes
+
+### Approach
+Used a line-by-line scanner.
+
+### Key Decisions
+- Chose bufio.Scanner for simplicity.
+
+### Known Limitations
+- Does not handle deeply nested headers.
+
+### Architecture
+Placed in domain layer with no external dependencies.
+`
+
+const fullReviewComment = `## Review Notes
+
+### Approved
+- Clean implementation.
+
+### Changes Requested
+- Add more tests.
+
+### Architecture Compliance
+Layer boundaries respected.
+`
+
+func TestParseImplementationNotes_Full(t *testing.T) {
+	t.Helper()
+	got := ParseImplementationNotes(fullImplComment)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if got.Approach != "Used a line-by-line scanner." {
+		t.Errorf("Approach = %q, want %q", got.Approach, "Used a line-by-line scanner.")
+	}
+	if got.KeyDecisions != "- Chose bufio.Scanner for simplicity." {
+		t.Errorf("KeyDecisions = %q, want %q", got.KeyDecisions, "- Chose bufio.Scanner for simplicity.")
+	}
+	if got.KnownLimitations != "- Does not handle deeply nested headers." {
+		t.Errorf("KnownLimitations = %q, want %q", got.KnownLimitations, "- Does not handle deeply nested headers.")
+	}
+	if got.Architecture != "Placed in domain layer with no external dependencies." {
+		t.Errorf("Architecture = %q, want %q", got.Architecture, "Placed in domain layer with no external dependencies.")
+	}
+	if got.Raw != fullImplComment {
+		t.Errorf("Raw does not match original comment text")
+	}
+}
+
+func TestParseImplementationNotes_Partial(t *testing.T) {
+	body := `## Implementation Notes
+
+### Approach
+Simple approach.
+
+### Key Decisions
+Some decisions.
+`
+	got := ParseImplementationNotes(body)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if got.Approach != "Simple approach." {
+		t.Errorf("Approach = %q, want %q", got.Approach, "Simple approach.")
+	}
+	if got.KeyDecisions != "Some decisions." {
+		t.Errorf("KeyDecisions = %q, want %q", got.KeyDecisions, "Some decisions.")
+	}
+	if got.KnownLimitations != "" {
+		t.Errorf("KnownLimitations = %q, want empty string", got.KnownLimitations)
+	}
+	if got.Architecture != "" {
+		t.Errorf("Architecture = %q, want empty string", got.Architecture)
+	}
+}
+
+func TestParseReviewNotes_Full(t *testing.T) {
+	got := ParseReviewNotes(fullReviewComment)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if got.Approved != "- Clean implementation." {
+		t.Errorf("Approved = %q, want %q", got.Approved, "- Clean implementation.")
+	}
+	if got.ChangesRequested != "- Add more tests." {
+		t.Errorf("ChangesRequested = %q, want %q", got.ChangesRequested, "- Add more tests.")
+	}
+	if got.ArchitectureCompliance != "Layer boundaries respected." {
+		t.Errorf("ArchitectureCompliance = %q, want %q", got.ArchitectureCompliance, "Layer boundaries respected.")
+	}
+	if got.Raw != fullReviewComment {
+		t.Errorf("Raw does not match original comment text")
+	}
+}
+
+func TestParseImplementationNotes_NotANotesComment(t *testing.T) {
+	body := "This is just a regular PR comment with no special headers."
+	got := ParseImplementationNotes(body)
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestParseReviewNotes_NotANotesComment(t *testing.T) {
+	body := "LGTM! Great work."
+	got := ParseReviewNotes(body)
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestParseComments_MultipleComments(t *testing.T) {
+	impl1 := `## Implementation Notes
+
+### Approach
+First implementation.
+
+### Key Decisions
+Decision A.
+
+### Known Limitations
+None.
+
+### Architecture
+Domain layer.
+`
+	review1 := `## Review Notes
+
+### Approved
+Looks good.
+
+### Changes Requested
+Fix the typo.
+
+### Architecture Compliance
+Compliant.
+`
+	impl2 := `## Implementation Notes
+
+### Approach
+Second implementation after review.
+
+### Key Decisions
+Decision B.
+
+### Known Limitations
+None known.
+
+### Architecture
+Same domain layer.
+`
+	bodies := []string{impl1, review1, impl2}
+	implNotes, reviewNotes := ParseComments(bodies)
+
+	if len(implNotes) != 2 {
+		t.Fatalf("len(implNotes) = %d, want 2", len(implNotes))
+	}
+	if len(reviewNotes) != 1 {
+		t.Fatalf("len(reviewNotes) = %d, want 1", len(reviewNotes))
+	}
+
+	// Verify order is preserved.
+	if implNotes[0].Approach != "First implementation." {
+		t.Errorf("implNotes[0].Approach = %q, want %q", implNotes[0].Approach, "First implementation.")
+	}
+	if implNotes[1].Approach != "Second implementation after review." {
+		t.Errorf("implNotes[1].Approach = %q, want %q", implNotes[1].Approach, "Second implementation after review.")
+	}
+	if reviewNotes[0].Approved != "Looks good." {
+		t.Errorf("reviewNotes[0].Approved = %q, want %q", reviewNotes[0].Approved, "Looks good.")
+	}
+}
+
+func TestParseImplementationNotes_WhitespaceHandling(t *testing.T) {
+	body := `## Implementation Notes
+
+### Approach
+
+   Indented and padded approach.
+
+### Key Decisions
+
+  Some decisions with leading spaces.
+
+`
+	got := ParseImplementationNotes(body)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if got.Approach != "Indented and padded approach." {
+		t.Errorf("Approach = %q, want %q", got.Approach, "Indented and padded approach.")
+	}
+	if got.KeyDecisions != "Some decisions with leading spaces." {
+		t.Errorf("KeyDecisions = %q, want %q", got.KeyDecisions, "Some decisions with leading spaces.")
+	}
+}
+
+func TestParseImplementationNotes_RawPreserved(t *testing.T) {
+	body := "## Implementation Notes\n\n### Approach\nDone.\n"
+	got := ParseImplementationNotes(body)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if got.Raw != body {
+		t.Errorf("Raw = %q, want %q", got.Raw, body)
+	}
+}
+
+func TestParseReviewNotes_RawPreserved(t *testing.T) {
+	body := "## Review Notes\n\n### Approved\nAll good.\n"
+	got := ParseReviewNotes(body)
+	if got == nil {
+		t.Fatal("expected non-nil, got nil")
+	}
+	if got.Raw != body {
+		t.Errorf("Raw = %q, want %q", got.Raw, body)
+	}
+}
+
+func TestParseComments_Empty(t *testing.T) {
+	implNotes, reviewNotes := ParseComments([]string{})
+	if len(implNotes) != 0 {
+		t.Errorf("len(implNotes) = %d, want 0", len(implNotes))
+	}
+	if len(reviewNotes) != 0 {
+		t.Errorf("len(reviewNotes) = %d, want 0", len(reviewNotes))
+	}
+}
+
+func TestParseComments_NoMatchingComments(t *testing.T) {
+	bodies := []string{"Just a regular comment.", "Another comment."}
+	implNotes, reviewNotes := ParseComments(bodies)
+	if len(implNotes) != 0 {
+		t.Errorf("len(implNotes) = %d, want 0", len(implNotes))
+	}
+	if len(reviewNotes) != 0 {
+		t.Errorf("len(reviewNotes) = %d, want 0", len(reviewNotes))
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/dialogue/` package (domain layer) that parses `## Implementation Notes` and `## Review Notes` from PR comment markdown
- Exports `ImplementationNotes`, `ReviewNotes`, `ParseImplementationNotes`, `ParseReviewNotes`, and `ParseComments`
- 11 unit tests covering all acceptance criteria: full parsing, partial sections, nil on non-matching, whitespace trimming, Raw field preservation, and multi-comment ordering

## Test plan

- [x] `ParseImplementationNotes` extracts all four subsections (Approach, Key Decisions, Known Limitations, Architecture)
- [x] `ParseReviewNotes` extracts all three subsections (Approved, Changes Requested, Architecture Compliance)
- [x] Missing subsections produce empty strings
- [x] Non-matching comments return nil
- [x] `ParseComments` returns notes in order from multiple mixed comments
- [x] Leading/trailing whitespace is trimmed from section content
- [x] `Raw` field holds full original comment text
- [x] All existing project tests still pass (`go test ./...`)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)