### PR TITLE
feat(skills): add /godark-configure-project skill

### DIFF
--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -104,6 +104,40 @@ func TestInitIdempotent(t *testing.T) {
 	}
 }
 
+func TestInitWritesConfigureProjectSkill(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	runInit(t)
+
+	skillPath := filepath.Join(".claude", "skills", "godark-configure-project", "SKILL.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("godark-configure-project skill not created: %v", err)
+	}
+
+	if !strings.Contains(string(data), "name: godark-configure-project") {
+		t.Error("SKILL.md missing expected frontmatter name")
+	}
+}
+
+func TestInitConfigureProjectSkillIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	runInit(t)
+	runInit(t)
+
+	skillPath := filepath.Join(".claude", "skills", "godark-configure-project", "SKILL.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Error("godark-configure-project skill file missing after second init")
+	}
+}
+
 func TestInitWritesHarnessDocs(t *testing.T) {
 	dir := t.TempDir()
 	origDir, _ := os.Getwd()

--- a/internal/skills/embed.go
+++ b/internal/skills/embed.go
@@ -2,5 +2,5 @@ package skills
 
 import "embed"
 
-//go:embed godark-create-roadmap godark-create-planning-doc godark-create-issues godark-create-scenarios godark-define-architecture godark-define-conventions godark-harness-claude-md
+//go:embed godark-configure-project godark-create-roadmap godark-create-planning-doc godark-create-issues godark-create-scenarios godark-define-architecture godark-define-conventions godark-harness-claude-md
 var SkillFiles embed.FS

--- a/internal/skills/godark-configure-project/SKILL.md
+++ b/internal/skills/godark-configure-project/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: godark-configure-project
+description: Analyze an existing project and populate godark.yaml with modules, codegen, CI, and env configuration
+argument-hint: "[project-path]"
+disable-model-invocation: true
+---
+
+# Configure Project
+
+Analyze an existing project and populate `godark.yaml` with the complex
+configuration fields that describe project structure. Scans for language
+markers, codegen configs, CI workflows, and project layout, then presents
+findings for user confirmation before writing.
+
+## Steps
+
+1. **Read existing configuration** — Read `godark.yaml` if it exists. Note
+   which fields are already set — those fields must not be overwritten. If
+   `godark.yaml` does not exist, start with an empty config.
+
+2. **Detect project modules** — Search recursively for module definition files
+   to identify multi-module projects:
+   - `go.mod` files (Go modules)
+   - `pubspec.yaml` files (Dart/Flutter packages)
+   - `package.json` files (Node.js/JavaScript packages — skip
+     `node_modules/` directories)
+
+   For each module found, note its directory path relative to the project
+   root. If more than one module is found, prepare a `modules:` list with
+   per-module entries. For each module, propose:
+   - `path:` — the directory containing the module definition file
+   - `build_command:` — language-appropriate default (e.g. `go build ./...`,
+     `flutter build`, `npm run build`)
+   - `test_command:` — language-appropriate default (e.g. `go test ./...`,
+     `flutter test`, `npm test`)
+   - `depends_on:` — list of other module paths this module imports; leave
+     empty if unknown
+
+3. **Detect code generation configuration** — Search for codegen config files
+   and patterns that indicate generated code:
+   - `sqlc.yml` or `sqlc.yaml` (SQL code generation via sqlc)
+   - `gqlgen.yml` or `gqlgen.yaml` (GraphQL code generation via gqlgen)
+   - `.mockery.yaml` (mock generation via mockery)
+   - `buf.yaml` or `buf.gen.yaml` (protobuf generation via buf)
+   - `*.proto` files (protocol buffer definitions — implies `buf generate` or
+     `protoc`)
+   - `Makefile` — scan for targets or commands containing `generate` (e.g.
+     `go generate ./...`, `sqlc generate`, `buf generate`)
+   - `build.yaml` or other custom build definitions
+
+   From the findings, propose:
+   - `generate_command:` — the command(s) that run all code generation (e.g.
+     `go generate ./...`, `make generate`)
+   - `generated_paths:` — directories where generated files are written (e.g.
+     `internal/db/generated/`, `internal/mocks/`, `gen/`)
+
+4. **Detect environment variable requirements** — Search for environment
+   variable declarations and references:
+   - `.env.example` or `.env.sample` — extract variable names (lines of the
+     form `VAR_NAME=` or `export VAR_NAME=`)
+   - `required_env:` keys already present in CI config files
+   - `environment:` or `secrets:` keys in `docker-compose*.yml` and
+     `compose.yml` files
+   - `env:` blocks in `.github/workflows/*.yml` files at the workflow or
+     job level
+
+   Compile a deduplicated, sorted list of variable names for the `required_env`
+   field. Exclude variables that look like build metadata (e.g. `CI`, `RUNNER_*`,
+   `GITHUB_*`) unless they appear in `.env.example`.
+
+5. **Detect CI workflow configuration** — Scan `.github/workflows/*.yml` files:
+   - For each workflow file, read the `jobs:` block and extract job keys.
+   - Identify jobs that represent required checks (any job that runs tests,
+     linting, building, or static analysis — e.g. jobs named `test`, `build`,
+     `lint`, `ci`, `check`, `verify`, `validate`).
+   - Prepare a `wait_for_checks:` list with the GitHub Actions check names.
+     The check name for a job is typically the job key or its `name:` field
+     if set.
+
+6. **Detect Docker Compose usage** — Check for `docker-compose.yml`,
+   `docker-compose.yaml`, `docker-compose*.yml`, or `compose.yml` files at
+   any level of the project tree. If found, note that integration tests run
+   via Compose likely require `no_sandbox: true` in the runtime config.
+
+7. **Present findings** — Display a structured summary of all detected
+   configuration. For each section, show the proposed `godark.yaml` snippet:
+
+   - **Modules** — list detected modules and proposed build/test commands
+   - **Code generation** — list detected tools and proposed `generate_command`
+     and `generated_paths`
+   - **Required environment** — list proposed `required_env` variables
+   - **CI checks** — list proposed `wait_for_checks` names
+   - **Docker Compose** — note if detected and explain the `no_sandbox`
+     recommendation
+
+   For each section, ask the user to confirm, edit, or skip before writing.
+   Do not write anything until the user has reviewed and approved the findings.
+
+8. **Merge into `godark.yaml`** — Write only the confirmed fields. Merge rules:
+   - Do not overwrite any fields that were already set when the skill started.
+   - Append new top-level fields after existing content.
+   - If `godark.yaml` does not exist, create it with just the confirmed fields.
+   - Preserve existing comments and formatting.
+   - If the user skipped a section, do not write those fields.
+
+## Format
+
+The `godark.yaml` fields this skill populates follow this structure:
+
+```yaml
+modules:
+  - path: services/api
+    build_command: go build ./...
+    test_command: go test ./...
+    depends_on: []
+  - path: services/worker
+    build_command: go build ./...
+    test_command: go test ./...
+    depends_on:
+      - services/api
+
+generate_command: go generate ./...
+generated_paths:
+  - internal/db/generated/
+  - internal/mocks/
+
+required_env:
+  - DATABASE_URL
+  - API_KEY
+  - SECRET_TOKEN
+
+wait_for_checks:
+  - test
+  - lint
+  - build
+
+runtime:
+  no_sandbox: true  # required for integration tests run via Docker Compose
+```
+
+## Rules
+
+- This skill is **re-runnable**. Always read existing `godark.yaml` first and
+  merge findings rather than overwriting.
+- Do not overwrite any fields already present in `godark.yaml` before this
+  skill ran.
+- Do not skip the confirmation step — the user must approve each section
+  before it is written.
+- If no multi-module structure is found (only one module at the root), do not
+  add a `modules:` field.
+- If no codegen configuration is found, do not add `generate_command` or
+  `generated_paths` fields.
+- If no environment variable requirements are detected, do not add
+  `required_env`.
+- If no CI workflows are found, do not add `wait_for_checks`.
+- Suggest `no_sandbox: true` only when Docker Compose is detected; do not
+  add it automatically without user confirmation.
+- Skip `node_modules/`, `.git/`, and other vendor directories when scanning.

--- a/internal/skills/godark_configure_project_test.go
+++ b/internal/skills/godark_configure_project_test.go
@@ -1,0 +1,186 @@
+package skills_test
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/skills"
+)
+
+func readConfigureProjectSkill(t *testing.T) string {
+	t.Helper()
+	data, err := fs.ReadFile(skills.SkillFiles, "godark-configure-project/SKILL.md")
+	if err != nil {
+		t.Fatalf("reading godark-configure-project/SKILL.md: %v", err)
+	}
+	return string(data)
+}
+
+func TestConfigureProjectSkillEmbedded(t *testing.T) {
+	_, err := fs.ReadFile(skills.SkillFiles, "godark-configure-project/SKILL.md")
+	if err != nil {
+		t.Errorf("godark-configure-project not embedded: %v", err)
+	}
+}
+
+func TestConfigureProjectSkillFrontmatterName(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	fm := parseFrontmatter(content)
+	if !strings.Contains(fm, "name: godark-configure-project") {
+		t.Error("frontmatter missing 'name: godark-configure-project'")
+	}
+}
+
+func TestConfigureProjectSkillFrontmatterDescription(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	fm := parseFrontmatter(content)
+	if !strings.Contains(fm, "description:") {
+		t.Error("frontmatter missing 'description' field")
+	}
+}
+
+func TestConfigureProjectSkillFrontmatterArgumentHint(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	fm := parseFrontmatter(content)
+	if !strings.Contains(fm, "argument-hint:") {
+		t.Error("frontmatter missing 'argument-hint' field")
+	}
+}
+
+func TestConfigureProjectSkillFrontmatterDisableModelInvocation(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	fm := parseFrontmatter(content)
+	if !strings.Contains(fm, "disable-model-invocation: true") {
+		t.Error("frontmatter missing 'disable-model-invocation: true'")
+	}
+}
+
+func TestConfigureProjectSkillDetectsMultipleModules(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	hasGoMod := strings.Contains(content, "go.mod")
+	hasPackageJSON := strings.Contains(content, "package.json")
+	hasPubspec := strings.Contains(content, "pubspec.yaml")
+	if !hasGoMod || !hasPackageJSON || !hasPubspec {
+		t.Error("skill does not describe detecting multi-module projects (go.mod, package.json, pubspec.yaml)")
+	}
+}
+
+func TestConfigureProjectSkillSuggestsModulesConfig(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, "modules:") {
+		t.Error("skill does not suggest modules: config for multi-module projects")
+	}
+}
+
+func TestConfigureProjectSkillModulesIncludeDependsOn(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, "depends_on") {
+		t.Error("skill does not mention depends_on for module dependency ordering")
+	}
+}
+
+func TestConfigureProjectSkillDetectsCodegenConfigs(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	hasSqlc := strings.Contains(content, "sqlc")
+	hasGqlgen := strings.Contains(content, "gqlgen")
+	if !hasSqlc || !hasGqlgen {
+		t.Error("skill does not describe detecting codegen config files (sqlc, gqlgen)")
+	}
+}
+
+func TestConfigureProjectSkillDetectsProtoFiles(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, ".proto") {
+		t.Error("skill does not describe detecting .proto files for protobuf codegen")
+	}
+}
+
+func TestConfigureProjectSkillDetectsMakefileGenerateTargets(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, "Makefile") {
+		t.Error("skill does not describe detecting Makefile generate targets")
+	}
+}
+
+func TestConfigureProjectSkillSuggestsGenerateCommand(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, "generate_command") {
+		t.Error("skill does not suggest generate_command for codegen")
+	}
+}
+
+func TestConfigureProjectSkillSuggestsGeneratedPaths(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, "generated_paths") {
+		t.Error("skill does not suggest generated_paths for codegen output directories")
+	}
+}
+
+func TestConfigureProjectSkillDetectsEnvExample(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, ".env.example") {
+		t.Error("skill does not describe detecting .env.example for required_env")
+	}
+}
+
+func TestConfigureProjectSkillDetectsComposeSecrets(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	hasCompose := strings.Contains(content, "docker-compose") || strings.Contains(content, "compose.yml")
+	hasSecrets := strings.Contains(content, "secrets:")
+	if !hasCompose || !hasSecrets {
+		t.Error("skill does not describe detecting secrets in Docker Compose files for required_env")
+	}
+}
+
+func TestConfigureProjectSkillSuggestsRequiredEnv(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, "required_env") {
+		t.Error("skill does not suggest required_env field")
+	}
+}
+
+func TestConfigureProjectSkillDetectsCIWorkflows(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, ".github/workflows") {
+		t.Error("skill does not describe detecting CI workflow files in .github/workflows/")
+	}
+}
+
+func TestConfigureProjectSkillSuggestsWaitForChecks(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, "wait_for_checks") {
+		t.Error("skill does not suggest wait_for_checks from CI workflow job names")
+	}
+}
+
+func TestConfigureProjectSkillDetectsDockerCompose(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	hasCompose := strings.Contains(content, "docker-compose.yml") || strings.Contains(content, "compose.yml")
+	if !hasCompose {
+		t.Error("skill does not describe detecting Docker Compose files")
+	}
+}
+
+func TestConfigureProjectSkillNotesNoSandbox(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	if !strings.Contains(content, "no_sandbox") {
+		t.Error("skill does not note that no_sandbox: true may be needed for Docker Compose integration tests")
+	}
+}
+
+func TestConfigureProjectSkillMergesExistingConfig(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	hasMerge := strings.Contains(content, "merge") || strings.Contains(content, "overwrite")
+	if !hasMerge {
+		t.Error("skill does not describe merging into existing godark.yaml without overwriting existing fields")
+	}
+}
+
+func TestConfigureProjectSkillRequiresUserConfirmation(t *testing.T) {
+	content := readConfigureProjectSkill(t)
+	hasConfirm := strings.Contains(content, "confirm") || strings.Contains(content, "approve")
+	if !hasConfirm {
+		t.Error("skill does not require user confirmation before writing")
+	}
+}


### PR DESCRIPTION
Closes #225

## Implementation Notes

### Approach

Added a new Claude skill (`/godark-configure-project`) that guides an agent through analyzing an existing project and populating `godark.yaml` with complex configuration fields. The skill follows the exact same YAML frontmatter + Markdown pattern as all other skills in `internal/skills/`.

The skill is embedded into the binary via the existing `embed.go` directive — adding the new directory there is all that's needed to have `godark init` install it automatically (the `writeSkillFiles` function already walks the entire `SkillFiles` embed.FS).

### Key Decisions

- **No changes to `init.go` logic**: The `writeSkillFiles` function already walks all embedded files generically, so updating the `//go:embed` directive in `embed.go` is sufficient to install the new skill on `godark init`. The issue mentioned updating `init.go`, but inspecting the code showed no new code was required there.
- **Skill covers all acceptance criteria in steps**: Each detection category (modules, codegen, env, CI, Compose) has a dedicated numbered step making the skill easy to follow and test against.
- **Merge-not-overwrite rule is explicit**: Both the Steps section and the Rules section call this out to ensure the skill cannot silently stomp existing config.
- **User confirmation gated**: The skill requires presenting all findings and waiting for user confirmation before writing — consistent with other skills like `godark-define-architecture`.

### Known Limitations

- The skill is a Claude skill (Markdown instructions), not executable Go code, so the detection logic is carried out by the agent following the steps rather than by compiled code. Edge cases in detection (e.g. unusual Makefile formatting) depend on the agent's judgment.
- `depends_on` between modules is noted as "leave empty if unknown" since static analysis of cross-module imports is non-trivial at skill instruction level.

### Architecture

Only the **content** layer was touched (`internal/skills/`), which has no dependencies on other layers per the architecture rules. Tests in `internal/skills/` (content layer, `_test` package) and `internal/cmd/` (cmd layer) were added/extended. No layer boundary violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)