### PR TITLE
feat: persist tool trace in run data and harden functional review test requirement

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -244,6 +244,17 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			}
 		}
 
+		// Pre-merge guard: if the reviewer approved without writing tests to the
+		// review dir, reject the approval and force a retry. This turns the
+		// no_review_tests_written quality flag into a hard gate.
+		if reviewResult.Verdict == "APPROVED" && hasQualityFlag(fFlags, "no_review_tests_written") {
+			logger.Warn("functional review approved without writing tests — rejecting approval",
+				"issue_number", issue.Number,
+				"attempt", attempt+1,
+			)
+			reviewResult.Verdict = "CHANGES_REQUESTED"
+		}
+
 		switch reviewResult.Verdict {
 		case "APPROVED":
 			if cfg.NoMerge {
@@ -373,6 +384,16 @@ func computeReviewFlags(result *Result, cfg *config.Config, checkTestExecution b
 	}
 
 	return flags
+}
+
+// hasQualityFlag reports whether any flag in the slice has the given code.
+func hasQualityFlag(flags []quality.Flag, code string) bool {
+	for _, f := range flags {
+		if f.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 // logAndRecordFlags logs each flag as a warning and returns a []rundata.Flag for storage.

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/quality"
 	"github.com/phs/dark-factory/internal/rundata"
 )
 
@@ -1156,5 +1158,171 @@ func TestProcessIssue_QualityReviewerExemptInLoop(t *testing.T) {
 	}
 	if !hasTestFlag {
 		t.Errorf("functional reviewer should have test-execution flags, got flags: %+v", fStep.Flags)
+	}
+}
+
+// --- Pre-merge guard tests ---
+
+func TestHasQualityFlag_Found(t *testing.T) {
+	flags := []quality.Flag{
+		{Code: "low_cost", Message: "too cheap"},
+		{Code: "no_review_tests_written", Message: "no tests"},
+	}
+	if !hasQualityFlag(flags, "no_review_tests_written") {
+		t.Error("hasQualityFlag should return true when flag is present")
+	}
+}
+
+func TestHasQualityFlag_NotFound(t *testing.T) {
+	flags := []quality.Flag{
+		{Code: "low_cost", Message: "too cheap"},
+	}
+	if hasQualityFlag(flags, "no_review_tests_written") {
+		t.Error("hasQualityFlag should return false when flag is absent")
+	}
+}
+
+func TestHasQualityFlag_Empty(t *testing.T) {
+	if hasQualityFlag(nil, "no_review_tests_written") {
+		t.Error("hasQualityFlag should return false for empty slice")
+	}
+}
+
+// TestProcessIssue_PreMergeGuardRejectsApprovalWithoutTests verifies that when the
+// functional reviewer approves a PR but the no_review_tests_written flag is detected,
+// the approval is rejected and retried rather than merged.
+func TestProcessIssue_PreMergeGuardRejectsApprovalWithoutTests(t *testing.T) {
+	// Create a scenario dir with a spec for issue #5 so hasScenarioSpec=true.
+	scenarioDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(scenarioDir, "spec.md"), []byte("Relates to: Issue #5\n"), 0600); err != nil {
+		t.Fatalf("failed to write scenario spec: %v", err)
+	}
+
+	cfg := loopConfig()
+	cfg.MaxRetries = 1
+	cfg.TestCommand = "go test ./..."
+	cfg.ReviewDir = "tests/review/"
+	cfg.ScenarioDir = scenarioDir
+
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = loopGuardFn
+
+	callIdx := 0
+	var mergeCallCount int
+
+	// reviewerWithoutTests returns a JSON runner result that includes REVIEW_RESULT=APPROVED
+	// but no Write to tests/review/ in the tool trace, so the guard should fire.
+	reviewerWithoutTests := func() []byte {
+		// Tool trace has no Write to tests/review/ so no_review_tests_written fires.
+		final := runnerFinalResult{
+			Result:    "REVIEW_RESULT=APPROVED",
+			ToolTrace: []string{"Read tests/existing_test.go", "go test ./..."},
+		}
+		b, _ := json.Marshal(final)
+		return b
+	}
+
+	// reviewerWithTests returns a result with a Write to tests/review/ in the trace.
+	reviewerWithTests := func() []byte {
+		final := runnerFinalResult{
+			Result:    "REVIEW_RESULT=APPROVED",
+			ToolTrace: []string{"Write tests/review/my_test.go", "go test ./..."},
+		}
+		b, _ := json.Marshal(final)
+		return b
+	}
+
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2: // quality reviewer — approve
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		case 3: // functional reviewer — approves without writing tests (guard should reject)
+			return reviewerWithoutTests(), []byte(""), 0, nil
+		case 4: // retry implementer
+			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
+		default: // second functional reviewer — approves with tests written
+			return reviewerWithTests(), []byte(""), 0, nil
+		}
+	}
+
+	guardFn := func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "gh" && strings.Contains(joined, "pr merge") {
+			mergeCallCount++
+		}
+		return loopGuardFn(name, args...)
+	}
+	GuardRunner = guardFn
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	// Should eventually succeed after the guard forced a retry.
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	// The guard should have triggered at least one retry (callIdx > 3).
+	if callIdx <= 3 {
+		t.Errorf("expected more than 3 agent calls (guard should have triggered retry), got %d", callIdx)
+	}
+	if mergeCallCount != 1 {
+		t.Errorf("gh pr merge should be called once at the end, got %d calls", mergeCallCount)
+	}
+}
+
+// TestProcessIssue_PreMergeGuardAllowsApprovalWithTests verifies that when the
+// functional reviewer approves a PR and writes tests, the guard does not interfere.
+func TestProcessIssue_PreMergeGuardAllowsApprovalWithTests(t *testing.T) {
+	scenarioDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(scenarioDir, "spec.md"), []byte("Relates to: Issue #5\n"), 0600); err != nil {
+		t.Fatalf("failed to write scenario spec: %v", err)
+	}
+
+	cfg := loopConfig()
+	cfg.TestCommand = "go test ./..."
+	cfg.ReviewDir = "tests/review/"
+	cfg.ScenarioDir = scenarioDir
+
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = loopGuardFn
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2: // quality reviewer — approve
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // functional reviewer — approves WITH tests written
+			final := runnerFinalResult{
+				Result:    "REVIEW_RESULT=APPROVED",
+				ToolTrace: []string{"Write tests/review/my_test.go", "go test ./..."},
+			}
+			b, _ := json.Marshal(final)
+			return b, []byte(""), 0, nil
+		}
+	}
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	// Should be exactly 3 agent calls: implement + quality + functional (no retries).
+	if callIdx != 3 {
+		t.Errorf("expected 3 agent calls (implement + quality + review), got %d", callIdx)
 	}
 }

--- a/internal/agent/rundata.go
+++ b/internal/agent/rundata.go
@@ -6,8 +6,9 @@ import "github.com/phs/dark-factory/internal/rundata"
 // DurationSeconds from the timing fields captured during execution.
 func ResultToStep(r *Result) rundata.StepResult {
 	step := rundata.StepResult{
-		Output:  r.ResultText,
-		CostUSD: r.CostUSD,
+		Output:    r.ResultText,
+		CostUSD:   r.CostUSD,
+		ToolTrace: r.ToolTrace,
 	}
 	if !r.StartedAt.IsZero() {
 		t := r.StartedAt

--- a/internal/agent/rundata_test.go
+++ b/internal/agent/rundata_test.go
@@ -52,6 +52,35 @@ func TestResultToStep_OutputFromResultText(t *testing.T) {
 	}
 }
 
+func TestResultToStep_ToolTracePropagated(t *testing.T) {
+	trace := []string{"Read /some/file", "Write /some/output", "Bash go test ./..."}
+	r := &Result{
+		ResultText: "done",
+		ToolTrace:  trace,
+	}
+
+	step := ResultToStep(r)
+
+	if len(step.ToolTrace) != len(trace) {
+		t.Fatalf("ToolTrace length = %d, want %d", len(step.ToolTrace), len(trace))
+	}
+	for i, want := range trace {
+		if step.ToolTrace[i] != want {
+			t.Errorf("ToolTrace[%d] = %q, want %q", i, step.ToolTrace[i], want)
+		}
+	}
+}
+
+func TestResultToStep_NilToolTraceOmitted(t *testing.T) {
+	r := &Result{ResultText: "done"}
+
+	step := ResultToStep(r)
+
+	if step.ToolTrace != nil {
+		t.Errorf("ToolTrace = %v, want nil when Result.ToolTrace is nil", step.ToolTrace)
+	}
+}
+
 func TestResultToStep_DurationSeconds_Positive(t *testing.T) {
 	started := time.Now()
 	finished := started.Add(5 * time.Second)

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -81,6 +81,7 @@ type TimelineStepView struct {
 	Flags        []rundata.Flag
 	HasOutput    bool
 	Output       string
+	ToolTrace    []string // tool calls recorded during this step
 }
 
 // IndexData is the data passed to the index template.
@@ -466,6 +467,7 @@ func stepToView(name string, step rundata.StepResult) TimelineStepView {
 		Flags:        step.Flags,
 		HasOutput:    step.Output != "",
 		Output:       step.Output,
+		ToolTrace:    step.ToolTrace,
 	}
 }
 

--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -306,7 +306,7 @@ func TestServer_IssueDetail_ToolTraceToggle(t *testing.T) {
 	writeJSON(t, filepath.Join(issueDir, "outcome.json"),
 		rundata.Outcome{IssueNumber: 3, Status: "implemented"})
 	writeJSON(t, filepath.Join(issueDir, "implement.json"),
-		rundata.StepResult{Output: "tool trace output here", DurationSeconds: 20})
+		rundata.StepResult{Output: "agent output here", DurationSeconds: 20})
 
 	srv := newServer(t, tmpDir)
 	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/3", nil)
@@ -320,19 +320,19 @@ func TestServer_IssueDetail_ToolTraceToggle(t *testing.T) {
 
 	// Alpine.js toggle attributes must be present
 	if !strings.Contains(body, "x-data") {
-		t.Errorf("body missing Alpine.js x-data attribute for tool trace toggle")
+		t.Errorf("body missing Alpine.js x-data attribute for agent output toggle")
 	}
 	if !strings.Contains(body, "x-show") {
-		t.Errorf("body missing Alpine.js x-show attribute for tool trace toggle")
+		t.Errorf("body missing Alpine.js x-show attribute for agent output toggle")
 	}
 	if !strings.Contains(body, "@click") {
-		t.Errorf("body missing Alpine.js @click attribute for tool trace toggle")
+		t.Errorf("body missing Alpine.js @click attribute for agent output toggle")
 	}
-	if !strings.Contains(body, "Tool Trace") {
-		t.Errorf("body missing 'Tool Trace' trigger label")
+	if !strings.Contains(body, "Agent Output") {
+		t.Errorf("body missing 'Agent Output' trigger label")
 	}
-	if !strings.Contains(body, "tool trace output here") {
-		t.Errorf("body missing tool trace content")
+	if !strings.Contains(body, "agent output here") {
+		t.Errorf("body missing agent output content")
 	}
 }
 
@@ -762,5 +762,97 @@ func TestServer_IndexRows_HaveRunDetailURL(t *testing.T) {
 	// The URL appears in a data-href attribute (not in JS context, so no escaping).
 	if !strings.Contains(body, `data-href="`+expectedURL+`"`) {
 		t.Errorf("index body missing run detail URL %q in data-href; got: %q", expectedURL, truncate(body, 800))
+	}
+}
+
+func TestServer_IssueDetail_ToolTraceSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{6},
+		StartedAt:    now,
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "6")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"),
+		rundata.Outcome{IssueNumber: 6, Status: "implemented"})
+	writeJSON(t, filepath.Join(issueDir, "functional-review.json"),
+		rundata.StepResult{
+			Output:    "REVIEW_RESULT=APPROVED",
+			ToolTrace: []string{"Read src/main.go", "Write tests/review/test_main.go", "go test ./..."},
+			DurationSeconds: 15,
+		})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/6", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 500))
+	}
+	body := rr.Body.String()
+
+	// Tool Trace section should be present with the call count.
+	if !strings.Contains(body, "Tool Trace (3 calls)") {
+		t.Errorf("body missing 'Tool Trace (3 calls)' trigger label; got: %q", truncate(body, 500))
+	}
+	// Each tool call entry should appear.
+	if !strings.Contains(body, "Read src/main.go") {
+		t.Errorf("body missing first tool trace entry 'Read src/main.go'")
+	}
+	if !strings.Contains(body, "Write tests/review/test_main.go") {
+		t.Errorf("body missing second tool trace entry 'Write tests/review/test_main.go'")
+	}
+	if !strings.Contains(body, "go test ./...") {
+		t.Errorf("body missing third tool trace entry 'go test ./...'")
+	}
+	// Alpine.js toggle should be present.
+	if !strings.Contains(body, "traceOpen") {
+		t.Errorf("body missing Alpine.js traceOpen variable for tool trace toggle")
+	}
+}
+
+func TestServer_IssueDetail_NoToolTraceWhenAbsent(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{7},
+		StartedAt:    now,
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "7")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"),
+		rundata.Outcome{IssueNumber: 7, Status: "implemented"})
+	// StepResult with no ToolTrace field.
+	writeJSON(t, filepath.Join(issueDir, "implement.json"),
+		rundata.StepResult{Output: "done", DurationSeconds: 5})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/7", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	// The "Tool Trace (N calls)" label should not appear when ToolTrace is empty.
+	if strings.Contains(body, "Tool Trace (") {
+		t.Errorf("body should not contain 'Tool Trace (N calls)' when ToolTrace is absent")
 	}
 }

--- a/internal/dashboard/templates/issue-detail.html
+++ b/internal/dashboard/templates/issue-detail.html
@@ -103,13 +103,28 @@
                   <span>{{.Cost}}</span>
                 </div>
                 {{if .HasOutput}}
-                <div class="expandable mt-2">
-                  <button class="expandable__trigger" @click="open = !open">
-                    <span class="expandable__arrow" :style="open ? 'transform: rotate(90deg)' : ''">&#9658;</span>
-                    Tool Trace
+                <div class="expandable mt-2" x-data="{ outputOpen: false }">
+                  <button class="expandable__trigger" @click="outputOpen = !outputOpen">
+                    <span class="expandable__arrow" :style="outputOpen ? 'transform: rotate(90deg)' : ''">&#9658;</span>
+                    Agent Output
                   </button>
-                  <div x-show="open" style="display:none; padding: var(--space-3); background: var(--bg-surface-1); border-top: 1px solid var(--border-muted); overflow-y: auto; max-height: 300px;">
+                  <div x-show="outputOpen" style="display:none; padding: var(--space-3); background: var(--bg-surface-1); border-top: 1px solid var(--border-muted); overflow-y: auto; max-height: 300px;">
                     <div class="markdown-body">{{renderMarkdown .Output}}</div>
+                  </div>
+                </div>
+                {{end}}
+                {{if .ToolTrace}}
+                <div class="expandable mt-2" x-data="{ traceOpen: false }">
+                  <button class="expandable__trigger" @click="traceOpen = !traceOpen">
+                    <span class="expandable__arrow" :style="traceOpen ? 'transform: rotate(90deg)' : ''">&#9658;</span>
+                    Tool Trace ({{len .ToolTrace}} calls)
+                  </button>
+                  <div x-show="traceOpen" style="display:none; padding: var(--space-3); background: var(--bg-surface-1); border-top: 1px solid var(--border-muted); overflow-y: auto; max-height: 300px;">
+                    <ol style="margin: 0; padding-left: var(--space-5); font-size: var(--text-sm); font-family: monospace;">
+                      {{range .ToolTrace}}
+                      <li style="margin-bottom: var(--space-1);">{{.}}</li>
+                      {{end}}
+                    </ol>
                   </div>
                 </div>
                 {{end}}

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -41,6 +41,7 @@ type StepResult struct {
 	DurationSeconds float64    `json:"duration_seconds,omitempty"`
 	CostUSD         float64    `json:"cost_usd,omitempty"`
 	Flags           []Flag     `json:"flags,omitempty"`
+	ToolTrace       []string   `json:"tool_trace,omitempty"`
 }
 
 // Outcome records the final result for a single issue.

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -295,6 +295,67 @@ func TestFlagsWrittenToReviewJSON(t *testing.T) {
 	}
 }
 
+func TestToolTraceWrittenToJSON(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	trace := []string{"Read main.go", "Write tests/review/test.go", "go test ./..."}
+	step := StepResult{Output: "review output", ToolTrace: trace}
+	if err := w.WriteReviewResult(42, "functional", step); err != nil {
+		t.Fatalf("WriteReviewResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "functional-review.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading functional-review.json: %v", err)
+	}
+
+	var written StepResult
+	if err := json.Unmarshal(data, &written); err != nil {
+		t.Fatalf("parsing functional-review.json: %v", err)
+	}
+
+	if len(written.ToolTrace) != len(trace) {
+		t.Fatalf("ToolTrace length: got %d, want %d", len(written.ToolTrace), len(trace))
+	}
+	for i, want := range trace {
+		if written.ToolTrace[i] != want {
+			t.Errorf("ToolTrace[%d] = %q, want %q", i, written.ToolTrace[i], want)
+		}
+	}
+}
+
+func TestToolTraceOmittedFromJSONWhenEmpty(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := StepResult{Output: "review output"}
+	if err := w.WriteReviewResult(42, "functional", step); err != nil {
+		t.Fatalf("WriteReviewResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "functional-review.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading functional-review.json: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+	if _, ok := raw["tool_trace"]; ok {
+		t.Error("tool_trace key should be omitted from JSON when empty")
+	}
+}
+
 func TestNoFlagsOmittedFromJSON(t *testing.T) {
 	base := t.TempDir()
 	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})

--- a/prompts/reviewer.txt
+++ b/prompts/reviewer.txt
@@ -41,6 +41,8 @@ CRITICAL RULES:
 - Do NOT modify files in {{.ScenarioDir}}
 {{- if .HasScenarioSpec}}
 - You MUST write integration tests to {{.ReviewDir}} (step 9) before making your verdict. This is non-negotiable.
+- Judging existing tests sufficient is NOT acceptable — you must write your own ephemeral tests in {{.ReviewDir}}.
+- The orchestrator verifies that you wrote files to {{.ReviewDir}} by inspecting your tool trace. If no Write to {{.ReviewDir}} is detected, your APPROVED verdict will be automatically rejected and the implementation retried.
 - After running tests, delete the {{.ReviewDir}} directory before finishing.
 {{- end}}
 


### PR DESCRIPTION
## Summary

- Add `ToolTrace []string` to `rundata.StepResult` so the functional reviewer's tool trace is persisted to `functional-review.json` for post-hoc diagnostics
- Populate `ToolTrace` in `ResultToStep()` from `agent.Result.ToolTrace`
- Surface tool trace in the dashboard issue-detail view as a separate expandable "Tool Trace (N calls)" section alongside "Agent Output"
- Add a pre-merge guard in `ProcessIssue`: when `no_review_tests_written` fires and the functional reviewer approves, override to `CHANGES_REQUESTED` — turning the quality flag into a hard gate
- Strengthen `reviewer.txt`: tell the agent explicitly that the orchestrator inspects the tool trace and will reject approvals without writes to `reviewDir`

## Implementation Notes

### Approach

**Part A (tool trace persistence):** Added `ToolTrace []string` to `rundata.StepResult` with `json:"tool_trace,omitempty"`. `ResultToStep()` now copies `r.ToolTrace` to the step. The dashboard `TimelineStepView` gains a `ToolTrace []string` field, and `stepToView()` populates it. The issue-detail template splits the old "Tool Trace" expandable (which showed agent text output) into two distinct sections: "Agent Output" (markdown-rendered) and "Tool Trace (N calls)" (ordered list of tool call strings).

**Part B (harden functional review):** Chose the pre-merge guard (Option 2). After computing quality flags for the functional reviewer, if `no_review_tests_written` is present and the verdict is `APPROVED`, the verdict is overridden to `CHANGES_REQUESTED`, sending the issue through the normal retry path. This is more reliable than prompt strengthening alone — the prompt already used MANDATORY language the agent rationalized away. The prompt is also updated to explain that the orchestrator will detect non-compliance, giving the agent a concrete reason to comply.

### Key Decisions

- **Guard placement**: The guard fires after flags are computed and the step result is written, so the persisted data always reflects the actual verdict the agent produced (APPROVED) plus the flags — and the override is logged as a warning. The retry is the corrective action.
- **No retry limit change**: The guard consumes one retry slot. If the agent keeps approving without writing tests across all retries, it falls through to `needs-human-review` as usual.
- **Template refactor**: The old expandable was labeled "Tool Trace" but showed `Output` (agent text). Renamed to "Agent Output" for clarity. A new "Tool Trace (N calls)" section appears only when `ToolTrace` is non-empty.
- **`hasQualityFlag()` is unexported**: It's a package-private helper in `loop.go` — no need to export it; only `ProcessIssue` uses it.

### Known Limitations

- The guard only fires for `no_review_tests_written`; `no_review_tests_run` is still a flag-only signal. A follow-up could gate on that too.
- The pre-merge guard applies only to the functional reviewer's approval. Quality reviewer approvals are not gated (as per existing exemption logic).

### Architecture

- **`internal/rundata`** (domain): `StepResult` extended with `ToolTrace`. No new dependencies.
- **`internal/agent`** (orchestration): `ResultToStep()` updated; `loop.go` gets `hasQualityFlag()` helper and guard logic. Imports `internal/quality` (already present). No layer violations.
- **`internal/dashboard`** (presentation): `TimelineStepView` extended; template updated. Depends only on `internal/rundata` (domain). No layer violations.
- **`prompts/`** (content): Prompt text updated. No code dependencies.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)