### PR TITLE
feat(architecture): add internal/analysis/ to domain layer

### DIFF
--- a/docs/architecture.json
+++ b/docs/architecture.json
@@ -31,7 +31,7 @@
     {
       "name": "domain",
       "description": "Pure business logic, models, and rules. No external service dependencies.",
-      "paths": ["internal/detect/", "internal/dialogue/", "internal/doctor/", "internal/patterns/", "internal/punchlist/", "internal/quality/", "internal/rundata/"],
+      "paths": ["internal/analysis/", "internal/detect/", "internal/dialogue/", "internal/doctor/", "internal/patterns/", "internal/punchlist/", "internal/quality/", "internal/rundata/"],
       "may_depend_on": ["foundation", "content"],
       "must_not_depend_on": ["cmd", "orchestration", "service", "infrastructure", "presentation"]
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,9 +72,9 @@ display but does not orchestrate workflows or call external services directly.
 
 ### domain
 
-**Paths:** `internal/detect/`, `internal/dialogue/`, `internal/doctor/`,
-`internal/patterns/`, `internal/punchlist/`, `internal/quality/`,
-`internal/rundata/`
+**Paths:** `internal/analysis/`, `internal/detect/`, `internal/dialogue/`,
+`internal/doctor/`, `internal/patterns/`, `internal/punchlist/`,
+`internal/quality/`, `internal/rundata/`
 
 **Purpose:** Pure business logic, data models, and validation rules. These
 packages define the core concepts of the system without depending on external


### PR DESCRIPTION
Closes #183

## Implementation Notes

### Approach
Added `internal/analysis/` to the domain layer paths in both `docs/architecture.json` and `docs/architecture.md`. The analysis package contains pure business logic (aggregation and statistics over run data) with no external service dependencies, which aligns it with the domain layer's definition.

### Key Decisions
- Inserted `internal/analysis/` at the beginning of the `paths` array (alphabetical order) for consistency.
- No code changes were required — this is a metadata/documentation-only update.

### Known Limitations
None. The change is purely additive and introduces no dependency cycles.

### Architecture
Only the **domain** layer definition was touched. The analysis package is classified as domain because it has no external service dependencies, matching the domain layer's contract ("Pure business logic, models, and rules. No external service dependencies."). No other layers were modified.