### PR TITLE
feat(analysis): add ComputeTrends for per-run time series data

### DIFF
--- a/internal/analysis/trends.go
+++ b/internal/analysis/trends.go
@@ -1,0 +1,82 @@
+package analysis
+
+import (
+	"sort"
+	"time"
+
+	"github.com/phs/dark-factory/internal/rundata"
+)
+
+// TrendPoint represents one data point in a time series, corresponding
+// to a single run.
+type TrendPoint struct {
+	Timestamp    time.Time `json:"timestamp"`
+	Repo         string    `json:"repo"`
+	Milestone    string    `json:"milestone"`
+	IssueCount   int       `json:"issue_count"`
+	SuccessRate  float64   `json:"success_rate"`  // 0.0–1.0
+	AvgRetries   float64   `json:"avg_retries"`
+	TotalCostUSD float64   `json:"total_cost_usd"`
+}
+
+// ComputeTrends returns one TrendPoint per run, sorted chronologically
+// (oldest first). Unfinished runs (no FinishedAt) are excluded.
+func ComputeTrends(runs []rundata.RunDetail) []TrendPoint {
+	if len(runs) == 0 {
+		return nil
+	}
+
+	var points []TrendPoint
+	for _, run := range runs {
+		if run.FinishedAt == nil {
+			continue
+		}
+
+		issueCount := len(run.Issues)
+		var implemented, totalRetries int
+		var totalCost float64
+
+		for _, issue := range run.Issues {
+			if issue.Outcome.Status == "implemented" {
+				implemented++
+			}
+			totalRetries += len(issue.Retries)
+
+			totalCost += issue.SpecGenerator.CostUSD
+			totalCost += issue.Implement.CostUSD
+			totalCost += issue.QualityReview.CostUSD
+			totalCost += issue.FunctionalReview.CostUSD
+			for _, retry := range issue.Retries {
+				totalCost += retry.Retry.CostUSD
+				totalCost += retry.QualityReview.CostUSD
+				totalCost += retry.FunctionalReview.CostUSD
+			}
+		}
+
+		var successRate, avgRetries float64
+		if issueCount > 0 {
+			successRate = float64(implemented) / float64(issueCount)
+			avgRetries = float64(totalRetries) / float64(issueCount)
+		}
+
+		points = append(points, TrendPoint{
+			Timestamp:    run.StartedAt,
+			Repo:         run.Repo,
+			Milestone:    run.Milestone,
+			IssueCount:   issueCount,
+			SuccessRate:  successRate,
+			AvgRetries:   avgRetries,
+			TotalCostUSD: totalCost,
+		})
+	}
+
+	if len(points) == 0 {
+		return nil
+	}
+
+	sort.Slice(points, func(i, j int) bool {
+		return points[i].Timestamp.Before(points[j].Timestamp)
+	})
+
+	return points
+}

--- a/internal/analysis/trends_test.go
+++ b/internal/analysis/trends_test.go
@@ -1,0 +1,201 @@
+package analysis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/phs/dark-factory/internal/rundata"
+)
+
+func ptr(t time.Time) *time.Time { return &t }
+
+func TestComputeTrendsNilInput(t *testing.T) {
+	got := ComputeTrends(nil)
+	if got != nil {
+		t.Errorf("ComputeTrends(nil) = %v, want nil", got)
+	}
+}
+
+func TestComputeTrendsEmptyInput(t *testing.T) {
+	got := ComputeTrends([]rundata.RunDetail{})
+	if got != nil {
+		t.Errorf("ComputeTrends([]) = %v, want nil", got)
+	}
+}
+
+func TestComputeTrendsChronologicalOrder(t *testing.T) {
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	runs := []rundata.RunDetail{
+		{RunMeta: rundata.RunMeta{StartedAt: t2, FinishedAt: ptr(t2)}},
+		{RunMeta: rundata.RunMeta{StartedAt: t1, FinishedAt: ptr(t1)}},
+		{RunMeta: rundata.RunMeta{StartedAt: t3, FinishedAt: ptr(t3)}},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 3 {
+		t.Fatalf("len(ComputeTrends) = %d, want 3", len(got))
+	}
+	if !got[0].Timestamp.Equal(t1) {
+		t.Errorf("got[0].Timestamp = %v, want %v (oldest first)", got[0].Timestamp, t1)
+	}
+	if !got[1].Timestamp.Equal(t3) {
+		t.Errorf("got[1].Timestamp = %v, want %v", got[1].Timestamp, t3)
+	}
+	if !got[2].Timestamp.Equal(t2) {
+		t.Errorf("got[2].Timestamp = %v, want %v (newest last)", got[2].Timestamp, t2)
+	}
+}
+
+func TestComputeTrendsSuccessRate(t *testing.T) {
+	// 3 implemented, 1 failed — rate 0.75
+	finishedAt := time.Now()
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{FinishedAt: &finishedAt},
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: "implemented"}},
+				{Outcome: rundata.Outcome{Status: "implemented"}},
+				{Outcome: rundata.Outcome{Status: "implemented"}},
+				{Outcome: rundata.Outcome{Status: "failed"}},
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 1 {
+		t.Fatalf("len(ComputeTrends) = %d, want 1", len(got))
+	}
+	if !nearlyEqual(got[0].SuccessRate, 0.75, 0.0001) {
+		t.Errorf("SuccessRate = %f, want 0.75", got[0].SuccessRate)
+	}
+	if got[0].IssueCount != 4 {
+		t.Errorf("IssueCount = %d, want 4", got[0].IssueCount)
+	}
+}
+
+func TestComputeTrendsAvgRetries(t *testing.T) {
+	// Issues with 0, 2, 4 retries — avg 2.0
+	finishedAt := time.Now()
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{FinishedAt: &finishedAt},
+			Issues: []rundata.IssueDetail{
+				{}, // 0 retries
+				{
+					Retries: []rundata.RetryDetail{{Attempt: 0}, {Attempt: 1}}, // 2 retries
+				},
+				{
+					Retries: []rundata.RetryDetail{{Attempt: 0}, {Attempt: 1}, {Attempt: 2}, {Attempt: 3}}, // 4 retries
+				},
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 1 {
+		t.Fatalf("len(ComputeTrends) = %d, want 1", len(got))
+	}
+	if !nearlyEqual(got[0].AvgRetries, 2.0, 0.0001) {
+		t.Errorf("AvgRetries = %f, want 2.0", got[0].AvgRetries)
+	}
+}
+
+func TestComputeTrendsCostSummed(t *testing.T) {
+	// 3 issues each costing $0.10 — total $0.30
+	finishedAt := time.Now()
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{FinishedAt: &finishedAt},
+			Issues: []rundata.IssueDetail{
+				{Implement: rundata.StepResult{CostUSD: 0.10}},
+				{Implement: rundata.StepResult{CostUSD: 0.10}},
+				{Implement: rundata.StepResult{CostUSD: 0.10}},
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 1 {
+		t.Fatalf("len(ComputeTrends) = %d, want 1", len(got))
+	}
+	if !nearlyEqual(got[0].TotalCostUSD, 0.30, 0.0001) {
+		t.Errorf("TotalCostUSD = %f, want 0.30", got[0].TotalCostUSD)
+	}
+}
+
+func TestComputeTrendsUnfinishedExcluded(t *testing.T) {
+	finishedAt := time.Now()
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{FinishedAt: nil}, // unfinished — excluded
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: "implemented"}},
+			},
+		},
+		{
+			RunMeta: rundata.RunMeta{FinishedAt: &finishedAt},
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: "implemented"}},
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 1 {
+		t.Fatalf("len(ComputeTrends) = %d, want 1 (unfinished run excluded)", len(got))
+	}
+}
+
+func TestComputeTrendsAllUnfinishedReturnsNil(t *testing.T) {
+	runs := []rundata.RunDetail{
+		{RunMeta: rundata.RunMeta{FinishedAt: nil}},
+		{RunMeta: rundata.RunMeta{FinishedAt: nil}},
+	}
+
+	got := ComputeTrends(runs)
+
+	if got != nil {
+		t.Errorf("ComputeTrends(all unfinished) = %v, want nil", got)
+	}
+}
+
+func TestComputeTrendsMetaFields(t *testing.T) {
+	finishedAt := time.Now()
+	ts := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{
+				Repo:       "owner/repo",
+				Milestone:  "v1.0",
+				StartedAt:  ts,
+				FinishedAt: &finishedAt,
+			},
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: "implemented"}},
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 1 {
+		t.Fatalf("len(ComputeTrends) = %d, want 1", len(got))
+	}
+	if got[0].Repo != "owner/repo" {
+		t.Errorf("Repo = %q, want %q", got[0].Repo, "owner/repo")
+	}
+	if got[0].Milestone != "v1.0" {
+		t.Errorf("Milestone = %q, want %q", got[0].Milestone, "v1.0")
+	}
+	if !got[0].Timestamp.Equal(ts) {
+		t.Errorf("Timestamp = %v, want %v", got[0].Timestamp, ts)
+	}
+}


### PR DESCRIPTION
Closes #186

## Implementation Notes

### Approach
Added `TrendPoint` struct and `ComputeTrends` function in a new file `internal/analysis/trends.go`. The function iterates over all provided runs, skips those without a `FinishedAt` timestamp, computes per-run statistics (success rate, average retries, total cost), builds a `TrendPoint` for each finished run, and returns the slice sorted chronologically oldest-first.

### Key Decisions
- **Nil return for empty/all-unfinished input**: Returns `nil` rather than an empty slice to match the issue spec ("Empty input returns nil") and to avoid allocating a slice when there's nothing to return.
- **Cost accumulation mirrors `Aggregate`**: Sums `SpecGenerator`, `Implement`, `QualityReview`, `FunctionalReview`, and all retry step costs — consistent with how `Aggregate` computes costs.
- **Separate file**: Placed in `trends.go` rather than `analysis.go` to keep concerns separated; the existing file handles cross-run aggregation while this handles per-run time series.

### Known Limitations
None. All acceptance criteria and test cases from the issue are covered.

### Architecture
Touches only the **domain** layer (`internal/analysis/`). Imports `internal/rundata/` (also domain) and standard library only. No new dependencies introduced.