### PR TITLE
feat(config): add LintCommand, Verify struct, and VerifyFix prompt path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,12 @@ type Quality struct {
 	MinReviewDurationSeconds int     `yaml:"min_review_duration_seconds"`
 }
 
+// Verify holds configuration for the verify step.
+type Verify struct {
+	MaxFixAttempts int  `yaml:"max_fix_attempts"`
+	Blocking       bool `yaml:"blocking"`
+}
+
 // Config holds all configuration for a godark run.
 type Config struct {
 	Repo       string `yaml:"repo"`
@@ -29,6 +35,7 @@ type Config struct {
 	AgentTimeout string            `yaml:"agent_timeout"`
 	BuildCommand string            `yaml:"build_command"`
 	TestCommand  string            `yaml:"test_command"`
+	LintCommand  string            `yaml:"lint_command"`
 	SandboxEnv   map[string]string `yaml:"sandbox_env"`
 	Runtime      Runtime           `yaml:"runtime"`
 
@@ -55,6 +62,7 @@ type Config struct {
 	Docker  Docker  `yaml:"docker"`
 	Prompts Prompts `yaml:"prompts"`
 	Quality Quality `yaml:"quality"`
+	Verify  Verify  `yaml:"verify"`
 }
 
 // Docker holds Docker sandbox configuration.
@@ -75,6 +83,7 @@ type Prompts struct {
 	QualityReviewer  string `yaml:"quality_reviewer"`
 	SpecGenerator    string `yaml:"spec_generator"`
 	Punchlist        string `yaml:"punchlist"`
+	VerifyFix        string `yaml:"verify_fix"`
 }
 
 // CLIFlags holds flag values passed on the command line.
@@ -125,6 +134,10 @@ func defaults() *Config {
 		ConventionsDoc:         "docs/conventions.md",
 		QualityStrictnessDecay: true,
 		AuthPreference:         "oauth",
+		Verify: Verify{
+			MaxFixAttempts: 2,
+			Blocking:       true,
+		},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -609,6 +609,81 @@ enforce_architecture: true
 	}
 }
 
+func TestVerifyDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LintCommand != "" {
+		t.Errorf("LintCommand = %q, want empty string", cfg.LintCommand)
+	}
+	if cfg.Verify.MaxFixAttempts != 2 {
+		t.Errorf("Verify.MaxFixAttempts = %d, want 2", cfg.Verify.MaxFixAttempts)
+	}
+	if !cfg.Verify.Blocking {
+		t.Error("Verify.Blocking = false, want true")
+	}
+}
+
+func TestLintCommandFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+lint_command: "./scripts/lint.sh"
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LintCommand != "./scripts/lint.sh" {
+		t.Errorf("LintCommand = %q, want %q", cfg.LintCommand, "./scripts/lint.sh")
+	}
+}
+
+func TestVerifyBlockFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+verify:
+  max_fix_attempts: 5
+  blocking: false
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Verify.MaxFixAttempts != 5 {
+		t.Errorf("Verify.MaxFixAttempts = %d, want 5", cfg.Verify.MaxFixAttempts)
+	}
+	if cfg.Verify.Blocking {
+		t.Error("Verify.Blocking = true, want false")
+	}
+}
+
+func TestVerifyFixPromptPathFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+prompts:
+  verify_fix: "custom/fix.txt"
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Prompts.VerifyFix != "custom/fix.txt" {
+		t.Errorf("Prompts.VerifyFix = %q, want %q", cfg.Prompts.VerifyFix, "custom/fix.txt")
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.


### PR DESCRIPTION
Closes #176

## Summary
- Add `LintCommand string` field (yaml: `lint_command`) to `Config` — empty default (lint skipped when empty)
- Add `Verify` struct with `MaxFixAttempts int` (yaml: `max_fix_attempts`, default 2) and `Blocking bool` (yaml: `blocking`, default true)
- Add `Verify Verify` field (yaml: `verify`) to `Config`
- Add `VerifyFix string` field (yaml: `verify_fix`) to `Prompts`
- Add four test cases covering defaults and YAML overrides for all new fields

## Implementation Notes

### Approach
Followed the exact same pattern as existing `build_command` / `test_command` fields for `lint_command`, and modeled the `Verify` struct after the existing `Quality` and `Docker` structs. Defaults are set in the `defaults()` function to ensure they're always applied before YAML parsing.

### Key Decisions
- `Verify.Blocking` defaults to `true` — verify failures block review by default, which is the safe/strict default.
- `LintCommand` defaults to `""` so that lint is skipped unless explicitly configured, matching the behavior of `build_command` and `test_command` (both default to empty).
- `VerifyFix` in `Prompts` defaults to `""` (zero value), consistent with all other prompt path fields.

### Known Limitations
None. All acceptance criteria are met. The fields are parsed and available for consumers but no orchestration code uses them yet — that will come in follow-on issues.

### Architecture
Only the `foundation` layer (`internal/config/`) was touched. This layer has no dependencies on other layers, so no dependency rules were affected.