### PR TITLE
feat: persist punchlist and dialogue in implement command

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -11,6 +11,7 @@ import (
 	"github.com/phs/dark-factory/internal/agent"
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/detect"
+	"github.com/phs/dark-factory/internal/dialogue"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/lock"
 	"github.com/phs/dark-factory/internal/logging"
@@ -144,6 +145,24 @@ loop directly, without milestone or dependency resolution.`,
 
 		outcome := agent.ProcessIssue(ctx, issue, cfg, prompts, authEnv, logger, hook)
 
+		// Write dialogue if we have a PR and a writer.
+		if writer != nil && outcome.PRNumber > 0 {
+			bodies, fetchErr := fetchPRCommentBodiesFn(cfg.Repo, outcome.PRNumber)
+			if fetchErr != nil {
+				logger.Warn("failed to fetch PR comment bodies for dialogue",
+					"issue_number", issueNumber, "error", fetchErr)
+			} else {
+				implNotes, reviewNotes := dialogue.ParseComments(bodies)
+				dialogueEntries := orchestrator.BuildDialogueEntries(implNotes, reviewNotes)
+				if len(dialogueEntries) > 0 {
+					if err := writer.WriteDialogue(issueNumber, dialogueEntries); err != nil {
+						logger.Warn("failed to write dialogue",
+							"issue_number", issueNumber, "error", err)
+					}
+				}
+			}
+		}
+
 		// Finalize run data regardless of outcome.
 		if writer != nil {
 			implemented := 0
@@ -197,6 +216,21 @@ loop directly, without milestone or dependency resolution.`,
 				ChangedFiles: files,
 			}}
 			agent.EnrichPunchlistEntries(ctx, entries, prompts, cfg, authEnv, logger)
+
+			if writer != nil {
+				e := entries[0]
+				plData := rundata.PunchlistData{
+					VerificationSteps: e.ExtractVerificationSteps(),
+					ScenarioCases:     e.ExtractScenarioCases(),
+					AcceptanceTests:   e.AcceptanceTests,
+					ChangedFiles:      e.ChangedFiles,
+				}
+				if err := writer.WritePunchlist(e.IssueNumber, plData); err != nil {
+					logger.Warn("failed to write punchlist data",
+						"issue_number", e.IssueNumber, "error", err)
+				}
+			}
+
 			text := punchlist.Generate(entries)
 			fmt.Println()
 			if err := punchlist.Write(text, punchlistPath); err != nil {
@@ -207,6 +241,10 @@ loop directly, without milestone or dependency resolution.`,
 		return nil
 	},
 }
+
+// fetchPRCommentBodiesFn fetches PR comment bodies for dialogue extraction.
+// Replaceable for testing.
+var fetchPRCommentBodiesFn = github.FetchPRCommentBodies
 
 func init() {
 	f := implementCmd.Flags()

--- a/internal/cmd/implement_test.go
+++ b/internal/cmd/implement_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/phs/dark-factory/internal/github"
+)
+
+func TestFetchPRCommentBodiesFnDefault(t *testing.T) {
+	// The package-level variable must default to the real GitHub implementation
+	// so that dialogue fetching works in production runs.
+	if fetchPRCommentBodiesFn == nil {
+		t.Fatal("fetchPRCommentBodiesFn is nil, want github.FetchPRCommentBodies")
+	}
+
+	// Verify it's the same function by checking it uses github.CommandRunner
+	// (indirectly: stub CommandRunner and confirm the variable calls through).
+	orig := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = orig })
+
+	called := false
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		called = true
+		return []byte("[]"), nil
+	}
+
+	// Call the default function — it will invoke github.CommandRunner.
+	fetchPRCommentBodiesFn("owner/repo", 1) //nolint:errcheck // best-effort; ignore error
+	if !called {
+		t.Error("fetchPRCommentBodiesFn did not delegate to github.CommandRunner, want github.FetchPRCommentBodies")
+	}
+}
+
+func TestFetchPRCommentBodiesFnReplaceable(t *testing.T) {
+	// Confirm the variable can be replaced for testing (testability seam).
+	orig := fetchPRCommentBodiesFn
+	t.Cleanup(func() { fetchPRCommentBodiesFn = orig })
+
+	called := false
+	fetchPRCommentBodiesFn = func(repo string, prNum int) ([]string, error) {
+		called = true
+		return []string{"body1", "body2"}, nil
+	}
+
+	bodies, err := fetchPRCommentBodiesFn("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("replaced fetchPRCommentBodiesFn was not called")
+	}
+	if len(bodies) != 2 {
+		t.Errorf("got %d bodies, want 2", len(bodies))
+	}
+}
+
+func TestImplementCmd_PunchlistFlagRegistered(t *testing.T) {
+	f := implementCmd.Flags().Lookup("punchlist")
+	if f == nil {
+		t.Fatal("implement command missing --punchlist flag")
+	}
+	if f.DefValue != "" {
+		t.Errorf("punchlist default = %q, want %q", f.DefValue, "")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -316,7 +316,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 						"issue_number", issue.Number, "error", fetchErr)
 				} else {
 					implNotes, reviewNotes := dialogue.ParseComments(bodies)
-					entries := buildDialogueEntries(implNotes, reviewNotes)
+					entries := BuildDialogueEntries(implNotes, reviewNotes)
 					if len(entries) > 0 {
 						if err := writer.WriteDialogue(issue.Number, entries); err != nil {
 							logger.Warn("failed to write dialogue",
@@ -464,9 +464,9 @@ var processIssueFn = agent.ProcessIssue
 // Replaceable for testing.
 var fetchPRCommentBodiesFn = github.FetchPRCommentBodies
 
-// buildDialogueEntries interleaves implementation and review notes by round,
+// BuildDialogueEntries interleaves implementation and review notes by round,
 // returning a slice of DialogueEntry values suitable for persisting.
-func buildDialogueEntries(implNotes []dialogue.ImplementationNotes, reviewNotes []dialogue.ReviewNotes) []rundata.DialogueEntry {
+func BuildDialogueEntries(implNotes []dialogue.ImplementationNotes, reviewNotes []dialogue.ReviewNotes) []rundata.DialogueEntry {
 	maxRounds := len(implNotes)
 	if len(reviewNotes) > maxRounds {
 		maxRounds = len(reviewNotes)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -612,7 +612,7 @@ func TestBuildDialogueEntries_SingleRound(t *testing.T) {
 		{Raw: "review body 1"},
 	}
 
-	entries := buildDialogueEntries(implNotes, reviewNotes)
+	entries := BuildDialogueEntries(implNotes, reviewNotes)
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d", len(entries))
 	}
@@ -634,7 +634,7 @@ func TestBuildDialogueEntries_MultipleRounds(t *testing.T) {
 		{Raw: "review 2"},
 	}
 
-	entries := buildDialogueEntries(implNotes, reviewNotes)
+	entries := BuildDialogueEntries(implNotes, reviewNotes)
 	if len(entries) != 4 {
 		t.Fatalf("expected 4 entries, got %d", len(entries))
 	}
@@ -658,7 +658,7 @@ func TestBuildDialogueEntries_MultipleRounds(t *testing.T) {
 }
 
 func TestBuildDialogueEntries_Empty(t *testing.T) {
-	entries := buildDialogueEntries(nil, nil)
+	entries := BuildDialogueEntries(nil, nil)
 	if len(entries) != 0 {
 		t.Errorf("expected 0 entries for empty input, got %d", len(entries))
 	}


### PR DESCRIPTION
Closes #168

## Summary
- Adds `writer.WritePunchlist()` call in `implement.go` after punchlist enrichment, guarded by `writer != nil`
- Adds `writer.WriteDialogue()` call in `implement.go` after processing the outcome, guarded by `writer != nil && outcome.PRNumber > 0`
- Exports `BuildDialogueEntries` from `orchestrator` package (was `buildDialogueEntries`) to avoid code duplication with `implement.go`
- Adds a package-level `fetchPRCommentBodiesFn` testability seam to `implement.go` matching the orchestrator pattern

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] `TestFetchPRCommentBodiesFnDefault` verifies the seam defaults to `github.FetchPRCommentBodies`
- [x] `TestFetchPRCommentBodiesFnReplaceable` verifies the seam can be replaced in tests
- [x] `TestImplementCmd_PunchlistFlagRegistered` verifies the `--punchlist` flag is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)