### PR TITLE
feat(config): add Modules field for per-module build/test/lint/generate config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,16 @@ type Verify struct {
 	Blocking       bool `yaml:"blocking"`
 }
 
+// Module holds per-module build/test/lint/generate commands and dependency
+// relationships. All fields are optional.
+type Module struct {
+	BuildCommand    string   `yaml:"build_command"`
+	TestCommand     string   `yaml:"test_command"`
+	LintCommand     string   `yaml:"lint_command"`
+	GenerateCommand string   `yaml:"generate_command"`
+	DependsOn       []string `yaml:"depends_on"`
+}
+
 // Config holds all configuration for a godark run.
 type Config struct {
 	Repo       string `yaml:"repo"`
@@ -67,6 +77,10 @@ type Config struct {
 	Prompts Prompts `yaml:"prompts"`
 	Quality Quality `yaml:"quality"`
 	Verify  Verify  `yaml:"verify"`
+
+	// Modules maps module names to per-module build/test/lint/generate commands
+	// and dependency relationships. Nil (absent) means single-module mode.
+	Modules map[string]Module `yaml:"modules"`
 }
 
 // Docker holds Docker sandbox configuration.
@@ -176,6 +190,62 @@ func validate(cfg *Config) error {
 		// valid
 	default:
 		return fmt.Errorf("auth_preference must be \"oauth\" or \"api_key\", got %q", cfg.AuthPreference)
+	}
+	if err := validateModules(cfg.Modules); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateModules checks that all depends_on references name existing modules
+// and that there are no dependency cycles.
+func validateModules(modules map[string]Module) error {
+	if len(modules) == 0 {
+		return nil
+	}
+
+	// Check all depends_on entries reference known modules.
+	for name, mod := range modules {
+		for _, dep := range mod.DependsOn {
+			if _, ok := modules[dep]; !ok {
+				return fmt.Errorf("module %q depends_on unknown module %q", name, dep)
+			}
+		}
+	}
+
+	// Detect cycles using DFS with three-color marking:
+	//   0 = white (unvisited), 1 = gray (in current path), 2 = black (done)
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int, len(modules))
+
+	var visit func(name string) error
+	visit = func(name string) error {
+		if color[name] == gray {
+			return fmt.Errorf("cycle detected in module dependencies involving %q", name)
+		}
+		if color[name] == black {
+			return nil
+		}
+		color[name] = gray
+		for _, dep := range modules[name].DependsOn {
+			if err := visit(dep); err != nil {
+				return err
+			}
+		}
+		color[name] = black
+		return nil
+	}
+
+	for name := range modules {
+		if color[name] == white {
+			if err := visit(name); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -835,6 +835,193 @@ generated_paths:
 	}
 }
 
+// --- Module tests ---
+
+func TestModulesDefaultNil(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Modules != nil {
+		t.Errorf("Modules = %v, want nil", cfg.Modules)
+	}
+}
+
+func TestSingleModuleConfigNoModulesKey(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+build_command: "go build ./..."
+test_command: "go test ./..."
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Modules != nil {
+		t.Errorf("Modules = %v, want nil (single-module mode)", cfg.Modules)
+	}
+	if cfg.BuildCommand != "go build ./..." {
+		t.Errorf("BuildCommand = %q, want %q", cfg.BuildCommand, "go build ./...")
+	}
+}
+
+func TestTwoModulesParseCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+modules:
+  service:
+    build_command: "go build ./..."
+  admin-cli:
+    depends_on: [service]
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Modules) != 2 {
+		t.Fatalf("Modules len = %d, want 2", len(cfg.Modules))
+	}
+	svc, ok := cfg.Modules["service"]
+	if !ok {
+		t.Fatal("expected module 'service' to exist")
+	}
+	if svc.BuildCommand != "go build ./..." {
+		t.Errorf("service.BuildCommand = %q, want %q", svc.BuildCommand, "go build ./...")
+	}
+	admin, ok := cfg.Modules["admin-cli"]
+	if !ok {
+		t.Fatal("expected module 'admin-cli' to exist")
+	}
+	if len(admin.DependsOn) != 1 || admin.DependsOn[0] != "service" {
+		t.Errorf("admin-cli.DependsOn = %v, want [service]", admin.DependsOn)
+	}
+}
+
+func TestModulesUnknownDependencyFails(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+modules:
+  service:
+    depends_on: [nonexistent]
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for unknown depends_on, got nil")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error = %q, want mention of 'nonexistent'", err.Error())
+	}
+}
+
+func TestModulesCycleDetected(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+modules:
+  a:
+    depends_on: [b]
+  b:
+    depends_on: [a]
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for cycle in dependencies, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error = %q, want mention of 'cycle'", err.Error())
+	}
+}
+
+func TestModulesPerModuleCommandsIndependent(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+modules:
+  service:
+    build_command: "go build ./service/..."
+    test_command: "go test ./service/..."
+    lint_command: "golangci-lint run ./service/..."
+    generate_command: "go generate ./service/..."
+  admin-cli:
+    build_command: "go build ./admin/..."
+    test_command: "go test ./admin/..."
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	svc := cfg.Modules["service"]
+	if svc.BuildCommand != "go build ./service/..." {
+		t.Errorf("service.BuildCommand = %q", svc.BuildCommand)
+	}
+	if svc.TestCommand != "go test ./service/..." {
+		t.Errorf("service.TestCommand = %q", svc.TestCommand)
+	}
+	if svc.LintCommand != "golangci-lint run ./service/..." {
+		t.Errorf("service.LintCommand = %q", svc.LintCommand)
+	}
+	if svc.GenerateCommand != "go generate ./service/..." {
+		t.Errorf("service.GenerateCommand = %q", svc.GenerateCommand)
+	}
+	admin := cfg.Modules["admin-cli"]
+	if admin.BuildCommand != "go build ./admin/..." {
+		t.Errorf("admin-cli.BuildCommand = %q", admin.BuildCommand)
+	}
+	if admin.TestCommand != "go test ./admin/..." {
+		t.Errorf("admin-cli.TestCommand = %q", admin.TestCommand)
+	}
+}
+
+func TestModulesLongChainNoCycle(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+modules:
+  a:
+    depends_on: []
+  b:
+    depends_on: [a]
+  c:
+    depends_on: [b]
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error for valid chain a->b->c: %v", err)
+	}
+}
+
+func TestModulesSelfCycleDetected(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+modules:
+  a:
+    depends_on: [a]
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for self-cycle, got nil")
+	}
+	if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error = %q, want mention of 'cycle'", err.Error())
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.


### PR DESCRIPTION
Closes #217

## Implementation Notes

### Approach
Added a new `Module` struct and a `Modules map[string]Module` field to the `Config` struct. When `modules` is absent or empty the map is nil, preserving all existing single-module behavior. Validation runs after YAML unmarshaling and CLI flag merging, consistent with the existing `validate()` pattern.

### Key Decisions
- **Cycle detection via DFS three-color marking**: white (unvisited) → gray (in current recursion path) → black (fully visited). A gray node encountered during traversal means a back-edge, i.e. a cycle. This handles all cycle shapes including self-loops and longer chains without requiring a separate topological sort pass.
- **Unknown-reference check precedes cycle check**: We verify all `depends_on` entries name real modules first; this produces a clearer error message than letting the DFS silently skip unknown nodes.
- **`Modules` defaults to `nil`**: Map zero value in Go. No change to `defaults()` needed.

### Known Limitations
- Per-module *execution* (running the commands in dependency order) is deferred to the follow-on issue per the issue spec.
- Cycle error messages report the first node detected in a cycle, not the full cycle path; this is sufficient for user diagnostics.

### Architecture
Only `internal/config/` (the **foundation** layer) was touched. No dependencies were added or changed — the package still imports only `errors`, `fmt`, `os`, and `gopkg.in/yaml.v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)