### PR TITLE
fix: preserve pre-retry functional reviews in timeline

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -246,13 +246,8 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		// Functional reviewer is subject to all quality checks including CheckReviewTestExecution.
 		fFlags := computeReviewFlags(reviewResult.AgentResult, cfg, true, hasSpec)
 		fRDFlags := logAndRecordFlags(fFlags, logger, issue.Number)
-		if hook != nil {
-			fStep := ResultToStep(reviewResult.AgentResult)
-			fStep.Flags = fRDFlags
-			if err := hook.WriteReviewResult(issue.Number, "functional", fStep); err != nil {
-				logger.Warn("failed to write functional review result", "error", err)
-			}
-		}
+		fStep := ResultToStep(reviewResult.AgentResult)
+		fStep.Flags = fRDFlags
 
 		// Pre-merge guard: if the reviewer approved without writing tests to the
 		// review dir, re-run the reviewer. The reviewer is the agent responsible
@@ -268,6 +263,12 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 
 		switch reviewResult.Verdict {
 		case "APPROVED":
+			// Final result — write to top-level functional-review.json.
+			if hook != nil {
+				if err := hook.WriteReviewResult(issue.Number, "functional", fStep); err != nil {
+					logger.Warn("failed to write functional review result", "error", err)
+				}
+			}
 			if cfg.NoMerge {
 				// Skip merge — human will review and merge manually.
 				logger.Info("PR approved, skipping merge (--no-merge)", "pr_number", prNum)
@@ -288,7 +289,20 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		case "CHANGES_REQUESTED":
 			retriesLeft := maxAttempts - attempt - 1
 			if retriesLeft <= 0 {
+				// Exhausted retries — write to top-level functional-review.json.
+				if hook != nil {
+					if err := hook.WriteReviewResult(issue.Number, "functional", fStep); err != nil {
+						logger.Warn("failed to write functional review result", "error", err)
+					}
+				}
 				break // exit loop, will label needs-human-review
+			}
+
+			// More retries available — write to retry dir so the pre-retry review is preserved.
+			if hook != nil {
+				if err := hook.WriteRetryFunctionalReviewResult(issue.Number, attempt, fStep); err != nil {
+					logger.Warn("failed to write functional review result", "error", err)
+				}
 			}
 
 			logger.Info("retrying implementation",
@@ -325,7 +339,12 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			}
 
 		default:
-			// No verdict found — treat as failure.
+			// No verdict found — write to top-level and treat as failure.
+			if hook != nil {
+				if err := hook.WriteReviewResult(issue.Number, "functional", fStep); err != nil {
+					logger.Warn("failed to write functional review result", "error", err)
+				}
+			}
 			outcome.Status = "failed"
 			outcome.Err = fmt.Errorf("reviewer agent did not produce a verdict")
 			return outcome

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -849,11 +849,12 @@ func TestProcessIssue_SkipsQualityReviewWhenNoPrompt(t *testing.T) {
 
 // testRunDataHook is a simple RunDataHook implementation for unit tests.
 type testRunDataHook struct {
-	implementCalls   int
-	reviewKinds      []string
-	retryCalls       int
-	retryReviewCalls int
-	outcomes         []rundata.Outcome
+	implementCalls               int
+	reviewKinds                  []string
+	retryCalls                   int
+	retryReviewCalls             int
+	retryFunctionalReviewCalls   int
+	outcomes                     []rundata.Outcome
 }
 
 func (h *testRunDataHook) WriteImplementResult(_ int, _ rundata.StepResult) error {
@@ -870,6 +871,10 @@ func (h *testRunDataHook) WriteRetryResult(_ int, _ int, _ rundata.StepResult) e
 }
 func (h *testRunDataHook) WriteRetryReviewResult(_ int, _ int, _ rundata.StepResult) error {
 	h.retryReviewCalls++
+	return nil
+}
+func (h *testRunDataHook) WriteRetryFunctionalReviewResult(_ int, _ int, _ rundata.StepResult) error {
+	h.retryFunctionalReviewCalls++
 	return nil
 }
 func (h *testRunDataHook) WriteOutcome(o rundata.Outcome) error {
@@ -1438,5 +1443,128 @@ func TestProcessIssue_PreMergeGuardAllowsApprovalWithTests(t *testing.T) {
 	// Should be exactly 3 agent calls: implement + quality + functional (no retries).
 	if callIdx != 3 {
 		t.Errorf("expected 3 agent calls (implement + quality + review), got %d", callIdx)
+	}
+}
+
+// captureRetryFunctionalHook extends testRunDataHook to record which attempts
+// triggered WriteRetryFunctionalReviewResult vs WriteReviewResult("functional").
+type captureRetryFunctionalHook struct {
+	testRunDataHook
+	retryFunctionalAttempts []int    // attempt indices passed to WriteRetryFunctionalReviewResult
+	topLevelFunctionalKinds []string // kinds passed to WriteReviewResult
+}
+
+func (h *captureRetryFunctionalHook) WriteReviewResult(_ int, kind string, _ rundata.StepResult) error {
+	h.reviewKinds = append(h.reviewKinds, kind)
+	h.topLevelFunctionalKinds = append(h.topLevelFunctionalKinds, kind)
+	return nil
+}
+
+func (h *captureRetryFunctionalHook) WriteRetryFunctionalReviewResult(_ int, attempt int, _ rundata.StepResult) error {
+	h.retryFunctionalReviewCalls++
+	h.retryFunctionalAttempts = append(h.retryFunctionalAttempts, attempt)
+	return nil
+}
+
+// TestProcessIssue_FunctionalReviewOnRetry_WritesToRetryDir verifies that when
+// the functional reviewer returns CHANGES_REQUESTED and a retry is available,
+// the pre-retry review is written to the retry dir (not top-level).
+func TestProcessIssue_FunctionalReviewOnRetry_WritesToRetryDir(t *testing.T) {
+	hook := &captureRetryFunctionalHook{}
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	// Pre-retry functional review should go to retry dir (attempt 0).
+	if hook.retryFunctionalReviewCalls != 1 {
+		t.Errorf("WriteRetryFunctionalReviewResult called %d times, want 1", hook.retryFunctionalReviewCalls)
+	}
+	if len(hook.retryFunctionalAttempts) == 1 && hook.retryFunctionalAttempts[0] != 0 {
+		t.Errorf("WriteRetryFunctionalReviewResult attempt = %d, want 0", hook.retryFunctionalAttempts[0])
+	}
+	// Final (approved) functional review should go to top-level.
+	functionalTopLevel := 0
+	for _, k := range hook.topLevelFunctionalKinds {
+		if k == "functional" {
+			functionalTopLevel++
+		}
+	}
+	if functionalTopLevel != 1 {
+		t.Errorf("WriteReviewResult(\"functional\") top-level called %d times, want 1; kinds: %v", functionalTopLevel, hook.topLevelFunctionalKinds)
+	}
+}
+
+// TestProcessIssue_FunctionalReviewExhausted_WritesToTopLevel verifies that when
+// retries are exhausted, the final CHANGES_REQUESTED review goes to top-level.
+func TestProcessIssue_FunctionalReviewExhausted_WritesToTopLevel(t *testing.T) {
+	cfg := loopConfig()
+	cfg.MaxRetries = 1
+
+	hook := &captureRetryFunctionalHook{}
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+	}, loopGuardFn)
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
+
+	if outcome.Status != "needs-human-review" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "needs-human-review", outcome.Err)
+	}
+	// First CHANGES_REQUESTED goes to retry dir (attempt 0 — retry available).
+	if hook.retryFunctionalReviewCalls != 1 {
+		t.Errorf("WriteRetryFunctionalReviewResult called %d times, want 1", hook.retryFunctionalReviewCalls)
+	}
+	// Final CHANGES_REQUESTED (retries exhausted) goes to top-level.
+	functionalTopLevel := 0
+	for _, k := range hook.topLevelFunctionalKinds {
+		if k == "functional" {
+			functionalTopLevel++
+		}
+	}
+	if functionalTopLevel != 1 {
+		t.Errorf("WriteReviewResult(\"functional\") top-level called %d times, want 1 (for exhausted retry); kinds: %v", functionalTopLevel, hook.topLevelFunctionalKinds)
+	}
+}
+
+// TestProcessIssue_FunctionalReviewApproved_WritesToTopLevel verifies that when
+// the functional reviewer approves on the first attempt, the result goes to top-level
+// and WriteRetryFunctionalReviewResult is never called.
+func TestProcessIssue_FunctionalReviewApproved_WritesToTopLevel(t *testing.T) {
+	hook := &captureRetryFunctionalHook{}
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if hook.retryFunctionalReviewCalls != 0 {
+		t.Errorf("WriteRetryFunctionalReviewResult called %d times, want 0", hook.retryFunctionalReviewCalls)
+	}
+	functionalTopLevel := 0
+	for _, k := range hook.topLevelFunctionalKinds {
+		if k == "functional" {
+			functionalTopLevel++
+		}
+	}
+	if functionalTopLevel != 1 {
+		t.Errorf("WriteReviewResult(\"functional\") called %d times, want 1; kinds: %v", functionalTopLevel, hook.topLevelFunctionalKinds)
 	}
 }

--- a/internal/agent/runhook.go
+++ b/internal/agent/runhook.go
@@ -10,5 +10,6 @@ type RunDataHook interface {
 	WriteReviewResult(issueNumber int, kind string, step rundata.StepResult) error
 	WriteRetryResult(issueNumber int, attempt int, step rundata.StepResult) error
 	WriteRetryReviewResult(issueNumber int, attempt int, step rundata.StepResult) error
+	WriteRetryFunctionalReviewResult(issueNumber int, attempt int, step rundata.StepResult) error
 	WriteOutcome(outcome rundata.Outcome) error
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -356,8 +356,8 @@ func issueToRowView(issue rundata.IssueDetail, owner, repo, timestamp string) Is
 	flagCount := len(issue.Implement.Flags) + len(issue.QualityReview.Flags) + len(issue.FunctionalReview.Flags)
 	totalCost := issue.Implement.CostUSD + issue.QualityReview.CostUSD + issue.FunctionalReview.CostUSD
 	for _, retry := range issue.Retries {
-		flagCount += len(retry.Retry.Flags) + len(retry.QualityReview.Flags)
-		totalCost += retry.Retry.CostUSD + retry.QualityReview.CostUSD
+		flagCount += len(retry.Retry.Flags) + len(retry.QualityReview.Flags) + len(retry.FunctionalReview.Flags)
+		totalCost += retry.Retry.CostUSD + retry.QualityReview.CostUSD + retry.FunctionalReview.CostUSD
 	}
 
 	statusLabel := "Running"
@@ -404,6 +404,9 @@ func buildTimeline(issue rundata.IssueDetail) []TimelineStepView {
 		steps = append(steps, stepToView("Quality Review", issue.QualityReview))
 	}
 	for _, retry := range issue.Retries {
+		if hasStepData(retry.FunctionalReview) {
+			steps = append(steps, stepToView("Functional Review", retry.FunctionalReview))
+		}
 		if hasStepData(retry.Retry) {
 			steps = append(steps, stepToView(fmt.Sprintf("Retry %d", retry.Attempt+1), retry.Retry))
 		}

--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -820,6 +820,80 @@ func TestServer_IssueDetail_ToolTraceSection(t *testing.T) {
 	}
 }
 
+func TestServer_IssueDetail_RetryFunctionalReviewInTimeline(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{15},
+		StartedAt:    now,
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "15")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"),
+		rundata.Outcome{IssueNumber: 15, Status: "implemented"})
+	writeJSON(t, filepath.Join(issueDir, "implement.json"),
+		rundata.StepResult{Output: "impl output", DurationSeconds: 30})
+
+	// Retry 0: pre-retry functional review (CHANGES_REQUESTED) + retry implementer
+	retryDir := filepath.Join(issueDir, "retries", "0")
+	if err := os.MkdirAll(retryDir, 0o755); err != nil {
+		t.Fatalf("creating retry dir: %v", err)
+	}
+	writeJSON(t, filepath.Join(retryDir, "functional-review.json"),
+		rundata.StepResult{Output: "REVIEW_RESULT=CHANGES_REQUESTED", DurationSeconds: 8})
+	writeJSON(t, filepath.Join(retryDir, "retry.json"),
+		rundata.StepResult{Output: "retry output", DurationSeconds: 25})
+
+	// Final functional review (APPROVED)
+	writeJSON(t, filepath.Join(issueDir, "functional-review.json"),
+		rundata.StepResult{Output: "REVIEW_RESULT=APPROVED", DurationSeconds: 7})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/15", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 500))
+	}
+	body := rr.Body.String()
+
+	// All steps should be present.
+	for _, want := range []string{"Implement", "Functional Review", "Retry 1"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing timeline step %q", want)
+		}
+	}
+
+	// The pre-retry functional review (Changes Requested) should appear before Retry 1.
+	idxFR := strings.Index(body, "REVIEW_RESULT=CHANGES_REQUESTED")
+	idxRetry := strings.Index(body, "retry output")
+	idxFinal := strings.Index(body, "REVIEW_RESULT=APPROVED")
+
+	if idxFR < 0 {
+		t.Error("body missing pre-retry functional review output")
+	}
+	if idxRetry < 0 {
+		t.Error("body missing retry implementer output")
+	}
+	if idxFinal < 0 {
+		t.Error("body missing final functional review output")
+	}
+	if idxFR >= 0 && idxRetry >= 0 && idxFR > idxRetry {
+		t.Error("pre-retry Functional Review should appear before Retry 1 in timeline")
+	}
+	if idxRetry >= 0 && idxFinal >= 0 && idxRetry > idxFinal {
+		t.Error("Retry 1 should appear before final Functional Review in timeline")
+	}
+}
+
 func TestServer_IssueDetail_NoToolTraceWhenAbsent(t *testing.T) {
 	tmpDir := t.TempDir()
 	now := time.Now().UTC()

--- a/internal/rundata/reader.go
+++ b/internal/rundata/reader.go
@@ -14,9 +14,10 @@ import (
 
 // RetryDetail holds the step results for one retry attempt.
 type RetryDetail struct {
-	Attempt       int
-	Retry         StepResult
-	QualityReview StepResult
+	Attempt          int
+	Retry            StepResult
+	QualityReview    StepResult
+	FunctionalReview StepResult
 }
 
 // IssueDetail aggregates all data for one issue within a run.
@@ -326,9 +327,10 @@ func (r *Reader) loadRetries(retriesDir string) []RetryDetail {
 		}
 		retryDir := filepath.Join(retriesDir, entry.Name())
 		retries = append(retries, RetryDetail{
-			Attempt:       attempt,
-			Retry:         r.readStep(filepath.Join(retryDir, "retry.json")),
-			QualityReview: r.readStep(filepath.Join(retryDir, "quality-review.json")),
+			Attempt:          attempt,
+			Retry:            r.readStep(filepath.Join(retryDir, "retry.json")),
+			QualityReview:    r.readStep(filepath.Join(retryDir, "quality-review.json")),
+			FunctionalReview: r.readStep(filepath.Join(retryDir, "functional-review.json")),
 		})
 	}
 

--- a/internal/rundata/reader_test.go
+++ b/internal/rundata/reader_test.go
@@ -537,6 +537,76 @@ func TestReadDialogueRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLoadRunRetryFunctionalReview(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:      "owner/repo",
+		StartedAt: time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "10")
+	retryDir := filepath.Join(issueDir, "retries", "0")
+	if err := os.MkdirAll(retryDir, 0o755); err != nil {
+		t.Fatalf("creating retry dir: %v", err)
+	}
+	if err := writeJSON(filepath.Join(retryDir, "retry.json"), StepResult{Output: "retry output"}); err != nil {
+		t.Fatalf("writing retry.json: %v", err)
+	}
+	if err := writeJSON(filepath.Join(retryDir, "functional-review.json"), StepResult{Output: "pre-retry functional review"}); err != nil {
+		t.Fatalf("writing functional-review.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+	retries := detail.Issues[0].Retries
+	if len(retries) != 1 {
+		t.Fatalf("expected 1 retry, got %d", len(retries))
+	}
+	if retries[0].FunctionalReview.Output != "pre-retry functional review" {
+		t.Errorf("FunctionalReview.Output = %q, want %q", retries[0].FunctionalReview.Output, "pre-retry functional review")
+	}
+}
+
+func TestLoadRunRetryFunctionalReviewAbsent(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:      "owner/repo",
+		StartedAt: time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "10")
+	retryDir := filepath.Join(issueDir, "retries", "0")
+	if err := os.MkdirAll(retryDir, 0o755); err != nil {
+		t.Fatalf("creating retry dir: %v", err)
+	}
+	// No functional-review.json written in retry dir.
+	if err := writeJSON(filepath.Join(retryDir, "retry.json"), StepResult{Output: "retry output"}); err != nil {
+		t.Fatalf("writing retry.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	retries := detail.Issues[0].Retries
+	if len(retries) != 1 {
+		t.Fatalf("expected 1 retry, got %d", len(retries))
+	}
+	// FunctionalReview should be zero value when file is absent.
+	if retries[0].FunctionalReview.Output != "" {
+		t.Errorf("FunctionalReview.Output = %q, want empty string when file absent", retries[0].FunctionalReview.Output)
+	}
+}
+
 func itoa(n int) string {
 	return strconv.Itoa(n)
 }

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -142,6 +142,14 @@ func (w *Writer) WriteRetryReviewResult(issueNum, retryNum int, step StepResult)
 	return writeJSONMkdirs(path, step)
 }
 
+// WriteRetryFunctionalReviewResult writes the functional review that triggered a retry.
+// Path: issues/<issueNum>/retries/<retryNum>/functional-review.json
+func (w *Writer) WriteRetryFunctionalReviewResult(issueNum, retryNum int, step StepResult) error {
+	path := filepath.Join(w.dir, "issues", fmt.Sprintf("%d", issueNum),
+		"retries", fmt.Sprintf("%d", retryNum), "functional-review.json")
+	return writeJSONMkdirs(path, step)
+}
+
 // WriteOutcome writes the outcome for the issue identified by outcome.IssueNumber.
 // Path: issues/<issueNum>/outcome.json
 func (w *Writer) WriteOutcome(outcome Outcome) error {

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -239,6 +239,24 @@ func TestRetryReviewWritten(t *testing.T) {
 	}
 }
 
+func TestRetryFunctionalReviewWritten(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := StepResult{Output: "pre-retry functional review output"}
+	if err := w.WriteRetryFunctionalReviewResult(42, 0, step); err != nil {
+		t.Fatalf("WriteRetryFunctionalReviewResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "retries", "0", "functional-review.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file at %s, got: %v", path, err)
+	}
+}
+
 func TestOutcomeWritten(t *testing.T) {
 	base := t.TempDir()
 	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})


### PR DESCRIPTION
Closes #164

## Summary

- Write the functional review result to `retries/<attempt>/functional-review.json` when `CHANGES_REQUESTED` and retries remain, instead of overwriting the top-level file
- Write to the top-level `functional-review.json` only on the final iteration (APPROVED, retries exhausted, or no verdict)
- Add `FunctionalReview StepResult` field to `RetryDetail` and read it in `loadRetries()`
- Show the pre-retry functional review step before the retry implementer step in `buildTimeline()`
- Include retry functional review flags/cost in `issueToRowView()` totals

## Implementation Notes

### Approach
Moved hook writes for the functional reviewer out of a single call-site (before the verdict check) into the individual verdict branches inside `switch reviewResult.Verdict`. This lets us route the result to the retry directory when CHANGES_REQUESTED with retries remaining, and to the top-level only for final outcomes.

### Key Decisions
- The `no_review_tests_written` guard (`continue`) was already before the `switch` and remains so. When the reviewer is re-run for missing tests it does not write a hook entry — this preserves the previous behavior for that edge case and avoids creating a retry-dir entry without a corresponding retry implementer step.
- `WriteRetryFunctionalReviewResult` is named consistently with the existing `WriteRetryReviewResult` (quality analogue).
- The timeline renders the pre-retry functional review as `"Functional Review"` (same label as the top-level one), distinguishable by its position before `Retry N`.

### Known Limitations
- If both quality and functional retry loops run for the same issue, they share the same `retries/<attempt>/` index space. The functional retry at attempt 0 would overwrite the quality retry data at attempt 0. This is a pre-existing design limitation not addressed by this PR.

### Architecture
- **orchestration** (`internal/agent/loop.go`, `runhook.go`): adds `WriteRetryFunctionalReviewResult` to the `RunDataHook` interface and calls it at the right moment in the review/retry loop.
- **domain** (`internal/rundata/writer.go`, `reader.go`): adds `WriteRetryFunctionalReviewResult` writer method and `FunctionalReview` field on `RetryDetail`.
- **presentation** (`internal/dashboard/handlers.go`): reads the new field and renders it in the timeline. No new cross-layer dependencies introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)