### PR TITLE
feat(config): add WaitForChecks config fields for CI check gating

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -223,8 +223,12 @@ func validateWaitForChecks(w *WaitForChecks) error {
 	if w == nil {
 		return nil
 	}
-	if _, err := time.ParseDuration(w.Timeout); err != nil {
+	d, err := time.ParseDuration(w.Timeout)
+	if err != nil {
 		return fmt.Errorf("wait_for_checks.timeout %q is not a valid duration: %w", w.Timeout, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("wait_for_checks.timeout must be a positive duration, got %q", w.Timeout)
 	}
 	if len(w.Required) == 0 {
 		return fmt.Errorf("wait_for_checks.required must be non-empty when wait_for_checks is set")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1169,6 +1169,44 @@ wait_for_checks:
 	}
 }
 
+func TestWaitForChecksZeroTimeout(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+wait_for_checks:
+  timeout: "0"
+  required:
+    - lint
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for zero timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "wait_for_checks.timeout") {
+		t.Errorf("error = %q, want mention of 'wait_for_checks.timeout'", err.Error())
+	}
+}
+
+func TestWaitForChecksNegativeTimeout(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+wait_for_checks:
+  timeout: "-5m"
+  required:
+    - lint
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for negative timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "wait_for_checks.timeout") {
+		t.Errorf("error = %q, want mention of 'wait_for_checks.timeout'", err.Error())
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.


### PR DESCRIPTION
## Summary

- Adds `WaitForChecks` struct with `Timeout string` and `Required []string` fields to `internal/config/config.go`
- Adds `WaitForChecks *WaitForChecks` pointer field to `Config` (nil = not configured, preserving current merge-immediately behavior)
- Adds `validateWaitForChecks()` that rejects invalid timeout durations and empty `required` lists
- Adds 5 unit tests covering defaults, valid config, multiple required checks, invalid timeout, and empty required

Closes #219

## Implementation Notes

### Approach
Added the `WaitForChecks` struct directly in `internal/config/config.go` following the same pattern as existing structs (`Quality`, `Verify`, `Module`). The field is a pointer so nil naturally means "not configured". Validation follows the same pattern as `validateModules` — a dedicated private function called from `validate()`.

### Key Decisions
- Used a pointer (`*WaitForChecks`) per the issue spec so nil clearly signals "not configured" vs. an empty struct
- Validation uses `time.ParseDuration` directly — no custom parsing, consistent with Go stdlib conventions
- Error messages name the specific field (`wait_for_checks.timeout`, `wait_for_checks.required`) for clear user feedback
- Added `"time"` to imports (only new import needed)

### Known Limitations
- This is config-only as specified. The polling and gating logic that actually uses `WaitForChecks` at runtime is deferred to a follow-on issue.

### Architecture
Only the `foundation` layer (`internal/config/`) was touched. No new dependencies were introduced — `time` is a Go stdlib package. This is consistent with the foundation layer's constraint of zero internal dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)