### PR TITLE
fix: preserve failed functional reviews in retry timeline

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -246,12 +246,11 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		// Functional reviewer is subject to all quality checks including CheckReviewTestExecution.
 		fFlags := computeReviewFlags(reviewResult.AgentResult, cfg, true, hasSpec)
 		fRDFlags := logAndRecordFlags(fFlags, logger, issue.Number)
+		// Build fStep here so it is available after the quality gate override below.
+		var fStep rundata.StepResult
 		if hook != nil {
-			fStep := ResultToStep(reviewResult.AgentResult)
+			fStep = ResultToStep(reviewResult.AgentResult)
 			fStep.Flags = fRDFlags
-			if err := hook.WriteReviewResult(issue.Number, "functional", fStep); err != nil {
-				logger.Warn("failed to write functional review result", "error", err)
-			}
 		}
 
 		// Pre-merge guard: if the reviewer approved without writing tests to the
@@ -278,6 +277,23 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			)
 			if _, err := GuardRunner("gh", "pr", "comment", fmt.Sprintf("%d", prNum), "--repo", cfg.Repo, "--body", overrideComment); err != nil {
 				logger.Warn("failed to post quality gate override comment", "error", err)
+			}
+		}
+
+		// Write the functional review result. Pre-retry failures are stored in the
+		// retry directory so the timeline can show each failed review before its
+		// corresponding retry. Only the final iteration (approved or retries exhausted)
+		// writes to the top-level functional-review.json.
+		if hook != nil {
+			retriesLeft := maxAttempts - attempt - 1
+			if reviewResult.Verdict == "CHANGES_REQUESTED" && retriesLeft > 0 {
+				if err := hook.WriteRetryFunctionalReview(issue.Number, attempt, fStep); err != nil {
+					logger.Warn("failed to write retry functional review result", "error", err)
+				}
+			} else {
+				if err := hook.WriteReviewResult(issue.Number, "functional", fStep); err != nil {
+					logger.Warn("failed to write functional review result", "error", err)
+				}
 			}
 		}
 

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -849,11 +849,12 @@ func TestProcessIssue_SkipsQualityReviewWhenNoPrompt(t *testing.T) {
 
 // testRunDataHook is a simple RunDataHook implementation for unit tests.
 type testRunDataHook struct {
-	implementCalls   int
-	reviewKinds      []string
-	retryCalls       int
-	retryReviewCalls int
-	outcomes         []rundata.Outcome
+	implementCalls            int
+	reviewKinds               []string
+	retryCalls                int
+	retryReviewCalls          int
+	retryFunctionalReviewCalls int
+	outcomes                  []rundata.Outcome
 }
 
 func (h *testRunDataHook) WriteImplementResult(_ int, _ rundata.StepResult) error {
@@ -870,6 +871,10 @@ func (h *testRunDataHook) WriteRetryResult(_ int, _ int, _ rundata.StepResult) e
 }
 func (h *testRunDataHook) WriteRetryReviewResult(_ int, _ int, _ rundata.StepResult) error {
 	h.retryReviewCalls++
+	return nil
+}
+func (h *testRunDataHook) WriteRetryFunctionalReview(_ int, _ int, _ rundata.StepResult) error {
+	h.retryFunctionalReviewCalls++
 	return nil
 }
 func (h *testRunDataHook) WriteOutcome(o rundata.Outcome) error {
@@ -1512,5 +1517,90 @@ func TestProcessIssue_PreMergeGuardAllowsApprovalWithTests(t *testing.T) {
 	// Should be exactly 3 agent calls: implement + quality + functional (no retries).
 	if callIdx != 3 {
 		t.Errorf("expected 3 agent calls (implement + quality + review), got %d", callIdx)
+	}
+}
+
+// retryFunctionalReviewHook extends testRunDataHook to capture attempts passed to
+// WriteRetryFunctionalReview so tests can verify the routing logic.
+type retryFunctionalReviewHook struct {
+	testRunDataHook
+	retryFunctionalAttempts []int
+}
+
+func (h *retryFunctionalReviewHook) WriteRetryFunctionalReview(_ int, attempt int, _ rundata.StepResult) error {
+	h.retryFunctionalAttempts = append(h.retryFunctionalAttempts, attempt)
+	return nil
+}
+
+// TestProcessIssue_FunctionalRetrySavedToRetryDir verifies that when the functional
+// reviewer returns CHANGES_REQUESTED and a retry remains, WriteRetryFunctionalReview
+// is called (not WriteReviewResult("functional")), and that WriteReviewResult is
+// called only for the final iteration.
+func TestProcessIssue_FunctionalRetrySavedToRetryDir(t *testing.T) {
+	cfg := loopConfig()
+	cfg.MaxRetries = 1 // 2 attempts: attempt=0 (CHANGES_REQUESTED) → attempt=1 (APPROVED)
+
+	hook := &retryFunctionalReviewHook{}
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	// WriteRetryFunctionalReview should be called once (attempt=0).
+	if len(hook.retryFunctionalAttempts) != 1 {
+		t.Fatalf("WriteRetryFunctionalReview called %d times, want 1", len(hook.retryFunctionalAttempts))
+	}
+	if hook.retryFunctionalAttempts[0] != 0 {
+		t.Errorf("WriteRetryFunctionalReview attempt = %d, want 0", hook.retryFunctionalAttempts[0])
+	}
+	// WriteReviewResult("functional") should be called once (the final, approved attempt).
+	foundFunctional := false
+	for _, k := range hook.reviewKinds {
+		if k == "functional" {
+			foundFunctional = true
+		}
+	}
+	if !foundFunctional {
+		t.Errorf("WriteReviewResult(\"functional\") not called for final attempt; calls: %v", hook.reviewKinds)
+	}
+}
+
+// TestProcessIssue_FunctionalApprovalWritesTopLevel verifies that when the
+// functional reviewer approves on the first attempt (no retry), WriteReviewResult
+// is called (not WriteRetryFunctionalReview).
+func TestProcessIssue_FunctionalApprovalWritesTopLevel(t *testing.T) {
+	hook := &retryFunctionalReviewHook{}
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	// WriteRetryFunctionalReview should NOT be called when approved on first try.
+	if len(hook.retryFunctionalAttempts) != 0 {
+		t.Errorf("WriteRetryFunctionalReview should not be called on approval, got %d calls", len(hook.retryFunctionalAttempts))
+	}
+	// WriteReviewResult("functional") should be called.
+	foundFunctional := false
+	for _, k := range hook.reviewKinds {
+		if k == "functional" {
+			foundFunctional = true
+		}
+	}
+	if !foundFunctional {
+		t.Errorf("WriteReviewResult(\"functional\") not called; calls: %v", hook.reviewKinds)
 	}
 }

--- a/internal/agent/runhook.go
+++ b/internal/agent/runhook.go
@@ -10,5 +10,6 @@ type RunDataHook interface {
 	WriteReviewResult(issueNumber int, kind string, step rundata.StepResult) error
 	WriteRetryResult(issueNumber int, attempt int, step rundata.StepResult) error
 	WriteRetryReviewResult(issueNumber int, attempt int, step rundata.StepResult) error
+	WriteRetryFunctionalReview(issueNumber int, attempt int, step rundata.StepResult) error
 	WriteOutcome(outcome rundata.Outcome) error
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -356,8 +356,8 @@ func issueToRowView(issue rundata.IssueDetail, owner, repo, timestamp string) Is
 	flagCount := len(issue.Implement.Flags) + len(issue.QualityReview.Flags) + len(issue.FunctionalReview.Flags)
 	totalCost := issue.Implement.CostUSD + issue.QualityReview.CostUSD + issue.FunctionalReview.CostUSD
 	for _, retry := range issue.Retries {
-		flagCount += len(retry.Retry.Flags) + len(retry.QualityReview.Flags)
-		totalCost += retry.Retry.CostUSD + retry.QualityReview.CostUSD
+		flagCount += len(retry.Retry.Flags) + len(retry.QualityReview.Flags) + len(retry.FunctionalReview.Flags)
+		totalCost += retry.Retry.CostUSD + retry.QualityReview.CostUSD + retry.FunctionalReview.CostUSD
 	}
 
 	statusLabel := "Running"
@@ -404,6 +404,9 @@ func buildTimeline(issue rundata.IssueDetail) []TimelineStepView {
 		steps = append(steps, stepToView("Quality Review", issue.QualityReview))
 	}
 	for _, retry := range issue.Retries {
+		if hasStepData(retry.FunctionalReview) {
+			steps = append(steps, stepToView("Functional Review", retry.FunctionalReview))
+		}
 		if hasStepData(retry.Retry) {
 			steps = append(steps, stepToView(fmt.Sprintf("Retry %d", retry.Attempt+1), retry.Retry))
 		}

--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -512,6 +512,85 @@ func TestServer_IssueDetail_WithRetries(t *testing.T) {
 	}
 }
 
+// TestServer_IssueDetail_FunctionalReviewBeforeRetry verifies that when a retry
+// directory contains a functional-review.json, the timeline shows the functional
+// review step before the corresponding retry implementer step.
+func TestServer_IssueDetail_FunctionalReviewBeforeRetry(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{15},
+		StartedAt:    now,
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "15")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"),
+		rundata.Outcome{IssueNumber: 15, Status: "implemented"})
+	writeJSON(t, filepath.Join(issueDir, "implement.json"),
+		rundata.StepResult{Output: "first attempt", DurationSeconds: 30})
+
+	// Retry 0: functional review (CHANGES_REQUESTED) stored in retry dir, then retry implementer.
+	retryDir := filepath.Join(issueDir, "retries", "0")
+	if err := os.MkdirAll(retryDir, 0o755); err != nil {
+		t.Fatalf("creating retry dir: %v", err)
+	}
+	writeJSON(t, filepath.Join(retryDir, "functional-review.json"),
+		rundata.StepResult{Output: "REVIEW_RESULT=CHANGES_REQUESTED", DurationSeconds: 10})
+	writeJSON(t, filepath.Join(retryDir, "retry.json"),
+		rundata.StepResult{Output: "retry attempt", DurationSeconds: 25})
+
+	// Final functional review at top level (APPROVED).
+	writeJSON(t, filepath.Join(issueDir, "functional-review.json"),
+		rundata.StepResult{Output: "REVIEW_RESULT=APPROVED", DurationSeconds: 8})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/15", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 500))
+	}
+	body := rr.Body.String()
+
+	// Both the pre-retry functional review and the retry step must be present.
+	if !strings.Contains(body, "Functional Review") {
+		t.Error("body missing Functional Review step")
+	}
+	if !strings.Contains(body, "Retry 1") {
+		t.Error("body missing Retry 1 step")
+	}
+
+	// The pre-retry functional review (Changes Requested) must appear BEFORE Retry 1.
+	idxFR := strings.Index(body, "Changes Requested")
+	idxRetry := strings.Index(body, "Retry 1")
+	if idxFR < 0 {
+		t.Error("body missing 'Changes Requested' verdict from pre-retry functional review")
+	}
+	if idxRetry < 0 {
+		t.Error("body missing 'Retry 1' step")
+	}
+	if idxFR >= 0 && idxRetry >= 0 && idxFR > idxRetry {
+		t.Error("Functional Review (Changes Requested) should appear before Retry 1")
+	}
+
+	// The final functional review (Passed) should appear after Retry 1.
+	idxPassed := strings.LastIndex(body, "Passed")
+	if idxPassed < 0 {
+		t.Error("body missing final 'Passed' verdict from approved functional review")
+	}
+	if idxRetry >= 0 && idxPassed >= 0 && idxPassed < idxRetry {
+		t.Error("final Functional Review (Passed) should appear after Retry 1")
+	}
+}
+
 // --- Dialogue tests ---
 
 // writeDialogueFile writes a dialogue.json file under issueDir.

--- a/internal/rundata/reader.go
+++ b/internal/rundata/reader.go
@@ -14,9 +14,10 @@ import (
 
 // RetryDetail holds the step results for one retry attempt.
 type RetryDetail struct {
-	Attempt       int
-	Retry         StepResult
-	QualityReview StepResult
+	Attempt          int
+	Retry            StepResult
+	QualityReview    StepResult
+	FunctionalReview StepResult
 }
 
 // IssueDetail aggregates all data for one issue within a run.
@@ -326,9 +327,10 @@ func (r *Reader) loadRetries(retriesDir string) []RetryDetail {
 		}
 		retryDir := filepath.Join(retriesDir, entry.Name())
 		retries = append(retries, RetryDetail{
-			Attempt:       attempt,
-			Retry:         r.readStep(filepath.Join(retryDir, "retry.json")),
-			QualityReview: r.readStep(filepath.Join(retryDir, "quality-review.json")),
+			Attempt:          attempt,
+			Retry:            r.readStep(filepath.Join(retryDir, "retry.json")),
+			QualityReview:    r.readStep(filepath.Join(retryDir, "quality-review.json")),
+			FunctionalReview: r.readStep(filepath.Join(retryDir, "functional-review.json")),
 		})
 	}
 

--- a/internal/rundata/reader_test.go
+++ b/internal/rundata/reader_test.go
@@ -382,6 +382,77 @@ func TestListRunsAcrossMultipleReposSameOwner(t *testing.T) {
 	}
 }
 
+func TestLoadRunRetryFunctionalReview(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:      "owner/repo",
+		StartedAt: time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "10")
+	retryDir := filepath.Join(issueDir, "retries", "0")
+	if err := os.MkdirAll(retryDir, 0o755); err != nil {
+		t.Fatalf("creating retry dir: %v", err)
+	}
+	if err := writeJSON(filepath.Join(retryDir, "retry.json"), StepResult{Output: "retry output"}); err != nil {
+		t.Fatalf("writing retry.json: %v", err)
+	}
+	if err := writeJSON(filepath.Join(retryDir, "functional-review.json"), StepResult{Output: "REVIEW_RESULT=CHANGES_REQUESTED"}); err != nil {
+		t.Fatalf("writing functional-review.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+	retries := detail.Issues[0].Retries
+	if len(retries) != 1 {
+		t.Fatalf("expected 1 retry, got %d", len(retries))
+	}
+	if retries[0].FunctionalReview.Output != "REVIEW_RESULT=CHANGES_REQUESTED" {
+		t.Errorf("FunctionalReview.Output = %q, want %q",
+			retries[0].FunctionalReview.Output, "REVIEW_RESULT=CHANGES_REQUESTED")
+	}
+}
+
+func TestLoadRunRetryFunctionalReviewAbsentIsZero(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:      "owner/repo",
+		StartedAt: time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "10")
+	retryDir := filepath.Join(issueDir, "retries", "0")
+	if err := os.MkdirAll(retryDir, 0o755); err != nil {
+		t.Fatalf("creating retry dir: %v", err)
+	}
+	// Only retry.json written — no functional-review.json.
+	if err := writeJSON(filepath.Join(retryDir, "retry.json"), StepResult{Output: "retry output"}); err != nil {
+		t.Fatalf("writing retry.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	retries := detail.Issues[0].Retries
+	if len(retries) != 1 {
+		t.Fatalf("expected 1 retry, got %d", len(retries))
+	}
+	// FunctionalReview should be zero value when file is absent.
+	if retries[0].FunctionalReview.Output != "" || retries[0].FunctionalReview.Error != "" {
+		t.Errorf("FunctionalReview should be zero value when absent, got %+v", retries[0].FunctionalReview)
+	}
+}
+
 func TestLoadRunRetriesSortedByAttempt(t *testing.T) {
 	base := t.TempDir()
 	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -142,6 +142,14 @@ func (w *Writer) WriteRetryReviewResult(issueNum, retryNum int, step StepResult)
 	return writeJSONMkdirs(path, step)
 }
 
+// WriteRetryFunctionalReview writes the functional review result that triggered a retry.
+// Path: issues/<issueNum>/retries/<retryNum>/functional-review.json
+func (w *Writer) WriteRetryFunctionalReview(issueNum, retryNum int, step StepResult) error {
+	path := filepath.Join(w.dir, "issues", fmt.Sprintf("%d", issueNum),
+		"retries", fmt.Sprintf("%d", retryNum), "functional-review.json")
+	return writeJSONMkdirs(path, step)
+}
+
 // WriteOutcome writes the outcome for the issue identified by outcome.IssueNumber.
 // Path: issues/<issueNum>/outcome.json
 func (w *Writer) WriteOutcome(outcome Outcome) error {

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -239,6 +239,24 @@ func TestRetryReviewWritten(t *testing.T) {
 	}
 }
 
+func TestRetryFunctionalReviewWritten(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := StepResult{Output: "REVIEW_RESULT=CHANGES_REQUESTED"}
+	if err := w.WriteRetryFunctionalReview(42, 0, step); err != nil {
+		t.Fatalf("WriteRetryFunctionalReview() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "retries", "0", "functional-review.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file at %s, got: %v", path, err)
+	}
+}
+
 func TestOutcomeWritten(t *testing.T) {
 	base := t.TempDir()
 	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})


### PR DESCRIPTION
## Summary

- When the functional reviewer returns `CHANGES_REQUESTED` and a retry occurs, the pre-retry result is now stored in `retries/<attempt>/functional-review.json` instead of overwriting `functional-review.json`
- The dashboard timeline now shows each failed functional review before its corresponding retry step
- Only the final functional review (approved or retries exhausted) is written to the top-level `functional-review.json`

## Implementation Notes

### Approach
Matched the existing pattern used for quality reviews: pre-retry quality reviews go to `retries/N/quality-review.json`, so pre-retry functional reviews now go to `retries/N/functional-review.json`. The fix restructures the write in `loop.go` to happen after the quality gate override (so the final verdict is known), then routes to the retry directory when a retry will follow.

### Key Decisions
- **Delay the write until after quality gate override**: The quality gate may change `APPROVED` → `CHANGES_REQUESTED`. Writing before the override could store the wrong verdict in the top-level file. Moving the write after the override ensures correct routing.
- **`retriesLeft` computed at write time**: Rather than threading state through the switch, `retriesLeft` is computed once at the write point to determine whether a retry will follow.
- **Timeline rendering**: `retry.FunctionalReview` is rendered before the retry step in `buildTimeline()`, so the chain reads: Functional Review (Changes Requested) → Retry N → ... → Functional Review (Passed).

### Known Limitations
- If both quality and functional review loops produce retries for the same issue, they share the `retries/` namespace. This pre-existing design means functional retry 0 would write to `retries/0/functional-review.json`, while quality retry 0 writes to `retries/0/quality-review.json` and `retries/0/retry.json` — the two loops use distinct filenames within the same directory, so there is no collision in practice.

### Architecture
- **`internal/agent`** (orchestration): `loop.go` routing fix; `runhook.go` interface addition — no new layer dependencies
- **`internal/rundata`** (domain): `writer.go` new method; `reader.go` new struct field and `loadRetries` update — pure data layer, no dependency changes
- **`internal/dashboard`** (presentation): `handlers.go` `buildTimeline` update — consumes `domain` models only, per architecture rules

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)