### PR TITLE
feat(rundata): add verify step result recording

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -155,6 +155,11 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	if verifyChecks := buildVerifyChecks(cfg); len(verifyChecks) > 0 {
 		logger.Info("running verify step", "issue_number", issue.Number, "check_count", len(verifyChecks))
 		verifyResult := RunVerify(ctx, verifyChecks, newHostRunner())
+		if hook != nil {
+			if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, 0, false)); err != nil {
+				logger.Warn("failed to write verify result", "error", err)
+			}
+		}
 
 		if !verifyResult.AllPassed && prompts.VerifyFix != "" && cfg.Verify.MaxFixAttempts > 0 {
 			for fixAttempt := 0; fixAttempt < cfg.Verify.MaxFixAttempts; fixAttempt++ {
@@ -193,6 +198,11 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 
 				// Re-run verify.
 				verifyResult = RunVerify(ctx, verifyChecks, newHostRunner())
+				if hook != nil {
+					if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, fixAttempt+1, true)); err != nil {
+						logger.Warn("failed to write verify result", "error", err)
+					}
+				}
 				if verifyResult.AllPassed {
 					break
 				}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -849,13 +849,14 @@ func TestProcessIssue_SkipsQualityReviewWhenNoPrompt(t *testing.T) {
 
 // testRunDataHook is a simple RunDataHook implementation for unit tests.
 type testRunDataHook struct {
-	specGeneratorCalls           int
-	implementCalls               int
-	reviewKinds                  []string
-	retryCalls                   int
-	retryReviewCalls             int
-	retryFunctionalReviewCalls   int
-	outcomes                     []rundata.Outcome
+	specGeneratorCalls         int
+	implementCalls             int
+	reviewKinds                []string
+	retryCalls                 int
+	retryReviewCalls           int
+	retryFunctionalReviewCalls int
+	verifyResults              []rundata.VerifyStepResult
+	outcomes                   []rundata.Outcome
 }
 
 func (h *testRunDataHook) WriteSpecGeneratorResult(_ int, _ rundata.StepResult) error {
@@ -880,6 +881,10 @@ func (h *testRunDataHook) WriteRetryReviewResult(_ int, _ int, _ rundata.StepRes
 }
 func (h *testRunDataHook) WriteRetryFunctionalReviewResult(_ int, _ int, _ rundata.StepResult) error {
 	h.retryFunctionalReviewCalls++
+	return nil
+}
+func (h *testRunDataHook) WriteVerifyResult(_ int, step rundata.VerifyStepResult) error {
+	h.verifyResults = append(h.verifyResults, step)
 	return nil
 }
 func (h *testRunDataHook) WriteOutcome(o rundata.Outcome) error {
@@ -1060,6 +1065,103 @@ func TestProcessIssue_HookCalledOnSpecGeneratorTimeout(t *testing.T) {
 
 	if hook.specGeneratorCalls != 1 {
 		t.Errorf("WriteSpecGeneratorResult called %d times, want 1", hook.specGeneratorCalls)
+	}
+}
+
+func TestProcessIssue_HookCalledOnVerifyPass(t *testing.T) {
+	hook := &testRunDataHook{}
+	cfg := verifyLoopConfig(true)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" {
+			return []byte(""), nil // verify command passes
+		}
+		return []byte(""), nil
+	})
+
+	ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
+
+	if len(hook.verifyResults) != 1 {
+		t.Fatalf("WriteVerifyResult called %d times, want 1", len(hook.verifyResults))
+	}
+	if hook.verifyResults[0].Attempt != 0 {
+		t.Errorf("verifyResults[0].Attempt = %d, want 0", hook.verifyResults[0].Attempt)
+	}
+	if hook.verifyResults[0].FixAttempted {
+		t.Errorf("verifyResults[0].FixAttempted = true, want false")
+	}
+}
+
+func TestProcessIssue_HookCalledOnVerifyFixRetries(t *testing.T) {
+	hook := &testRunDataHook{}
+	cfg := verifyFixLoopConfig(true, 1)
+	shCallIdx := 0
+
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=APPROVED",
+		"verify-fix output",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" {
+			idx := shCallIdx
+			shCallIdx++
+			if idx == 0 {
+				// First verify: fail.
+				return []byte("error output"), fmt.Errorf("exit status 1")
+			}
+			// Second verify (after fix): pass.
+			return []byte(""), nil
+		}
+		return []byte(""), nil
+	})
+
+	ProcessIssue(context.Background(), loopIssue(), cfg, verifyFixPrompts(t), nil, testLogger(t), hook)
+
+	// Expect two WriteVerifyResult calls: attempt 0 (fail) and attempt 1 (pass after fix).
+	if len(hook.verifyResults) != 2 {
+		t.Fatalf("WriteVerifyResult called %d times, want 2", len(hook.verifyResults))
+	}
+	if hook.verifyResults[0].Attempt != 0 {
+		t.Errorf("verifyResults[0].Attempt = %d, want 0", hook.verifyResults[0].Attempt)
+	}
+	if hook.verifyResults[0].FixAttempted {
+		t.Errorf("verifyResults[0].FixAttempted = true, want false")
+	}
+	if hook.verifyResults[1].Attempt != 1 {
+		t.Errorf("verifyResults[1].Attempt = %d, want 1", hook.verifyResults[1].Attempt)
+	}
+	if !hook.verifyResults[1].FixAttempted {
+		t.Errorf("verifyResults[1].FixAttempted = false, want true")
 	}
 }
 

--- a/internal/agent/rundata.go
+++ b/internal/agent/rundata.go
@@ -23,3 +23,23 @@ func ResultToStep(r *Result) rundata.StepResult {
 	}
 	return step
 }
+
+// verifyToRundata converts a VerifyResult to a rundata.VerifyStepResult.
+// attempt is 0-indexed; fixAttempted indicates whether a fix was run before this check.
+func verifyToRundata(vr VerifyResult, attempt int, fixAttempted bool) rundata.VerifyStepResult {
+	checks := make([]rundata.CheckResult, len(vr.Checks))
+	for i, cr := range vr.Checks {
+		checks[i] = rundata.CheckResult{
+			Name:     cr.Name,
+			Passed:   cr.Passed,
+			Output:   cr.Output,
+			ExitCode: cr.ExitCode,
+		}
+	}
+	return rundata.VerifyStepResult{
+		Attempt:      attempt,
+		Checks:       checks,
+		AllPassed:    vr.AllPassed,
+		FixAttempted: fixAttempted,
+	}
+}

--- a/internal/agent/runhook.go
+++ b/internal/agent/runhook.go
@@ -12,5 +12,6 @@ type RunDataHook interface {
 	WriteRetryResult(issueNumber int, attempt int, step rundata.StepResult) error
 	WriteRetryReviewResult(issueNumber int, attempt int, step rundata.StepResult) error
 	WriteRetryFunctionalReviewResult(issueNumber int, attempt int, step rundata.StepResult) error
+	WriteVerifyResult(issueNumber int, step rundata.VerifyStepResult) error
 	WriteOutcome(outcome rundata.Outcome) error
 }

--- a/internal/rundata/reader.go
+++ b/internal/rundata/reader.go
@@ -31,6 +31,7 @@ type IssueDetail struct {
 	Retries          []RetryDetail
 	Punchlist        *PunchlistData
 	Dialogue         []DialogueEntry
+	VerifyResults    []VerifyStepResult
 }
 
 // RunDetail holds the full data for one run, including per-issue details.
@@ -222,6 +223,7 @@ func (r *Reader) loadIssueDetail(issueDir string, issueNum int) IssueDetail {
 		Retries:          r.loadRetries(filepath.Join(issueDir, "retries")),
 		Punchlist:        r.readPunchlist(filepath.Join(issueDir, "punchlist.json")),
 		Dialogue:         r.readDialogue(filepath.Join(issueDir, "dialogue.json")),
+		VerifyResults:    r.loadVerifyResults(issueDir),
 	}
 }
 
@@ -303,6 +305,68 @@ func (r *Reader) readOutcome(path string) Outcome {
 		return Outcome{}
 	}
 	return outcome
+}
+
+// loadVerifyResults reads all verify-N.json files from issueDir, sorted by attempt number.
+// Returns nil if no verify files are present (backwards compatible).
+func (r *Reader) loadVerifyResults(issueDir string) []VerifyStepResult {
+	entries, err := os.ReadDir(issueDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		r.logger.Warn("skipping verify results", "dir", issueDir, "error", err)
+		return nil
+	}
+
+	var results []VerifyStepResult
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasPrefix(name, "verify-") || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		numStr := strings.TrimSuffix(strings.TrimPrefix(name, "verify-"), ".json")
+		attempt, err := strconv.Atoi(numStr)
+		if err != nil {
+			r.logger.Warn("skipping non-numeric verify file", "file", name)
+			continue
+		}
+		path := filepath.Join(issueDir, name)
+		vr := r.readVerifyResult(path, attempt)
+		results = append(results, vr)
+	}
+
+	if len(results) == 0 {
+		return nil
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Attempt < results[j].Attempt
+	})
+	return results
+}
+
+// readVerifyResult reads a VerifyStepResult from path. On missing or corrupt files,
+// returns a zero-value VerifyStepResult with the given attempt number.
+func (r *Reader) readVerifyResult(path string, attempt int) VerifyStepResult {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return VerifyStepResult{Attempt: attempt}
+	}
+	if err != nil {
+		r.logger.Warn("skipping verify file", "path", path, "error", err)
+		return VerifyStepResult{Attempt: attempt}
+	}
+
+	var vr VerifyStepResult
+	if err := json.Unmarshal(data, &vr); err != nil {
+		r.logger.Warn("corrupt verify file, using zero value", "path", path, "error", err)
+		return VerifyStepResult{Attempt: attempt}
+	}
+	return vr
 }
 
 // loadRetries reads all retry step results from retriesDir, sorted by attempt number.

--- a/internal/rundata/reader_test.go
+++ b/internal/rundata/reader_test.go
@@ -712,6 +712,127 @@ func TestLoadRunOutcomeDescriptionRoundTrip(t *testing.T) {
 	}
 }
 
+func TestLoadRunVerifyResults(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:         "owner/repo",
+		IssueNumbers: []int{42},
+		StartedAt:    time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "42")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+
+	// Write two verify results.
+	vr0 := VerifyStepResult{Attempt: 0, AllPassed: false, FixAttempted: false,
+		Checks: []CheckResult{{Name: "build", Passed: false, ExitCode: 1}}}
+	vr1 := VerifyStepResult{Attempt: 1, AllPassed: true, FixAttempted: true,
+		Checks: []CheckResult{{Name: "build", Passed: true, ExitCode: 0}}}
+
+	if err := writeJSON(filepath.Join(issueDir, "verify-0.json"), vr0); err != nil {
+		t.Fatalf("writing verify-0.json: %v", err)
+	}
+	if err := writeJSON(filepath.Join(issueDir, "verify-1.json"), vr1); err != nil {
+		t.Fatalf("writing verify-1.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+	vrs := detail.Issues[0].VerifyResults
+	if len(vrs) != 2 {
+		t.Fatalf("VerifyResults: got %d, want 2", len(vrs))
+	}
+	if vrs[0].Attempt != 0 {
+		t.Errorf("VerifyResults[0].Attempt = %d, want 0", vrs[0].Attempt)
+	}
+	if vrs[0].AllPassed {
+		t.Errorf("VerifyResults[0].AllPassed = true, want false")
+	}
+	if vrs[1].Attempt != 1 {
+		t.Errorf("VerifyResults[1].Attempt = %d, want 1", vrs[1].Attempt)
+	}
+	if !vrs[1].AllPassed {
+		t.Errorf("VerifyResults[1].AllPassed = false, want true")
+	}
+	if !vrs[1].FixAttempted {
+		t.Errorf("VerifyResults[1].FixAttempted = false, want true")
+	}
+}
+
+func TestLoadRunVerifyResultsMissingFiles(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:      "owner/repo",
+		StartedAt: time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "42")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	// No verify-*.json files written.
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+	if detail.Issues[0].VerifyResults != nil {
+		t.Errorf("VerifyResults: expected nil when no files, got %v", detail.Issues[0].VerifyResults)
+	}
+}
+
+func TestLoadRunVerifyResultsSortedByAttempt(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:      "owner/repo",
+		StartedAt: time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "42")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+
+	// Write out-of-order verify files.
+	for _, n := range []int{2, 0, 1} {
+		vr := VerifyStepResult{Attempt: n}
+		path := filepath.Join(issueDir, "verify-"+strconv.Itoa(n)+".json")
+		if err := writeJSON(path, vr); err != nil {
+			t.Fatalf("writing verify-%d.json: %v", n, err)
+		}
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	vrs := detail.Issues[0].VerifyResults
+	if len(vrs) != 3 {
+		t.Fatalf("VerifyResults: got %d, want 3", len(vrs))
+	}
+	for i, want := range []int{0, 1, 2} {
+		if vrs[i].Attempt != want {
+			t.Errorf("VerifyResults[%d].Attempt = %d, want %d", i, vrs[i].Attempt, want)
+		}
+	}
+}
+
 func itoa(n int) string {
 	return strconv.Itoa(n)
 }

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -179,6 +179,30 @@ func (w *Writer) WriteDialogue(issueNum int, entries []DialogueEntry) error {
 	return writeJSONMkdirs(path, entries)
 }
 
+// CheckResult holds the outcome of a single verification check.
+type CheckResult struct {
+	Name     string `json:"name"`
+	Passed   bool   `json:"passed"`
+	Output   string `json:"output,omitempty"`
+	ExitCode int    `json:"exit_code"`
+}
+
+// VerifyStepResult holds the outcome of one verify attempt (initial or fix retry).
+type VerifyStepResult struct {
+	Attempt      int           `json:"attempt"` // 0-indexed
+	Checks       []CheckResult `json:"checks"`
+	AllPassed    bool          `json:"all_passed"`
+	FixAttempted bool          `json:"fix_attempted"`
+}
+
+// WriteVerifyResult writes a verify step result for the given issue and attempt.
+// Path: issues/<issueNum>/verify-<attempt>.json
+func (w *Writer) WriteVerifyResult(issueNum int, step VerifyStepResult) error {
+	path := filepath.Join(w.dir, "issues", fmt.Sprintf("%d", issueNum),
+		fmt.Sprintf("verify-%d.json", step.Attempt))
+	return writeJSONMkdirs(path, step)
+}
+
 // PunchlistData holds the per-issue punchlist content persisted to punchlist.json.
 type PunchlistData struct {
 	VerificationSteps []string `json:"verification_steps,omitempty"`

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -560,6 +560,108 @@ func TestWriteDialogueMultipleRounds(t *testing.T) {
 	}
 }
 
+func TestWriteVerifyResult(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := VerifyStepResult{
+		Attempt:   0,
+		AllPassed: true,
+		Checks: []CheckResult{
+			{Name: "build", Passed: true, ExitCode: 0},
+		},
+	}
+	if err := w.WriteVerifyResult(42, step); err != nil {
+		t.Fatalf("WriteVerifyResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "verify-0.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file at %s, got: %v", path, err)
+	}
+}
+
+func TestWriteVerifyResultMultipleAttempts(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step0 := VerifyStepResult{Attempt: 0, AllPassed: false, FixAttempted: false}
+	if err := w.WriteVerifyResult(42, step0); err != nil {
+		t.Fatalf("WriteVerifyResult(attempt=0) error: %v", err)
+	}
+
+	step1 := VerifyStepResult{Attempt: 1, AllPassed: true, FixAttempted: true}
+	if err := w.WriteVerifyResult(42, step1); err != nil {
+		t.Fatalf("WriteVerifyResult(attempt=1) error: %v", err)
+	}
+
+	for _, name := range []string{"verify-0.json", "verify-1.json"} {
+		path := filepath.Join(w.Dir(), "issues", "42", name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected file at %s, got: %v", path, err)
+		}
+	}
+}
+
+func TestWriteVerifyResultContents(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := VerifyStepResult{
+		Attempt:      1,
+		AllPassed:    false,
+		FixAttempted: true,
+		Checks: []CheckResult{
+			{Name: "build", Passed: false, Output: "error: build failed", ExitCode: 1},
+		},
+	}
+	if err := w.WriteVerifyResult(42, step); err != nil {
+		t.Fatalf("WriteVerifyResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "verify-1.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading verify-1.json: %v", err)
+	}
+
+	var written VerifyStepResult
+	if err := json.Unmarshal(data, &written); err != nil {
+		t.Fatalf("parsing verify-1.json: %v", err)
+	}
+
+	if written.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", written.Attempt)
+	}
+	if written.AllPassed {
+		t.Errorf("AllPassed = true, want false")
+	}
+	if !written.FixAttempted {
+		t.Errorf("FixAttempted = false, want true")
+	}
+	if len(written.Checks) != 1 {
+		t.Fatalf("Checks: got %d, want 1", len(written.Checks))
+	}
+	if written.Checks[0].Name != "build" {
+		t.Errorf("Checks[0].Name = %q, want %q", written.Checks[0].Name, "build")
+	}
+	if written.Checks[0].Passed {
+		t.Errorf("Checks[0].Passed = true, want false")
+	}
+	if written.Checks[0].ExitCode != 1 {
+		t.Errorf("Checks[0].ExitCode = %d, want 1", written.Checks[0].ExitCode)
+	}
+}
+
 func TestPathTraversalRejected(t *testing.T) {
 	cases := []string{
 		"../evil/../../path",


### PR DESCRIPTION
Closes #182

## Summary

- Adds `VerifyStepResult` and `CheckResult` types to `internal/rundata`
- Adds `WriteVerifyResult` to both `Writer` and `RunDataHook` interface
- Loop calls hook after each verify attempt (initial + fix retries)
- Reader loads `verify-*.json` files into `IssueDetail.VerifyResults`

## Implementation Notes

### Approach
Followed the same pattern used by existing step recording (implement, review, retry). Each verify attempt writes an indexed JSON file (`verify-0.json`, `verify-1.json`, …) so the full history of checks is preserved even when fix retries are involved.

The `FixAttempted` flag distinguishes the initial verify (false) from post-fix re-verifies (true), allowing consumers to understand the progression without needing to cross-reference the fix attempt logs.

### Key Decisions
- Added `verifyToRundata` helper in `agent/rundata.go` alongside `ResultToStep`, keeping all `agent → rundata` conversions in one file.
- `loadVerifyResults` returns `nil` (not `[]VerifyStepResult{}`) when no files exist, matching the pattern used by `loadRetries` and `readDialogue` for backwards compatibility.
- `CheckResult.Output` uses `omitempty` in the rundata type (as specified in the issue) but not in the agent-internal type, since the agent doesn't need to omit empty output.

### Known Limitations
None — all acceptance criteria satisfied.

### Architecture
- **domain** (`internal/rundata`): New types `VerifyStepResult`, `CheckResult`; new `WriteVerifyResult` method on `Writer`; `VerifyResults` field on `IssueDetail` with `loadVerifyResults` reader.
- **orchestration** (`internal/agent`): `RunDataHook` interface extended; loop wired; `verifyToRundata` helper added. `*rundata.Writer` satisfies the updated interface automatically.
- No new cross-layer dependencies introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)