### PR TITLE
feat: configurable architecture enforcement (#152)

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -94,6 +94,7 @@ func newPromptData(issue github.Issue, cfg *config.Config, slug string) PromptDa
 		ScenarioDir:     cfg.ScenarioDir,
 		ReviewDir:       cfg.ReviewDir,
 		HasScenarioSpec: HasScenarioSpec(cfg.ScenarioDir, issue.Number),
+		EnforceArchitecture:    cfg.EnforceArchitecture,
 		ArchitectureDocContent: readFileOrEmpty(cfg.ArchitectureDoc),
 		ArchitectureJSON:       readFileOrEmpty(cfg.ArchitectureJSON),
 		ConventionsDocContent:  readFileOrEmpty(cfg.ConventionsDoc),

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -421,3 +421,25 @@ func TestNewPromptData_ArchitectureJSONFileMissing(t *testing.T) {
 		t.Errorf("ArchitectureJSON = %q, want empty string for missing file", data.ArchitectureJSON)
 	}
 }
+
+func TestNewPromptData_EnforceArchitectureFromConfig(t *testing.T) {
+	cfg := testConfig()
+	cfg.EnforceArchitecture = true
+
+	data := newPromptData(testIssue(), cfg, "test-slug")
+
+	if !data.EnforceArchitecture {
+		t.Error("EnforceArchitecture should be true when set in config")
+	}
+}
+
+func TestNewPromptData_EnforceArchitectureDefaultFalse(t *testing.T) {
+	cfg := testConfig()
+	// EnforceArchitecture not set — zero value is false.
+
+	data := newPromptData(testIssue(), cfg, "test-slug")
+
+	if data.EnforceArchitecture {
+		t.Error("EnforceArchitecture should be false when not set in config")
+	}
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -37,6 +37,7 @@ type PromptData struct {
 	ReviewDir      string
 	BranchExists           bool
 	StrictnessDirective    string
+	EnforceArchitecture    bool
 	ArchitectureDocContent string
 	ArchitectureJSON       string
 	ConventionsDocContent  string

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -434,6 +434,95 @@ func TestReviewerPrompt_IncludesArchitectureJSONBlock(t *testing.T) {
 	}
 }
 
+func TestReviewerPrompt_EnforceArchitectureOn_IncludesBlockingDirective(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	jsonContent := `{"layers":[{"name":"foundation","may_depend_on":[]}]}`
+	data := PromptData{
+		IssueNumber:         1,
+		Repo:                "owner/repo",
+		PRNumber:            10,
+		TestCommand:         "make test",
+		BuildCommand:        "make build",
+		ProtectedPaths:      "CLAUDE.md",
+		ScenarioDir:         "tests/scenarios/",
+		ReviewDir:           "tests/review/",
+		ArchitectureJSON:    jsonContent,
+		EnforceArchitecture: true,
+	}
+	rendered, err := RenderPrompt(p.Reviewer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "MUST result in CHANGES_REQUESTED") {
+		t.Error("reviewer prompt should include blocking directive when EnforceArchitecture is true")
+	}
+	if strings.Contains(rendered, "do not block approval") {
+		t.Error("reviewer prompt should not include informational directive when EnforceArchitecture is true")
+	}
+}
+
+func TestReviewerPrompt_EnforceArchitectureOff_IncludesInformationalDirective(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	jsonContent := `{"layers":[{"name":"foundation","may_depend_on":[]}]}`
+	data := PromptData{
+		IssueNumber:         1,
+		Repo:                "owner/repo",
+		PRNumber:            10,
+		TestCommand:         "make test",
+		BuildCommand:        "make build",
+		ProtectedPaths:      "CLAUDE.md",
+		ScenarioDir:         "tests/scenarios/",
+		ReviewDir:           "tests/review/",
+		ArchitectureJSON:    jsonContent,
+		EnforceArchitecture: false,
+	}
+	rendered, err := RenderPrompt(p.Reviewer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "do not block approval") {
+		t.Error("reviewer prompt should include informational directive when EnforceArchitecture is false")
+	}
+	if strings.Contains(rendered, "MUST result in CHANGES_REQUESTED") {
+		t.Error("reviewer prompt should not include blocking directive when EnforceArchitecture is false")
+	}
+}
+
+func TestReviewerPrompt_NoArchitectureJSON_OmitsBothDirectives(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:         1,
+		Repo:                "owner/repo",
+		PRNumber:            10,
+		TestCommand:         "make test",
+		BuildCommand:        "make build",
+		ProtectedPaths:      "CLAUDE.md",
+		ScenarioDir:         "tests/scenarios/",
+		ReviewDir:           "tests/review/",
+		ArchitectureJSON:    "",
+		EnforceArchitecture: true,
+	}
+	rendered, err := RenderPrompt(p.Reviewer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if strings.Contains(rendered, "MUST result in CHANGES_REQUESTED") {
+		t.Error("reviewer prompt should not include blocking directive when ArchitectureJSON is empty")
+	}
+	if strings.Contains(rendered, "do not block approval") {
+		t.Error("reviewer prompt should not include informational directive when ArchitectureJSON is empty")
+	}
+}
+
 func TestReviewerPrompt_OmitsArchitectureJSONBlockWhenEmpty(t *testing.T) {
 	p, err := LoadPrompts(&config.Config{})
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	NoSandbox              bool `yaml:"no_sandbox"`
 	NoMerge                bool `yaml:"no_merge"`
 	QualityStrictnessDecay bool `yaml:"quality_strictness_decay"`
+	EnforceArchitecture    bool `yaml:"enforce_architecture"`
 
 	// AuthPreference controls which Anthropic auth token is preferred when both
 	// ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN are set.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -578,6 +578,37 @@ conventions_doc: custom/conventions.md
 	}
 }
 
+func TestEnforceArchitectureDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.EnforceArchitecture {
+		t.Error("EnforceArchitecture should default to false")
+	}
+}
+
+func TestEnforceArchitectureFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+enforce_architecture: true
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.EnforceArchitecture {
+		t.Error("EnforceArchitecture = false, want true from YAML")
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.

--- a/prompts/reviewer.txt
+++ b/prompts/reviewer.txt
@@ -17,6 +17,11 @@ Steps:
 {{- if .ArchitectureJSON}}
    Machine-readable layer definitions — for each changed file, verify that its imports respect the `may_depend_on` and `must_not_depend_on` rules for its layer:
 {{.ArchitectureJSON}}
+{{- if .EnforceArchitecture}}
+   Layer violations MUST result in CHANGES_REQUESTED. Do not approve PRs with layer violations.
+{{- else}}
+   Flag any layer violations in your Review Notes under Architecture Compliance, but they do not block approval.
+{{- end}}
 {{- end}}
 {{- if .TestCommand}}
 7. Run unit tests: {{.TestCommand}}


### PR DESCRIPTION
## Summary

- Adds `enforce_architecture` config option (default `false`) to control whether architecture layer violations block PR approval or are informational only
- Propagates the setting through `PromptData` to the reviewer prompt template
- Reviewer prompt emits a blocking or informational directive inside the `ArchitectureJSON` block based on the setting

Closes #152

## Implementation Notes

### Approach
Followed the existing `StrictnessDirective` pattern: added a boolean field to the config struct, threaded it through `PromptData`, and rendered it conditionally in the reviewer prompt template. The directive is guarded inside the `{{- if .ArchitectureJSON}}` block so it only appears when machine-readable layer definitions are actually provided.

### Key Decisions
- Default is `false` (informational) as specified in the issue — this is a non-breaking change for existing configs.
- The template uses `{{- if .EnforceArchitecture}}` / `{{- else}}` / `{{- end}}` inside the existing `ArchitectureJSON` conditional, ensuring both the JSON content and the enforcement directive are absent when no JSON is configured.
- No new packages or dependencies introduced.

### Known Limitations
- `EnforceArchitecture` is meaningful only when `ArchitectureJSON` resolves to a non-empty file; when the file is missing the field is ignored (by template logic), which matches the acceptance criteria.

### Architecture
- `internal/config/` — **foundation** layer. Added one bool field; no new imports, no dependency changes.
- `internal/agent/` — **orchestration** layer. Reads from config (foundation), which is already an allowed dependency. No new imports.
- `prompts/` — **content** layer. Static template text; no runtime dependencies.

All layer boundary rules respected.