### PR TITLE
feat(preflight): fail fast if working tree is dirty

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -85,6 +85,11 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			return nil
 		}
 
+		// Preflight: fail fast if working tree is dirty.
+		if err := checkWorkingTreeFn(); err != nil {
+			return err
+		}
+
 		if cfg.NoSandbox {
 			fmt.Fprintln(os.Stderr, "WARNING: running without sandbox — agent execution is not containerized")
 		}
@@ -351,6 +356,10 @@ func parseIssueNumbers(s string) ([]int, error) {
 // fetchPRCommentBodiesFn fetches PR comment bodies for dialogue extraction.
 // Replaceable for testing.
 var fetchPRCommentBodiesFn = github.FetchPRCommentBodies
+
+// checkWorkingTreeFn checks whether the working tree has uncommitted changes.
+// Replaceable for testing.
+var checkWorkingTreeFn = orchestrator.CheckWorkingTree
 
 func init() {
 	f := implementCmd.Flags()

--- a/internal/cmd/implement_test.go
+++ b/internal/cmd/implement_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/phs/dark-factory/internal/github"
@@ -71,6 +72,48 @@ func TestImplementCmd_IssuesFlagRegistered(t *testing.T) {
 	}
 	if f.DefValue != "" {
 		t.Errorf("issues default = %q, want %q", f.DefValue, "")
+	}
+}
+
+func TestCheckWorkingTreeFnDefault(t *testing.T) {
+	// checkWorkingTreeFn must default to a non-nil function.
+	if checkWorkingTreeFn == nil {
+		t.Fatal("checkWorkingTreeFn is nil, want orchestrator.CheckWorkingTree")
+	}
+}
+
+func TestCheckWorkingTreeFnReplaceable(t *testing.T) {
+	orig := checkWorkingTreeFn
+	t.Cleanup(func() { checkWorkingTreeFn = orig })
+
+	called := false
+	checkWorkingTreeFn = func() error {
+		called = true
+		return nil
+	}
+
+	if err := checkWorkingTreeFn(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("replaced checkWorkingTreeFn was not called")
+	}
+}
+
+func TestCheckWorkingTreeFnBlocksOnDirty(t *testing.T) {
+	orig := checkWorkingTreeFn
+	t.Cleanup(func() { checkWorkingTreeFn = orig })
+
+	checkWorkingTreeFn = func() error {
+		return fmt.Errorf("working tree is dirty — commit or stash your changes before running:\n M dirty.go")
+	}
+
+	err := checkWorkingTreeFn()
+	if err == nil {
+		t.Fatal("expected error when working tree is dirty")
+	}
+	if err.Error() == "" {
+		t.Error("expected non-empty error message")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -31,6 +31,13 @@ import (
 // crashed instances). punchlistPath is the optional file path to write the
 // punchlist to (always printed to stdout as well).
 func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone string, issue int, dryRun bool, force bool, punchlistPath string) error {
+	// Preflight: fail fast if working tree is dirty (skip in dry-run mode).
+	if !dryRun {
+		if err := CheckWorkingTree(); err != nil {
+			return err
+		}
+	}
+
 	// Auto-detect project type when no runtime/commands are explicitly configured.
 	detect.ApplyToConfig(cfg, ".", logger)
 
@@ -512,6 +519,20 @@ var newRunDataWriterFn = func(repo, milestone string, issueNumbers []int) (*rund
 // Replaceable for testing.
 var CommandRunner = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
+}
+
+// CheckWorkingTree returns an error if the git working tree has uncommitted
+// changes. The error message includes the list of dirty files from
+// `git status --porcelain`.
+func CheckWorkingTree() error {
+	out, err := CommandRunner("git", "status", "--porcelain")
+	if err != nil {
+		return fmt.Errorf("checking working tree: %w", err)
+	}
+	if dirty := strings.TrimSpace(string(out)); dirty != "" {
+		return fmt.Errorf("working tree is dirty — commit or stash your changes before running:\n%s", dirty)
+	}
+	return nil
 }
 
 // PullAfterMerge syncs the local repo with the remote after a successful merge.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -208,6 +208,13 @@ func TestAllBlocked(t *testing.T) {
 	}
 	setupFakeGH(t, openIssues, nil)
 
+	// Stub CommandRunner so CheckWorkingTree sees a clean working tree.
+	origCmd := CommandRunner
+	t.Cleanup(func() { CommandRunner = origCmd })
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(""), nil
+	}
+
 	// Run creates a RunDataWriter when dryRun=false; disable it for this test.
 	origWriter := newRunDataWriterFn
 	t.Cleanup(func() { newRunDataWriterFn = origWriter })
@@ -756,6 +763,146 @@ func TestPunchlistEnrichmentStatus_SuccessEmptySlice(t *testing.T) {
 	if status != "success" {
 		t.Errorf("expected %q for empty non-nil slice, got %q", "success", status)
 	}
+}
+
+func TestCheckWorkingTree_DirtyReturnsError(t *testing.T) {
+	orig := CommandRunner
+	t.Cleanup(func() { CommandRunner = orig })
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(" M docs/README.md\n?? scratch.txt\n"), nil
+	}
+
+	err := CheckWorkingTree()
+	if err == nil {
+		t.Fatal("expected error for dirty working tree")
+	}
+	if !strings.Contains(err.Error(), "working tree is dirty") {
+		t.Errorf("error should mention 'working tree is dirty', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "docs/README.md") {
+		t.Errorf("error should list dirty files, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "scratch.txt") {
+		t.Errorf("error should list all dirty files, got: %v", err)
+	}
+}
+
+func TestCheckWorkingTree_CleanReturnsNil(t *testing.T) {
+	orig := CommandRunner
+	t.Cleanup(func() { CommandRunner = orig })
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	if err := CheckWorkingTree(); err != nil {
+		t.Errorf("expected nil error for clean tree, got: %v", err)
+	}
+}
+
+func TestCheckWorkingTree_StagedFilesBlocked(t *testing.T) {
+	orig := CommandRunner
+	t.Cleanup(func() { CommandRunner = orig })
+	// git status --porcelain shows staged files with 'A' or 'M' in the first column.
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte("A  staged-new-file.go\nM  modified-staged.go\n"), nil
+	}
+
+	err := CheckWorkingTree()
+	if err == nil {
+		t.Fatal("expected error for staged (uncommitted) changes")
+	}
+	if !strings.Contains(err.Error(), "working tree is dirty") {
+		t.Errorf("expected 'working tree is dirty', got: %v", err)
+	}
+}
+
+func TestCheckWorkingTree_CommandError(t *testing.T) {
+	orig := CommandRunner
+	t.Cleanup(func() { CommandRunner = orig })
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("git not found")
+	}
+
+	err := CheckWorkingTree()
+	if err == nil {
+		t.Fatal("expected error when git command fails")
+	}
+	if !strings.Contains(err.Error(), "checking working tree") {
+		t.Errorf("expected 'checking working tree' in error, got: %v", err)
+	}
+}
+
+func TestRun_DirtyTreeBlocksRun(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "test", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	orig := CommandRunner
+	t.Cleanup(func() { CommandRunner = orig })
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(" M docs/README.md\n"), nil
+	}
+
+	captureStdout(t, func() {
+		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, false, false, "")
+		if err == nil {
+			t.Fatal("expected error for dirty working tree")
+		}
+		if !strings.Contains(err.Error(), "working tree is dirty") {
+			t.Errorf("expected 'working tree is dirty', got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "docs/README.md") {
+			t.Errorf("expected dirty file name in error, got: %v", err)
+		}
+	})
+}
+
+func TestRun_DirtyTreeErrorListsFiles(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "test", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	orig := CommandRunner
+	t.Cleanup(func() { CommandRunner = orig })
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(" M file-a.go\n?? file-b.txt\n"), nil
+	}
+
+	captureStdout(t, func() {
+		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, false, false, "")
+		if err == nil {
+			t.Fatal("expected error for dirty working tree")
+		}
+		if !strings.Contains(err.Error(), "file-a.go") {
+			t.Errorf("expected 'file-a.go' in error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "file-b.txt") {
+			t.Errorf("expected 'file-b.txt' in error, got: %v", err)
+		}
+	})
+}
+
+func TestRun_DryRunSkipsDirtyCheck(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "test", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	// CommandRunner would return dirty if called, but dry-run must skip the check.
+	orig := CommandRunner
+	t.Cleanup(func() { CommandRunner = orig })
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(" M dirty.txt\n"), nil
+	}
+
+	captureStdout(t, func() {
+		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, true, false, "")
+		if err != nil {
+			t.Fatalf("dry-run should not fail on dirty tree: %v", err)
+		}
+	})
 }
 
 // Suppress unused import warnings.


### PR DESCRIPTION
Closes #252

## Summary
- Adds `CheckWorkingTree()` to `internal/orchestrator/orchestrator.go` that runs `git status --porcelain` and returns a descriptive error listing dirty files
- Calls it at the start of `Run()` (skipped when `--dry-run`) before any issue fetching or agent work
- Mirrors the same check in `implement.go` via a `checkWorkingTreeFn` testability seam, also skipped when `--dry-run`

## Implementation Notes

### Approach
The preflight check uses the existing `CommandRunner` testability seam in the `orchestrator` package, which is already used by `PullAfterMerge`. This means `CheckWorkingTree` is fully testable without spawning real git processes: tests stub `CommandRunner` the same way they already did for `PullAfterMerge`.

In `implement.go`, a `checkWorkingTreeFn` package-level variable (defaulting to `orchestrator.CheckWorkingTree`) follows the project's established testability-seam pattern (`fetchPRCommentBodiesFn`), keeping the check replaceable in unit tests.

### Key Decisions
- **Placement in `Run()`**: The check is the very first thing in `Run()`, before `detect.ApplyToConfig` and before any GitHub API calls. This provides the fastest possible failure with no side effects.
- **Placement in `implement.go`**: Added immediately after the `dryRun` early-return block and before any setup (RunDataWriter, sandbox, etc.), keeping it symmetrical with `Run()`.
- **Existing `TestAllBlocked` fix**: That test called `Run()` with `dryRun=false` without mocking `CommandRunner`, so it now also stubs `CommandRunner` to return a clean tree — consistent with what `setupProcessMocks` already does.

### Known Limitations
None. The existing `PullAfterMerge` dirty-tree handling is unchanged (defense in depth per the issue spec).

### Architecture
Only two layers were touched:
- **orchestration** (`internal/orchestrator/`): `CheckWorkingTree()` added here — this layer already owns `CommandRunner` and `PullAfterMerge`, so it is the natural home for working-tree inspection.
- **cmd** (`internal/cmd/`): `implement.go` calls `orchestrator.CheckWorkingTree` via a function variable. The `cmd` layer is permitted to depend on the `orchestration` layer per the architecture graph.

No new inter-layer dependencies were introduced.