### PR TITLE
feat(config): add ValidateRequiredEnv and call it in run/implement

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -67,6 +67,10 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			return fmt.Errorf("loading config: %w", err)
 		}
 
+		if err := config.ValidateRequiredEnv(cfg.RequiredEnv); err != nil {
+			return err
+		}
+
 		if dryRun {
 			for _, num := range issueNums {
 				issue, err := github.FetchIssue(cfg.Repo, num)

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -86,6 +86,10 @@ each unblocked issue through the implement → review → merge loop.`,
 			return fmt.Errorf("loading config: %w", err)
 		}
 
+		if err := config.ValidateRequiredEnv(cfg.RequiredEnv); err != nil {
+			return err
+		}
+
 		if cfg.NoSandbox {
 			fmt.Fprintln(os.Stderr, "WARNING: running without sandbox — agent execution is not containerized")
 		}

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ValidateRequiredEnv checks that all required environment variables are set.
+// Returns an error listing any missing variables.
+func ValidateRequiredEnv(required []string) error {
+	if len(required) == 0 {
+		return nil
+	}
+
+	var missing []string
+	for _, name := range required {
+		if os.Getenv(name) == "" {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
+	}
+
+	return nil
+}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateRequiredEnvAllPresent(t *testing.T) {
+	// HOME is always set in the test environment.
+	if err := ValidateRequiredEnv([]string{"HOME"}); err != nil {
+		t.Errorf("unexpected error for present var: %v", err)
+	}
+}
+
+func TestValidateRequiredEnvOneMissing(t *testing.T) {
+	err := ValidateRequiredEnv([]string{"DEFINITELY_NOT_SET_12345"})
+	if err == nil {
+		t.Fatal("expected error for missing var, got nil")
+	}
+	if !strings.Contains(err.Error(), "DEFINITELY_NOT_SET_12345") {
+		t.Errorf("error = %q, want mention of 'DEFINITELY_NOT_SET_12345'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "missing required environment variables") {
+		t.Errorf("error = %q, want mention of 'missing required environment variables'", err.Error())
+	}
+}
+
+func TestValidateRequiredEnvMultipleMissing(t *testing.T) {
+	err := ValidateRequiredEnv([]string{"DEFINITELY_NOT_SET_AAA", "DEFINITELY_NOT_SET_BBB"})
+	if err == nil {
+		t.Fatal("expected error for missing vars, got nil")
+	}
+	if !strings.Contains(err.Error(), "DEFINITELY_NOT_SET_AAA") {
+		t.Errorf("error = %q, want mention of 'DEFINITELY_NOT_SET_AAA'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "DEFINITELY_NOT_SET_BBB") {
+		t.Errorf("error = %q, want mention of 'DEFINITELY_NOT_SET_BBB'", err.Error())
+	}
+}
+
+func TestValidateRequiredEnvEmptyList(t *testing.T) {
+	if err := ValidateRequiredEnv([]string{}); err != nil {
+		t.Errorf("unexpected error for empty list: %v", err)
+	}
+}
+
+func TestValidateRequiredEnvNilList(t *testing.T) {
+	if err := ValidateRequiredEnv(nil); err != nil {
+		t.Errorf("unexpected error for nil list: %v", err)
+	}
+}
+
+func TestValidateRequiredEnvErrorFormat(t *testing.T) {
+	err := ValidateRequiredEnv([]string{"MISSING_X", "MISSING_Y"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	want := "missing required environment variables: MISSING_X, MISSING_Y"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}


### PR DESCRIPTION
Closes #222

## Summary
- Add `ValidateRequiredEnv(required []string) error` to `internal/config/env.go`
- Call it in `godark run` and `godark implement` immediately after config loads, before any expensive work (Docker build, lock acquisition, orchestration)
- 6 unit tests covering all acceptance criteria

## Test plan
- [ ] `go test ./internal/config/...` — all tests pass including the 6 new `TestValidateRequiredEnv*` tests
- [ ] `go build ./...` — compiles cleanly
- [ ] Manual: set a config with `required_env: [DEFINITELY_NOT_SET]` and run `godark implement` — should fail immediately with `missing required environment variables: DEFINITELY_NOT_SET`
- [ ] Manual: set `required_env: [HOME]` — should pass validation and proceed

## Implementation Notes

### Approach
New standalone file `internal/config/env.go` in the `config` package. The function iterates over the required slice, collects missing names via `os.Getenv`, and returns a single formatted error listing all absent variables. Empty/nil input short-circuits with `nil`.

Both `run` and `implement` commands call it right after `config.Load` returns, before any Docker image building or orchestrator work begins.

### Key Decisions
- Placed in `internal/config/` (foundation layer) so it has no upward dependencies and is reusable from any layer.
- Returns a plain `fmt.Errorf` string rather than a custom error type — consistent with the project convention of using `fmt.Errorf` for most errors.
- Checks `os.Getenv(name) == ""` which treats both unset and empty-string values as missing, matching typical credential validation expectations.

### Known Limitations
- A variable set to an empty string is treated as missing. This is intentional for credential use cases but could be surprising for variables that legitimately allow empty values.

### Architecture
- **foundation** (`internal/config/`): new `ValidateRequiredEnv` function — no new dependencies introduced; this layer is allowed to read `os.Getenv`.
- **cmd** (`internal/cmd/`): two call sites added in `run.go` and `implement.go` — `cmd` is allowed to depend on `foundation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)