### PR TITLE
feat(agent): add generated path protection in PreToolUse hook (#220)

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -124,6 +124,7 @@ func newPromptData(issue github.Issue, cfg *config.Config, slug string) PromptDa
 		BuildCommand:    cfg.BuildCommand,
 		TestCommand:     cfg.TestCommand,
 		ProtectedPaths:  strings.Join(cfg.ProtectedPaths, ", "),
+		GeneratedPaths:  strings.Join(cfg.GeneratedPaths, ", "),
 		ScenarioDir:     cfg.ScenarioDir,
 		ReviewDir:       cfg.ReviewDir,
 		HasScenarioSpec: HasScenarioSpec(cfg.ScenarioDir, issue.Number),
@@ -163,6 +164,7 @@ func newRunOpts(rendered string, cfg *config.Config, authEnv map[string]string, 
 		env[k] = v
 	}
 	env["GODARK_PROTECTED_PATHS"] = strings.Join(cfg.ProtectedPaths, ",")
+	env["GODARK_GENERATED_PATHS"] = strings.Join(cfg.GeneratedPaths, ",")
 	env["GODARK_DENIED_COMMANDS"] = strings.Join(cfg.DeniedCommands, ",")
 
 	return RunOpts{

--- a/internal/agent/implementer_test.go
+++ b/internal/agent/implementer_test.go
@@ -573,3 +573,73 @@ func TestVerifyFix_SetsImplementerRetryRole(t *testing.T) {
 		t.Errorf("GODARK_ROLE = %q, want %q", capturedEnv["GODARK_ROLE"], "implementer_retry")
 	}
 }
+
+func TestNewRunOpts_SetsGeneratedPathsEnv(t *testing.T) {
+	cfg := testConfig()
+	cfg.GeneratedPaths = []string{"service/api/grpc/gen/", "**/*.freezed.dart"}
+	opts, err := newRunOpts("prompt", cfg, nil, "implementer")
+	if err != nil {
+		t.Fatalf("newRunOpts() error = %v", err)
+	}
+	got := opts.Env["GODARK_GENERATED_PATHS"]
+	if got != "service/api/grpc/gen/,**/*.freezed.dart" {
+		t.Errorf("GODARK_GENERATED_PATHS = %q, want %q", got, "service/api/grpc/gen/,**/*.freezed.dart")
+	}
+}
+
+func TestNewRunOpts_EmptyGeneratedPathsEnv(t *testing.T) {
+	cfg := testConfig()
+	cfg.GeneratedPaths = nil
+	opts, err := newRunOpts("prompt", cfg, nil, "implementer")
+	if err != nil {
+		t.Fatalf("newRunOpts() error = %v", err)
+	}
+	got := opts.Env["GODARK_GENERATED_PATHS"]
+	if got != "" {
+		t.Errorf("GODARK_GENERATED_PATHS = %q, want empty string", got)
+	}
+}
+
+func TestImplement_GeneratedPathsInEnv(t *testing.T) {
+	var capturedEnv map[string]string
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		capturedEnv = env
+		return []byte(`{"session_id":"","result":"ok","cost_usd":0,"is_error":false}`), []byte(""), 0, nil
+	})
+
+	cfg := testConfig()
+	cfg.GeneratedPaths = []string{"gen/", "**/*.pb.go"}
+
+	_, err := Implement(context.Background(), testIssue(), cfg, testPrompts(t), nil, testLogger(t))
+	if err != nil {
+		t.Fatalf("Implement() error = %v", err)
+	}
+
+	got := capturedEnv["GODARK_GENERATED_PATHS"]
+	if got != "gen/,**/*.pb.go" {
+		t.Errorf("GODARK_GENERATED_PATHS = %q, want %q", got, "gen/,**/*.pb.go")
+	}
+}
+
+func TestNewPromptData_GeneratedPathsJoined(t *testing.T) {
+	cfg := testConfig()
+	cfg.GeneratedPaths = []string{"service/api/grpc/gen/", "**/*.freezed.dart"}
+
+	data := newPromptData(testIssue(), cfg, "test-slug")
+
+	want := "service/api/grpc/gen/, **/*.freezed.dart"
+	if data.GeneratedPaths != want {
+		t.Errorf("GeneratedPaths = %q, want %q", data.GeneratedPaths, want)
+	}
+}
+
+func TestNewPromptData_EmptyGeneratedPaths(t *testing.T) {
+	cfg := testConfig()
+	cfg.GeneratedPaths = nil
+
+	data := newPromptData(testIssue(), cfg, "test-slug")
+
+	if data.GeneratedPaths != "" {
+		t.Errorf("GeneratedPaths = %q, want empty string", data.GeneratedPaths)
+	}
+}

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -34,6 +34,7 @@ type PromptData struct {
 	BuildCommand   string
 	TestCommand    string
 	ProtectedPaths string
+	GeneratedPaths string
 	ScenarioDir    string
 	ReviewDir      string
 	VerifyErrors           string

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -11,12 +11,14 @@ Environment variables:
   GODARK_SESSION_ID        Session ID for resuming a previous session
   GODARK_WORKDIR           Working directory (default: /workspace)
   GODARK_PROTECTED_PATHS   Comma-separated list of protected paths (exact or dir prefix)
+  GODARK_GENERATED_PATHS   Comma-separated list of generated paths (dir prefix or glob pattern)
   GODARK_DENIED_COMMANDS   Comma-separated list of denied Bash command patterns (substring match)
   GH_TOKEN                 GitHub token forwarded to the agent environment
 """
 
 import asyncio
 import datetime
+import fnmatch
 import json
 import os
 import random
@@ -128,6 +130,56 @@ def make_protected_path_hook(protected_paths: list[str]):
     return hook
 
 
+def _is_generated(file_path: str, generated_paths: list[str]) -> str | None:
+    """Return the first matching generated path if file_path is generated, else None.
+
+    Matching rules:
+    - Glob pattern (entry contains '*'): fnmatch match against file_path
+    - Directory prefix (no '*'): file_path starts with entry (with trailing slash normalised)
+    """
+    for p in generated_paths:
+        if "*" in p:
+            if fnmatch.fnmatch(file_path, p):
+                return p
+        else:
+            prefix = p.rstrip("/")
+            if file_path == prefix or file_path.startswith(prefix + "/"):
+                return p
+    return None
+
+
+def make_generated_path_hook(generated_paths: list[str]):
+    """Return an async PreToolUse hook that blocks writes to generated paths.
+
+    For Write/Edit tools: checks tool_input.file_path against generated paths.
+    Directory prefixes (no '*') use startswith matching; glob patterns (contain
+    '*') use fnmatch matching.
+    """
+
+    async def hook(hook_input: PreToolUseHookInput, matcher: str | None, ctx) -> dict:
+        tool_name = hook_input.get("tool_name", "")
+        if tool_name not in ("Write", "Edit"):
+            return {}
+
+        tool_input = hook_input.get("tool_input", {})
+        file_path = tool_input.get("file_path", "")
+        if not file_path:
+            return {}
+
+        matched = _is_generated(file_path, generated_paths)
+        if matched is None:
+            return {}
+
+        return {
+            "decision": "block",
+            "systemMessage": (
+                "this file is generated — edit the source file or re-run code generation instead"
+            ),
+        }
+
+    return hook
+
+
 def make_denied_commands_hook(denied_patterns: list[str]):
     """Return an async PreToolUse hook that blocks Bash commands matching denied patterns.
 
@@ -192,6 +244,7 @@ async def main() -> None:
     session_id = os.environ.get("GODARK_SESSION_ID", "")
     work_dir = os.environ.get("GODARK_WORKDIR", "/workspace")
     protected_paths_raw = os.environ.get("GODARK_PROTECTED_PATHS", "")
+    generated_paths_raw = os.environ.get("GODARK_GENERATED_PATHS", "")
     denied_commands_raw = os.environ.get("GODARK_DENIED_COMMANDS", "")
 
     if role not in _ROLE_PERMISSIONS:
@@ -212,8 +265,9 @@ async def main() -> None:
     if os.environ.get("GH_TOKEN"):
         env["GH_TOKEN"] = os.environ["GH_TOKEN"]
 
-    # Build hooks: PreToolUse guard for protected paths + denied commands + PostToolUse audit log.
+    # Build hooks: PreToolUse guard for protected paths + generated paths + denied commands + PostToolUse audit log.
     protected_paths = [p.strip() for p in protected_paths_raw.split(",") if p.strip()]
+    generated_paths = [p.strip() for p in generated_paths_raw.split(",") if p.strip()]
     denied_commands = [c.strip() for c in denied_commands_raw.split(",") if c.strip()]
 
     pre_tool_use_hooks: list = []
@@ -222,6 +276,13 @@ async def main() -> None:
             HookMatcher(
                 matcher="Write|Edit|Bash",
                 hooks=[make_protected_path_hook(protected_paths)],
+            )
+        )
+    if generated_paths:
+        pre_tool_use_hooks.append(
+            HookMatcher(
+                matcher="Write|Edit",
+                hooks=[make_generated_path_hook(generated_paths)],
             )
         )
     if denied_commands:

--- a/internal/agent/runner/test_hooks.py
+++ b/internal/agent/runner/test_hooks.py
@@ -9,9 +9,11 @@ from unittest.mock import patch
 
 # Import helpers directly from agent_runner
 from agent_runner import (
+    _is_generated,
     _is_protected,
     make_audit_hook,
     make_denied_commands_hook,
+    make_generated_path_hook,
     make_protected_path_hook,
 )
 
@@ -149,6 +151,100 @@ class TestProtectedPathHookBash(unittest.TestCase):
     def test_bash_empty_command_allowed(self):
         hook = make_protected_path_hook(["CLAUDE.md"])
         result = self._call_bash(hook, "")
+        self.assertNotEqual(result.get("decision"), "block")
+
+
+class TestIsGenerated(unittest.TestCase):
+    """Tests for the _is_generated path-matching helper."""
+
+    def test_directory_prefix_blocked(self):
+        result = _is_generated("service/api/grpc/gen/foo.go", ["service/api/grpc/gen/"])
+        self.assertEqual(result, "service/api/grpc/gen/")
+
+    def test_directory_prefix_without_trailing_slash(self):
+        result = _is_generated("service/api/grpc/gen/foo.go", ["service/api/grpc/gen"])
+        self.assertEqual(result, "service/api/grpc/gen")
+
+    def test_glob_pattern_blocked(self):
+        result = _is_generated("lib/models/load.freezed.dart", ["**/*.freezed.dart"])
+        self.assertEqual(result, "**/*.freezed.dart")
+
+    def test_glob_pattern_no_match(self):
+        result = _is_generated("lib/models/load.dart", ["**/*.freezed.dart"])
+        self.assertIsNone(result)
+
+    def test_non_matching_path_returns_none(self):
+        result = _is_generated(
+            "service/api/graph/resolver.go", ["service/api/grpc/gen/", "**/*.freezed.dart"]
+        )
+        self.assertIsNone(result)
+
+    def test_empty_generated_paths(self):
+        result = _is_generated("service/api/grpc/gen/foo.go", [])
+        self.assertIsNone(result)
+
+    def test_exact_match(self):
+        result = _is_generated("service/api/grpc/gen", ["service/api/grpc/gen/"])
+        self.assertEqual(result, "service/api/grpc/gen/")
+
+    def test_partial_prefix_not_matched(self):
+        result = _is_generated("service/api/grpc/gen_extra/foo.go", ["service/api/grpc/gen/"])
+        self.assertIsNone(result)
+
+
+class TestGeneratedPathHook(unittest.TestCase):
+    """Tests for the make_generated_path_hook PreToolUse hook."""
+
+    def _call(self, hook, tool_name: str, tool_input: dict) -> dict:
+        hook_input = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_use_id": "tu_010",
+            "session_id": "sess_001",
+            "transcript_path": "/tmp/transcript",
+            "cwd": "/workspace",
+        }
+        return run(hook(hook_input, "Write|Edit", None))
+
+    def test_directory_prefix_write_blocked(self):
+        hook = make_generated_path_hook(["service/api/grpc/gen/"])
+        result = self._call(hook, "Write", {"file_path": "service/api/grpc/gen/foo.go"})
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_directory_prefix_edit_blocked(self):
+        hook = make_generated_path_hook(["service/api/grpc/gen/"])
+        result = self._call(hook, "Edit", {"file_path": "service/api/grpc/gen/foo.go"})
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_glob_pattern_blocked(self):
+        hook = make_generated_path_hook(["**/*.freezed.dart"])
+        result = self._call(hook, "Write", {"file_path": "lib/models/load.freezed.dart"})
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_non_matching_path_allowed(self):
+        hook = make_generated_path_hook(["service/api/grpc/gen/", "**/*.freezed.dart"])
+        result = self._call(hook, "Write", {"file_path": "service/api/graph/resolver.go"})
+        self.assertNotEqual(result.get("decision"), "block")
+
+    def test_empty_generated_paths_allows_all(self):
+        hook = make_generated_path_hook([])
+        result = self._call(hook, "Write", {"file_path": "service/api/grpc/gen/foo.go"})
+        self.assertNotEqual(result.get("decision"), "block")
+
+    def test_system_message_contains_generated(self):
+        hook = make_generated_path_hook(["service/api/grpc/gen/"])
+        result = self._call(hook, "Write", {"file_path": "service/api/grpc/gen/foo.go"})
+        self.assertIn("generated", result.get("systemMessage", ""))
+
+    def test_missing_file_path_allowed(self):
+        hook = make_generated_path_hook(["service/api/grpc/gen/"])
+        result = self._call(hook, "Write", {})
+        self.assertNotEqual(result.get("decision"), "block")
+
+    def test_bash_tool_not_blocked(self):
+        hook = make_generated_path_hook(["service/api/grpc/gen/"])
+        result = self._call(hook, "Bash", {"command": "cat service/api/grpc/gen/foo.go"})
         self.assertNotEqual(result.get("decision"), "block")
 
 

--- a/prompts/implementer.txt
+++ b/prompts/implementer.txt
@@ -27,6 +27,9 @@ CRITICAL RULES:
 - Never commit directly to main
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
 - Do NOT modify files in {{.ScenarioDir}} or {{.ReviewDir}}
+{{- if .GeneratedPaths}}
+- Do NOT edit generated files directly ({{.GeneratedPaths}}); edit source files or re-run code generation instead
+{{- end}}
 
 Implementation steps:
 1. Write the implementation code{{if .ArchitectureDocContent}}, respecting the architecture layer rules above{{end}}

--- a/prompts/reviewer.txt
+++ b/prompts/reviewer.txt
@@ -39,6 +39,9 @@ Steps:
 CRITICAL RULES:
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
 - Do NOT modify files in {{.ScenarioDir}}
+{{- if .GeneratedPaths}}
+- Do NOT edit generated files directly ({{.GeneratedPaths}}); edit source files or re-run code generation instead
+{{- end}}
 {{- if .HasScenarioSpec}}
 - You MUST write integration tests to {{.ReviewDir}} (step 9) before making your verdict. This is non-negotiable.
 - Judging existing tests sufficient is NOT acceptable — you must write your own ephemeral tests in {{.ReviewDir}}.


### PR DESCRIPTION
## Summary

- Adds `GODARK_GENERATED_PATHS` env var (comma-separated from `cfg.GeneratedPaths`) passed to the agent runner
- Agent runner blocks `Write`/`Edit` tool calls to files matching generated path patterns with error message: "this file is generated — edit the source file or re-run code generation instead"
- Directory prefixes (no `*`) use `startswith` matching; glob patterns (contain `*`) use `fnmatch.fnmatch`
- Prompt templates (`implementer.txt`, `reviewer.txt`) include a `{{.GeneratedPaths}}` summary when non-empty

## Implementation Notes

### Approach

The implementation follows the same architectural pattern as `protected_paths`:
1. `cfg.GeneratedPaths` is formatted to a comma-separated string and stored in `GODARK_GENERATED_PATHS` env var inside `newRunOpts` in `implementer.go`
2. `newPromptData` populates `PromptData.GeneratedPaths` (joined with `, `) for template rendering
3. In `agent_runner.py`, a new `_is_generated()` helper handles the two matching modes (glob via `fnmatch`, prefix via `startswith`), and `make_generated_path_hook()` returns the `PreToolUse` hook
4. The hook is registered only on `Write|Edit` (not `Bash`) since generated files are write-protected, not reference-protected

### Key Decisions

- **No Bash hook**: Unlike `protected_paths`, the generated path hook only guards `Write|Edit`. Generated file protection is about preventing direct edits, not blocking any command that mentions the path.
- **Exact error message**: The system message is exactly as specified in the issue: "this file is generated — edit the source file or re-run code generation instead"
- **`fnmatch` for globs**: Python's built-in `fnmatch.fnmatch` correctly handles `**/*.freezed.dart` patterns as specified

### Known Limitations

- The `**` glob prefix in patterns like `**/*.freezed.dart` is handled by `fnmatch` which treats `**` similarly to `*` for flat matching. For deeply nested paths like `a/b/c/file.freezed.dart`, `fnmatch("a/b/c/file.freezed.dart", "**/*.freezed.dart")` returns `True` because `fnmatch` matches `**` as a multi-character wildcard including `/`. This matches the expected behavior from the test cases.

### Architecture

- **`internal/agent/`** (orchestration layer): `implementer.go` and `prompt.go` modified — both already in the orchestration layer, no new cross-layer dependencies introduced
- **`internal/agent/runner/`** (infrastructure layer): `agent_runner.py` modified — self-contained Python script, no new package-level imports beyond stdlib `fnmatch`
- **`prompts/`** (content layer): template files modified — static content, no runtime dependencies

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)