### PR TITLE
feat(agent): add verify fix-retry cycle

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -76,6 +76,39 @@ func Retry(ctx context.Context, issue github.Issue, prNumber int, prevSessionID 
 	return Run(ctx, opts, cfg.NoSandbox, logger)
 }
 
+// VerifyFix runs the implementer agent in verify-fix mode. It renders the
+// verify_fix prompt with the provided verifyErrors string and invokes Run
+// with role "implementer_retry". prevSessionID, if non-empty, is forwarded
+// as GODARK_SESSION_ID so the agent can resume its previous session context.
+func VerifyFix(ctx context.Context, issue github.Issue, prNumber int, verifyErrors string, prevSessionID string, cfg *config.Config, prompts *Prompts, authEnv map[string]string, logger *slog.Logger) (*Result, error) {
+	slug := Slugify(issue.Title)
+	data := newPromptData(issue, cfg, slug)
+	data.PRNumber = prNumber
+	data.VerifyErrors = verifyErrors
+
+	rendered, err := RenderPrompt(prompts.VerifyFix, data)
+	if err != nil {
+		return nil, fmt.Errorf("rendering verify_fix prompt: %w", err)
+	}
+
+	opts, err := newRunOpts(rendered, cfg, authEnv, "implementer_retry")
+	if err != nil {
+		return nil, err
+	}
+
+	if prevSessionID != "" {
+		opts.Env["GODARK_SESSION_ID"] = prevSessionID
+	}
+
+	logger.Info("starting verify-fix agent",
+		"issue_number", issue.Number,
+		"pr_number", prNumber,
+		"resume_session", prevSessionID != "",
+	)
+
+	return Run(ctx, opts, cfg.NoSandbox, logger)
+}
+
 // BranchName returns the conventional branch name for an issue.
 func BranchName(issueNumber int, slug string) string {
 	return fmt.Sprintf("%d-%s", issueNumber, slug)

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -490,3 +490,86 @@ func TestNewPromptData_EnforceArchitectureDefaultFalse(t *testing.T) {
 		t.Error("EnforceArchitecture should be false when not set in config")
 	}
 }
+
+func TestVerifyFix_RendersPromptWithErrors(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	prompts := &Prompts{
+		VerifyFix: "PR #{{.PRNumber}} issue #{{.IssueNumber}} errors: {{.VerifyErrors}}",
+	}
+	verifyErrors := "=== build (exit code 1) ===\nbuild failed\n"
+
+	_, err := VerifyFix(context.Background(), testIssue(), 7, verifyErrors, "", testConfig(), prompts, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("VerifyFix() error = %v", err)
+	}
+
+	prompt := capturedEnv["GODARK_PROMPT"]
+	if !strings.Contains(prompt, "PR #7") {
+		t.Errorf("expected PR number in prompt, got: %s", prompt)
+	}
+	if !strings.Contains(prompt, "#42") {
+		t.Errorf("expected issue number in prompt, got: %s", prompt)
+	}
+	if !strings.Contains(prompt, "build failed") {
+		t.Errorf("expected verify errors in prompt, got: %s", prompt)
+	}
+}
+
+func TestVerifyFix_WithSessionID_SetsGODARK_SESSION_ID(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"sess-new","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	prompts := &Prompts{VerifyFix: "fix prompt"}
+	_, err := VerifyFix(context.Background(), testIssue(), 7, "some errors", "sess-abc123", testConfig(), prompts, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("VerifyFix() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_SESSION_ID"] != "sess-abc123" {
+		t.Errorf("GODARK_SESSION_ID = %q, want %q", capturedEnv["GODARK_SESSION_ID"], "sess-abc123")
+	}
+}
+
+func TestVerifyFix_WithoutSessionID_NoSessionEnv(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	prompts := &Prompts{VerifyFix: "fix prompt"}
+	_, err := VerifyFix(context.Background(), testIssue(), 7, "some errors", "", testConfig(), prompts, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("VerifyFix() error = %v", err)
+	}
+
+	if _, ok := capturedEnv["GODARK_SESSION_ID"]; ok {
+		t.Errorf("GODARK_SESSION_ID should not be set when prevSessionID is empty, got %q", capturedEnv["GODARK_SESSION_ID"])
+	}
+}
+
+func TestVerifyFix_SetsImplementerRetryRole(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	prompts := &Prompts{VerifyFix: "fix prompt"}
+	_, err := VerifyFix(context.Background(), testIssue(), 7, "errors", "", testConfig(), prompts, nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("VerifyFix() error = %v", err)
+	}
+
+	if capturedEnv["GODARK_ROLE"] != "implementer_retry" {
+		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "implementer_retry")
+	}
+}

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -155,6 +155,50 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	if verifyChecks := buildVerifyChecks(cfg); len(verifyChecks) > 0 {
 		logger.Info("running verify step", "issue_number", issue.Number, "check_count", len(verifyChecks))
 		verifyResult := RunVerify(ctx, verifyChecks, newHostRunner())
+
+		if !verifyResult.AllPassed && prompts.VerifyFix != "" && cfg.Verify.MaxFixAttempts > 0 {
+			for fixAttempt := 0; fixAttempt < cfg.Verify.MaxFixAttempts; fixAttempt++ {
+				if ctx.Err() != nil {
+					outcome.Status = "failed"
+					outcome.Err = ctx.Err()
+					return outcome
+				}
+
+				verifyErrors := formatVerifyErrors(verifyResult)
+				logger.Info("running verify-fix attempt",
+					"issue_number", issue.Number,
+					"attempt", fixAttempt+1,
+					"max_attempts", cfg.Verify.MaxFixAttempts,
+				)
+
+				fixResult, err := VerifyFix(ctx, issue, prNum, verifyErrors, sessionID, cfg, prompts, authEnv, logger)
+				if err != nil {
+					outcome.Status = "failed"
+					outcome.Err = fmt.Errorf("verify-fix agent: %w", err)
+					return outcome
+				}
+				if fixResult.TimedOut {
+					outcome.Status = "failed"
+					outcome.Err = fmt.Errorf("verify-fix agent timed out")
+					return outcome
+				}
+				sessionID = fixResult.SessionID
+
+				// Re-check drift after each fix attempt.
+				if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
+					outcome.Status = "failed"
+					outcome.Err = driftErr
+					return outcome
+				}
+
+				// Re-run verify.
+				verifyResult = RunVerify(ctx, verifyChecks, newHostRunner())
+				if verifyResult.AllPassed {
+					break
+				}
+			}
+		}
+
 		if verifyResult.AllPassed {
 			logger.Info("verify step passed", "issue_number", issue.Number)
 		} else {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -2022,3 +2022,443 @@ func TestProcessIssue_VerifyRunsBeforeQualityReview(t *testing.T) {
 		t.Errorf("agentCalls = %d, want 1 (quality review should not run when verify blocks)", stubs.agentCalls)
 	}
 }
+
+// verifyFixLoopConfig returns a loop config with a build command, blocking setting,
+// and MaxFixAttempts configured for verify-fix cycle tests.
+func verifyFixLoopConfig(blocking bool, maxFixAttempts int) *config.Config {
+	cfg := verifyLoopConfig(blocking)
+	cfg.Verify.MaxFixAttempts = maxFixAttempts
+	return cfg
+}
+
+// verifyFixPrompts returns test prompts with a VerifyFix template.
+func verifyFixPrompts(t *testing.T) *Prompts {
+	t.Helper()
+	p := testPrompts(t)
+	p.VerifyFix = "Fix PR #{{.PRNumber}} issue #{{.IssueNumber}} errors: {{.VerifyErrors}}"
+	return p
+}
+
+// TestProcessIssue_VerifyFixSucceedsOnFirstAttempt verifies that when verify
+// initially fails but the fix agent succeeds, processing continues to review.
+func TestProcessIssue_VerifyFixSucceedsOnFirstAttempt(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	shCallIdx := 0
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			shCallIdx++
+			if shCallIdx == 1 {
+				// First verify run: fail.
+				return []byte("build error output"), fmt.Errorf("exit status 1")
+			}
+			// Second verify run (after fix): pass.
+			return []byte(""), nil
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			out := `{"session_id":"sess-impl","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 2: // verify-fix agent
+			out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 3: // quality reviewer
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	cfg := verifyFixLoopConfig(true, 1)
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, verifyFixPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want implemented (err: %v)", outcome.Status, outcome.Err)
+	}
+	if shCallIdx != 2 {
+		t.Errorf("shCallIdx = %d, want 2 (initial verify + re-verify after fix)", shCallIdx)
+	}
+}
+
+// TestProcessIssue_VerifyFixExhaustedBlocking verifies that when all fix attempts
+// are exhausted and verify still fails with Blocking=true, status is "failed".
+func TestProcessIssue_VerifyFixExhaustedBlocking(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			// All verify runs fail.
+			return []byte("build error"), fmt.Errorf("exit status 1")
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		// All agent calls return OK — verify failures drive the outcome.
+		out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	}
+
+	// MaxFixAttempts=2 → 2 fix agents called, then blocked.
+	cfg := verifyFixLoopConfig(true, 2)
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, verifyFixPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "failed" {
+		t.Errorf("Status = %q, want failed after exhausted blocking fix attempts", outcome.Status)
+	}
+	if outcome.Err == nil || !strings.Contains(outcome.Err.Error(), "verify") {
+		t.Errorf("Err = %v, want error containing 'verify'", outcome.Err)
+	}
+	// Agent calls: 1 (implementer) + 2 (fix agents) = 3
+	if callIdx != 3 {
+		t.Errorf("callIdx = %d, want 3 (implementer + 2 fix agents)", callIdx)
+	}
+}
+
+// TestProcessIssue_VerifyFixExhaustedNonBlocking verifies that when all fix attempts
+// are exhausted with Blocking=false, processing proceeds to review with a warning.
+func TestProcessIssue_VerifyFixExhaustedNonBlocking(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			// All verify runs fail.
+			return []byte("build error"), fmt.Errorf("exit status 1")
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			out := `{"session_id":"sess-impl","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 2: // verify-fix agent
+			out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 3: // quality reviewer (non-blocking proceeds here)
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	// MaxFixAttempts=1, Blocking=false → 1 fix agent, then proceed to review.
+	cfg := verifyFixLoopConfig(false, 1)
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, verifyFixPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want implemented (non-blocking proceeds to review)", outcome.Status)
+	}
+}
+
+// TestProcessIssue_VerifyFixDriftCheckedAfterFix verifies that protected path drift
+// is re-checked after each fix attempt, and a drift detection fails the issue.
+func TestProcessIssue_VerifyFixDriftCheckedAfterFix(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	shCallIdx := 0
+	driftCheckCount := 0
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			driftCheckCount++
+			if driftCheckCount == 2 {
+				// Drift detected after the fix attempt.
+				return []byte("CLAUDE.md\n"), nil
+			}
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			shCallIdx++
+			// First verify fails so fix cycle triggers.
+			return []byte("build error"), fmt.Errorf("exit status 1")
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	}
+
+	cfg := verifyFixLoopConfig(true, 2)
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, verifyFixPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "failed" {
+		t.Errorf("Status = %q, want failed (drift detected after fix)", outcome.Status)
+	}
+	if !strings.Contains(outcome.Err.Error(), "protected path drift") {
+		t.Errorf("Err = %v, want 'protected path drift'", outcome.Err)
+	}
+	if driftCheckCount < 2 {
+		t.Errorf("driftCheckCount = %d, want >= 2 (drift re-checked after fix)", driftCheckCount)
+	}
+}
+
+// TestProcessIssue_VerifyFixSessionContinuity verifies that the fix agent receives
+// the implementer's session ID for context resumption.
+func TestProcessIssue_VerifyFixSessionContinuity(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	shCallIdx := 0
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			shCallIdx++
+			if shCallIdx == 1 {
+				return []byte("build error"), fmt.Errorf("exit status 1")
+			}
+			return []byte(""), nil
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	var fixAgentEnv map[string]string
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer — returns a session ID
+			out := `{"session_id":"sess-impl-xyz","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 2: // verify-fix agent — capture env
+			fixAgentEnv = make(map[string]string, len(env))
+			for k, v := range env {
+				fixAgentEnv[k] = v
+			}
+			out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 3: // quality reviewer
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	cfg := verifyFixLoopConfig(true, 1)
+	ProcessIssue(context.Background(), loopIssue(), cfg, verifyFixPrompts(t), nil, testLogger(t), nil)
+
+	if fixAgentEnv == nil {
+		t.Fatal("verify-fix agent was never called")
+	}
+	if fixAgentEnv["GODARK_SESSION_ID"] != "sess-impl-xyz" {
+		t.Errorf("GODARK_SESSION_ID = %q, want sess-impl-xyz", fixAgentEnv["GODARK_SESSION_ID"])
+	}
+}
+
+// TestProcessIssue_VerifyFixPromptContainsErrorOutput verifies that the rendered
+// verify_fix prompt includes check names and output from failed verify checks.
+func TestProcessIssue_VerifyFixPromptContainsErrorOutput(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	shCallIdx := 0
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			shCallIdx++
+			if shCallIdx == 1 {
+				return []byte("undefined: Foo"), fmt.Errorf("exit status 1")
+			}
+			return []byte(""), nil
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	var fixAgentPrompt string
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			out := `{"session_id":"sess-impl","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 2: // verify-fix agent — capture prompt
+			fixAgentPrompt = env["GODARK_PROMPT"]
+			out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
+			return []byte(out), []byte(""), 0, nil
+		case 3: // quality reviewer
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	cfg := verifyFixLoopConfig(true, 1)
+	ProcessIssue(context.Background(), loopIssue(), cfg, verifyFixPrompts(t), nil, testLogger(t), nil)
+
+	if fixAgentPrompt == "" {
+		t.Fatal("verify-fix agent was never called")
+	}
+	if !strings.Contains(fixAgentPrompt, "build") {
+		t.Errorf("fix prompt missing check name 'build', got: %s", fixAgentPrompt)
+	}
+	if !strings.Contains(fixAgentPrompt, "undefined: Foo") {
+		t.Errorf("fix prompt missing check output 'undefined: Foo', got: %s", fixAgentPrompt)
+	}
+}
+
+// TestProcessIssue_VerifyFixSkippedWhenNoPrompt verifies that when VerifyFix prompt
+// is not configured, verify failures use the original blocking/non-blocking behavior.
+func TestProcessIssue_VerifyFixSkippedWhenNoPrompt(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			return []byte("build error"), fmt.Errorf("exit status 1")
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		out := `{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`
+		return []byte(out), []byte(""), 0, nil
+	}
+
+	// No VerifyFix prompt → fix cycle should not trigger.
+	prompts := testPrompts(t) // VerifyFix is empty
+	cfg := verifyFixLoopConfig(true, 2)
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, prompts, nil, testLogger(t), nil)
+
+	if outcome.Status != "failed" {
+		t.Errorf("Status = %q, want failed (no fix prompt, blocking verify failure)", outcome.Status)
+	}
+	// Only 1 agent call — fix cycle never triggered.
+	if callIdx != 1 {
+		t.Errorf("callIdx = %d, want 1 (no fix agents when VerifyFix prompt is empty)", callIdx)
+	}
+}

--- a/internal/agent/verify.go
+++ b/internal/agent/verify.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"strings"
 )
 
 // Check defines a single verification command to run.
@@ -73,4 +75,20 @@ func truncateVerifyOutput(b []byte) string {
 		return string(b)
 	}
 	return string(b[len(b)-verifyOutputLimit:])
+}
+
+// formatVerifyErrors formats the failed checks from a VerifyResult as a
+// human-readable string suitable for inclusion in the verify_fix prompt.
+// Each failed check is rendered as "=== <name> (exit code N) ===\n<output>\n".
+func formatVerifyErrors(result VerifyResult) string {
+	var sb strings.Builder
+	for _, cr := range result.Checks {
+		if cr.Passed {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("=== %s (exit code %d) ===\n", cr.Name, cr.ExitCode))
+		sb.WriteString(cr.Output)
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }

--- a/internal/agent/verify_test.go
+++ b/internal/agent/verify_test.go
@@ -310,3 +310,80 @@ func TestRunVerify_OutputWithinLimitNotTruncated(t *testing.T) {
 		t.Errorf("Output = %q, want %q (should not be truncated)", result.Checks[0].Output, smallOutput)
 	}
 }
+
+func TestFormatVerifyErrors_FailedChecksIncluded(t *testing.T) {
+	result := VerifyResult{
+		AllPassed: false,
+		Checks: []CheckResult{
+			{Name: "build", Passed: false, Output: "build error output", ExitCode: 1},
+		},
+	}
+
+	got := formatVerifyErrors(result)
+
+	if !strings.Contains(got, "=== build (exit code 1) ===") {
+		t.Errorf("expected check header in output, got: %q", got)
+	}
+	if !strings.Contains(got, "build error output") {
+		t.Errorf("expected check output in result, got: %q", got)
+	}
+}
+
+func TestFormatVerifyErrors_PassedChecksExcluded(t *testing.T) {
+	result := VerifyResult{
+		AllPassed: false,
+		Checks: []CheckResult{
+			{Name: "build", Passed: true, Output: "ok", ExitCode: 0},
+			{Name: "lint", Passed: false, Output: "lint error", ExitCode: 1},
+		},
+	}
+
+	got := formatVerifyErrors(result)
+
+	if strings.Contains(got, "build") {
+		t.Errorf("passed check 'build' should not appear in errors, got: %q", got)
+	}
+	if !strings.Contains(got, "lint") {
+		t.Errorf("failed check 'lint' should appear in errors, got: %q", got)
+	}
+}
+
+func TestFormatVerifyErrors_MultipleFailures(t *testing.T) {
+	result := VerifyResult{
+		AllPassed: false,
+		Checks: []CheckResult{
+			{Name: "build", Passed: false, Output: "build failed", ExitCode: 1},
+			{Name: "test", Passed: false, Output: "tests failed", ExitCode: 2},
+		},
+	}
+
+	got := formatVerifyErrors(result)
+
+	if !strings.Contains(got, "=== build (exit code 1) ===") {
+		t.Errorf("expected build header in output, got: %q", got)
+	}
+	if !strings.Contains(got, "=== test (exit code 2) ===") {
+		t.Errorf("expected test header in output, got: %q", got)
+	}
+	if !strings.Contains(got, "build failed") {
+		t.Errorf("expected build output, got: %q", got)
+	}
+	if !strings.Contains(got, "tests failed") {
+		t.Errorf("expected test output, got: %q", got)
+	}
+}
+
+func TestFormatVerifyErrors_EmptyWhenAllPassed(t *testing.T) {
+	result := VerifyResult{
+		AllPassed: true,
+		Checks: []CheckResult{
+			{Name: "build", Passed: true, Output: "ok", ExitCode: 0},
+		},
+	}
+
+	got := formatVerifyErrors(result)
+
+	if got != "" {
+		t.Errorf("expected empty string when all checks passed, got: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #200

## Summary
- Adds `VerifyFix` function to `implementer.go` that renders the `verify_fix.txt` prompt with failed check errors and invokes the implementer agent in retry mode with session ID continuity
- Adds `formatVerifyErrors` helper to `verify.go` that formats failed `CheckResult` entries as structured text for the prompt
- Replaces the simple fail/warn on verify failure in `loop.go` with a full fix-retry cycle that loops up to `cfg.Verify.MaxFixAttempts` times, calling `VerifyFix`, re-checking drift, and re-running verify after each attempt

## Implementation Notes

### Approach
The fix cycle is inserted inline within the existing verify step block in `ProcessIssue`. After the initial `RunVerify` call, if it fails and both `prompts.VerifyFix` and `cfg.Verify.MaxFixAttempts > 0` are set, the fix loop runs. After the loop (whether it succeeded or exhausted attempts), the existing blocking/non-blocking logic applies to the final `verifyResult`.

### Key Decisions
- **`formatVerifyErrors` in `verify.go`**: Placed alongside `VerifyResult`/`CheckResult` types since it operates directly on those types. Format is `=== <name> (exit code N) ===\n<output>\n` for readability in the prompt.
- **`VerifyFix` mirrors `Retry`**: Same pattern — renders prompt with `PromptData`, calls `newRunOpts` with `implementer_retry` role, forwards `prevSessionID`. No new abstractions.
- **Session ID propagation**: `sessionID` (the loop-level variable tracking the current agent session) is updated with each fix agent's returned `SessionID`, so subsequent fix attempts and later retries all chain correctly.
- **Drift check placement**: Re-checked immediately after each fix agent call, before re-running verify. This ensures a malicious or buggy agent can't sneak protected file modifications through the fix cycle.
- **Skip condition**: Fix cycle is skipped when `prompts.VerifyFix == ""` OR `cfg.Verify.MaxFixAttempts == 0`, preserving backward compatibility with configs that don't configure the fix prompt.

### Known Limitations
- Fix attempts are not recorded via the `RunDataHook` (no `WriteFixResult` method exists). This is consistent with the current interface — if run data for fix attempts is needed, that would be a separate issue.

### Architecture
Only `internal/agent/` (orchestration layer) was modified. No new cross-layer dependencies introduced. `formatVerifyErrors` is a pure function operating on types already defined in `verify.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)