### PR TITLE
fix: fetch spec from remote branch to host after GenerateSpec succeeds

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -64,6 +64,19 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			logger.Warn("spec generation failed, continuing without spec", "error", err)
 		} else if specResult.TimedOut {
 			logger.Warn("spec generation timed out, continuing without spec")
+		} else {
+			// The spec was pushed to the remote branch inside the container but
+			// the host filesystem never received it. Fetch it now so that
+			// HasScenarioSpec works for all subsequent orchestrator-side checks.
+			if _, fetchErr := GuardRunner("git", "fetch", "origin", branch); fetchErr == nil {
+				if _, checkoutErr := GuardRunner("git", "checkout", "FETCH_HEAD", "--", cfg.ScenarioDir); checkoutErr != nil {
+					logger.Warn("failed to checkout spec from remote branch", "branch", branch, "error", checkoutErr)
+				} else {
+					logger.Info("fetched spec from remote branch", "branch", branch, "scenario_dir", cfg.ScenarioDir)
+				}
+			} else {
+				logger.Warn("failed to fetch remote branch for spec", "branch", branch, "error", fetchErr)
+			}
 		}
 	}
 

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1277,6 +1277,134 @@ func TestProcessIssue_PreMergeGuardRejectsApprovalWithoutTests(t *testing.T) {
 	}
 }
 
+// TestProcessIssue_FetchesSpecAfterSuccessfulGeneration verifies that after
+// GenerateSpec succeeds, loop.go issues git fetch and git checkout to pull the
+// spec file from the remote branch to the host ScenarioDir.
+func TestProcessIssue_FetchesSpecAfterSuccessfulGeneration(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	var guardCalls [][]string
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		call := append([]string{name}, args...)
+		guardCalls = append(guardCalls, call)
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // spec generator
+			return []byte(wrapRunnerJSON("spec generated")), []byte(""), 0, nil
+		case 2: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 3: // quality reviewer
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // functional reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	cfg := loopConfig()
+	prompts := testPrompts(t)
+	prompts.SpecGenerator = "Generate spec for #{{.IssueNumber}}"
+
+	ProcessIssue(context.Background(), loopIssue(), cfg, prompts, nil, testLogger(t), nil)
+
+	// Verify git fetch origin <branch> was called.
+	expectedBranch := BranchName(loopIssue().Number, Slugify(loopIssue().Title))
+	fetchFound := false
+	checkoutFound := false
+	for _, call := range guardCalls {
+		if len(call) == 4 && call[0] == "git" && call[1] == "fetch" && call[2] == "origin" && call[3] == expectedBranch {
+			fetchFound = true
+		}
+		if len(call) == 5 && call[0] == "git" && call[1] == "checkout" && call[2] == "FETCH_HEAD" && call[3] == "--" && call[4] == cfg.ScenarioDir {
+			checkoutFound = true
+		}
+	}
+	if !fetchFound {
+		t.Errorf("expected git fetch origin %s to be called, guard calls: %v", expectedBranch, guardCalls)
+	}
+	if !checkoutFound {
+		t.Errorf("expected git checkout FETCH_HEAD -- %s to be called, guard calls: %v", cfg.ScenarioDir, guardCalls)
+	}
+}
+
+// TestProcessIssue_ContinuesWhenSpecFetchFails verifies that a git fetch
+// failure after spec generation does not abort the issue processing.
+func TestProcessIssue_ContinuesWhenSpecFetchFails(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "git" && len(args) > 1 && args[0] == "fetch" {
+			return nil, fmt.Errorf("fetch failed: remote not found")
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // spec generator
+			return []byte(wrapRunnerJSON("spec generated")), []byte(""), 0, nil
+		case 2: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 3: // quality reviewer
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // functional reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	prompts := testPrompts(t)
+	prompts.SpecGenerator = "Generate spec for #{{.IssueNumber}}"
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t), nil)
+
+	// Fetch failure must not abort the run; processing should continue normally.
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+}
+
 // TestProcessIssue_PreMergeGuardAllowsApprovalWithTests verifies that when the
 // functional reviewer approves a PR and writes tests, the guard does not interfere.
 func TestProcessIssue_PreMergeGuardAllowsApprovalWithTests(t *testing.T) {


### PR DESCRIPTION
Closes #167

## Implementation Notes

### Approach
After `GenerateSpec()` succeeds in `ProcessIssue` (loop.go), the fix fetches the scenario spec from the remote feature branch to the host's `ScenarioDir` before continuing:

```go
if _, fetchErr := GuardRunner("git", "fetch", "origin", branch); fetchErr == nil {
    if _, checkoutErr := GuardRunner("git", "checkout", "FETCH_HEAD", "--", cfg.ScenarioDir); checkoutErr != nil {
        logger.Warn("failed to checkout spec from remote branch", ...)
    } else {
        logger.Info("fetched spec from remote branch", ...)
    }
} else {
    logger.Warn("failed to fetch remote branch for spec", ...)
}
```

The `branch` variable is already computed earlier in `ProcessIssue`, so no additional state is needed.

### Key Decisions
- **Best-effort only**: fetch/checkout failures are logged as warnings and do not abort processing. The existing behavior (continuing without a spec) is preserved as the fallback.
- **Uses existing `GuardRunner` seam**: no new abstractions needed; the same replaceable function variable used by the rest of the file makes the new code trivially testable.
- **Only fetches `ScenarioDir`**: `git checkout FETCH_HEAD -- <ScenarioDir>` checks out only the scenario directory files, not the full branch, keeping the host worktree clean.

### Known Limitations
- The implementer's container still clones from `main` and won't see the spec. The implementer prompt already handles this via the `HasScenarioSpec` template variable, so no change is needed there.
- Committing the spec to `main` before implementation (alternative approach mentioned in the issue) was intentionally avoided to prevent polluting `main` with pre-implementation artifacts.

### Architecture
Only the `orchestration` layer (`internal/agent/loop.go`) was touched. The fix uses `GuardRunner` (already present in the file) and the `branch` variable (already in scope). No new imports or dependencies were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)