### PR TITLE
feat: persist and display issue description in run data and dashboard

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -34,6 +34,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			if err := hook.WriteOutcome(rundata.Outcome{
 				IssueNumber: outcome.IssueNumber,
 				Title:       issue.Title,
+				Description: issue.Body,
 				Status:      outcome.Status,
 				PRNumber:    outcome.PRNumber,
 			}); err != nil {

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -61,6 +61,7 @@ type IssueDetailData struct {
 	Timestamp   string
 	IssueNumber int
 	Title       string
+	Description string
 	PRNumber    int
 	PRLink      string
 	IssueLink   string
@@ -332,6 +333,7 @@ func (s *Server) handleIssueDetail(w http.ResponseWriter, r *http.Request) {
 		Timestamp:   timestamp,
 		IssueNumber: issueNum,
 		Title:       found.Outcome.Title,
+		Description: found.Outcome.Description,
 		PRNumber:    found.Outcome.PRNumber,
 		PRLink:      prLink,
 		IssueLink:   issueLink,

--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -978,6 +978,89 @@ func TestServer_IssueDetail_SpecGeneratorInTimeline(t *testing.T) {
 	}
 }
 
+func TestServer_IssueDetail_DescriptionDisplayed(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{30},
+		StartedAt:    now,
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "30")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"),
+		rundata.Outcome{
+			IssueNumber: 30,
+			Status:      "implemented",
+			Description: "This is the issue description body text.",
+		})
+	writeJSON(t, filepath.Join(issueDir, "implement.json"),
+		rundata.StepResult{Output: "done", DurationSeconds: 5})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/30", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "Issue Description") {
+		t.Errorf("body missing 'Issue Description' section header")
+	}
+	if !strings.Contains(body, "This is the issue description body text.") {
+		t.Errorf("body missing description content")
+	}
+	// Should be rendered inside a <details> element (collapsed by default).
+	if !strings.Contains(body, "<details") {
+		t.Errorf("body missing <details> element for collapsible description")
+	}
+}
+
+func TestServer_IssueDetail_NoDescriptionHidesSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{31},
+		StartedAt:    now,
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "31")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	// Outcome with no Description field.
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"),
+		rundata.Outcome{IssueNumber: 31, Status: "implemented"})
+	writeJSON(t, filepath.Join(issueDir, "implement.json"),
+		rundata.StepResult{Output: "done", DurationSeconds: 5})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/31", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	// The Issue Description card should not appear when description is empty.
+	if strings.Contains(body, `card__title">Issue Description`) {
+		t.Errorf("body should not contain 'Issue Description' card when description is absent")
+	}
+}
+
 func TestServer_IssueDetail_SpecGeneratorAbsentOmitted(t *testing.T) {
 	tmpDir := t.TempDir()
 	now := time.Now().UTC()

--- a/internal/dashboard/templates/issue-detail.html
+++ b/internal/dashboard/templates/issue-detail.html
@@ -69,8 +69,23 @@
         </p>
       </div>
 
-      <!-- Review Chain Timeline -->
+      {{if .Description}}
+      <!-- Issue Description -->
       <div class="card animate-in animate-in-1">
+        <div class="card__header">
+          <span class="card__title">Issue Description</span>
+        </div>
+        <div class="card__body" style="padding: var(--space-4) var(--space-5);">
+          <details>
+            <summary style="cursor: pointer; user-select: none; padding: var(--space-2) 0; font-size: var(--text-sm); font-weight: 500;">Show description</summary>
+            <div class="markdown-body" style="margin-top: var(--space-3);">{{renderMarkdown .Description}}</div>
+          </details>
+        </div>
+      </div>
+      {{end}}
+
+      <!-- Review Chain Timeline -->
+      <div class="card animate-in animate-in-2">
         <div class="card__header">
           <span class="card__title">Review Chain</span>
         </div>

--- a/internal/rundata/reader_test.go
+++ b/internal/rundata/reader_test.go
@@ -675,6 +675,43 @@ func TestLoadRunSpecGeneratorAbsentIsZeroValue(t *testing.T) {
 	}
 }
 
+func TestLoadRunOutcomeDescriptionRoundTrip(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:         "owner/repo",
+		IssueNumbers: []int{42},
+		StartedAt:    time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "42")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	wantDesc := "## Problem\nThis is the description.\n\n## Fix\nDo the thing."
+	if err := writeJSON(filepath.Join(issueDir, "outcome.json"), Outcome{
+		IssueNumber: 42,
+		Title:       "My Issue",
+		Description: wantDesc,
+		Status:      "implemented",
+		PRNumber:    7,
+	}); err != nil {
+		t.Fatalf("writing outcome.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+	if detail.Issues[0].Outcome.Description != wantDesc {
+		t.Errorf("Description = %q, want %q", detail.Issues[0].Outcome.Description, wantDesc)
+	}
+}
+
 func itoa(n int) string {
 	return strconv.Itoa(n)
 }

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -48,6 +48,7 @@ type StepResult struct {
 type Outcome struct {
 	IssueNumber int    `json:"issue_number"`
 	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
 	Status      string `json:"status"`
 	PRNumber    int    `json:"pr_number"`
 }

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -293,6 +293,67 @@ func TestOutcomeWritten(t *testing.T) {
 	}
 }
 
+func TestOutcomeDescriptionWritten(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	outcome := Outcome{
+		IssueNumber: 42,
+		Title:       "Some issue title",
+		Description: "## Problem\nThis is the issue body.",
+		Status:      "implemented",
+		PRNumber:    57,
+	}
+	if err := w.WriteOutcome(outcome); err != nil {
+		t.Fatalf("WriteOutcome() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "outcome.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading outcome.json: %v", err)
+	}
+
+	var written Outcome
+	if err := json.Unmarshal(data, &written); err != nil {
+		t.Fatalf("parsing outcome.json: %v", err)
+	}
+
+	if written.Description != outcome.Description {
+		t.Errorf("Description = %q, want %q", written.Description, outcome.Description)
+	}
+}
+
+func TestOutcomeDescriptionOmittedWhenEmpty(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	outcome := Outcome{IssueNumber: 42, Status: "implemented"}
+	if err := w.WriteOutcome(outcome); err != nil {
+		t.Fatalf("WriteOutcome() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "outcome.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading outcome.json: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+	if _, ok := raw["description"]; ok {
+		t.Error("description key should be omitted from JSON when empty")
+	}
+}
+
 func TestFlagsWrittenToReviewJSON(t *testing.T) {
 	base := t.TempDir()
 	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})


### PR DESCRIPTION
## Summary

- Add `Description string` field to `rundata.Outcome` (persisted as `description` in `outcome.json`, omitted when empty)
- Populate it from `issue.Body` in `agent/loop.go`'s deferred `WriteOutcome` call
- Expose it via `IssueDetailData.Description` in the dashboard handler
- Render it in `issue-detail.html` as a collapsible \"Issue Description\" card (using `<details>`) above the Review Chain

## Test plan

- [x] `TestOutcomeDescriptionWritten` — verifies Description field is serialized to `outcome.json`
- [x] `TestOutcomeDescriptionOmittedWhenEmpty` — verifies `description` key is omitted when empty
- [x] `TestLoadRunOutcomeDescriptionRoundTrip` — verifies reader deserializes Description correctly
- [x] `TestServer_IssueDetail_DescriptionDisplayed` — verifies description text and `<details>` appear in rendered page
- [x] `TestServer_IssueDetail_NoDescriptionHidesSection` — verifies description card is absent when field is empty
- [x] Full test suite passes (`go test ./...`)

## Implementation Notes

### Approach
Added a single `Description string` field to the existing `Outcome` struct with `omitempty`, so it's backward-compatible with existing `outcome.json` files (missing field deserializes to empty string). The dashboard renders it only when non-empty, using a native HTML `<details>`/`<summary>` element for collapse — no Alpine.js dependency needed.

### Key Decisions
- Used `omitempty` on the JSON tag to keep existing run data files unaffected.
- Placed the description card before the Review Chain (most useful context to show first) but after the page header.
- Used `<details>` rather than Alpine.js for collapse since descriptions can be long and this requires no JavaScript.

### Known Limitations
- Description is only persisted for runs started after this change; older `outcome.json` files will show no description (gracefully — the card is hidden).

### Architecture
- **domain** (`internal/rundata`): added `Description` field to `Outcome` struct — no new dependencies.
- **orchestration** (`internal/agent`): populated `Description` from `issue.Body` — already depends on `rundata` and `github` packages.
- **presentation** (`internal/dashboard`): reads `Description` from domain type, passes to template — no new dependencies, layer rules satisfied.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)