### PR TITLE
feat(config): add Watch struct for watch command poll settings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,12 @@ type WaitForChecks struct {
 	Required []string `yaml:"required"` // check names to wait for
 }
 
+// Watch holds polling configuration for the godark watch command. When nil,
+// the watch command uses a hardcoded default interval of "60s".
+type Watch struct {
+	PollInterval string `yaml:"poll_interval"`
+}
+
 // Module holds per-module build/test/lint/generate commands and dependency
 // relationships. All fields are optional.
 type Module struct {
@@ -127,6 +133,10 @@ type Config struct {
 	// WaitForChecks configures CI check gating before merge. Nil means merge
 	// immediately after the review cycle (current behavior).
 	WaitForChecks *WaitForChecks `yaml:"wait_for_checks"`
+
+	// Watch configures polling settings for the godark watch command. Nil
+	// means the watch command uses its hardcoded default interval ("60s").
+	Watch *Watch `yaml:"watch"`
 }
 
 // Docker holds Docker sandbox configuration.
@@ -243,6 +253,9 @@ func validate(cfg *Config) error {
 	if err := validateWaitForChecks(cfg.WaitForChecks); err != nil {
 		return err
 	}
+	if err := validateWatch(cfg.Watch); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -260,6 +273,19 @@ func validateWaitForChecks(w *WaitForChecks) error {
 	}
 	if len(w.Required) == 0 {
 		return fmt.Errorf("wait_for_checks.required must be non-empty when wait_for_checks is set")
+	}
+	return nil
+}
+
+// validateWatch ensures Watch fields are valid when set.
+func validateWatch(w *Watch) error {
+	if w == nil {
+		return nil
+	}
+	if w.PollInterval != "" {
+		if _, err := time.ParseDuration(w.PollInterval); err != nil {
+			return fmt.Errorf("watch.poll_interval %q is not a valid duration: %w", w.PollInterval, err)
+		}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1207,6 +1207,75 @@ wait_for_checks:
 	}
 }
 
+// --- Watch tests ---
+
+func TestWatchDefaultNil(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Watch != nil {
+		t.Errorf("Watch = %v, want nil", cfg.Watch)
+	}
+}
+
+func TestWatchValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+watch:
+  poll_interval: "30s"
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Watch == nil {
+		t.Fatal("Watch = nil, want non-nil")
+	}
+	if cfg.Watch.PollInterval != "30s" {
+		t.Errorf("Watch.PollInterval = %q, want %q", cfg.Watch.PollInterval, "30s")
+	}
+}
+
+func TestWatchInvalidPollInterval(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+watch:
+  poll_interval: "not-a-duration"
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for invalid poll_interval, got nil")
+	}
+	if !strings.Contains(err.Error(), "watch.poll_interval") {
+		t.Errorf("error = %q, want mention of 'watch.poll_interval'", err.Error())
+	}
+}
+
+func TestWatchNotConfigured(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Watch != nil {
+		t.Errorf("Watch = %v, want nil (not configured)", cfg.Watch)
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.


### PR DESCRIPTION
Closes #239

## Implementation Notes

### Approach
Added a `Watch` struct with a `PollInterval string` field to `internal/config/config.go`, following the exact pattern used by the existing `WaitForChecks` pointer field. The `Watch *Watch` field on `Config` is nil by default (not configured), meaning the watch command will use its own hardcoded default of "60s". A `validateWatch` helper validates the poll_interval field as a `time.Duration` when it is non-empty, mirroring how `validateWaitForChecks` validates its timeout.

### Key Decisions
- Used a pointer (`*Watch`) so nil unambiguously means "not configured", consistent with `WaitForChecks *WaitForChecks`.
- Validation only rejects non-empty, non-parseable values — an empty `poll_interval` is valid (watch command falls back to its default).
- No default value is set in `defaults()` since nil is the correct default per the issue spec.

### Known Limitations
- The watch command itself is handled in a follow-on issue; this PR is config-only.

### Architecture
Only the `foundation` layer (`internal/config/`) was touched. This layer has zero dependencies on other internal packages, so no layer rules were at risk of violation.