### PR TITLE
feat(config): add Watch struct for watch command poll settings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,8 +290,12 @@ func validateWatch(w *Watch) error {
 		return nil
 	}
 	if w.PollInterval != "" {
-		if _, err := time.ParseDuration(w.PollInterval); err != nil {
+		d, err := time.ParseDuration(w.PollInterval)
+		if err != nil {
 			return fmt.Errorf("watch.poll_interval %q is not a valid duration: %w", w.PollInterval, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("watch.poll_interval must be a positive duration, got %q", w.PollInterval)
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1277,6 +1277,40 @@ watch:
 	}
 }
 
+func TestWatchZeroPollInterval(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+watch:
+  poll_interval: "0s"
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for zero poll_interval, got nil")
+	}
+	if !strings.Contains(err.Error(), "watch.poll_interval") {
+		t.Errorf("error = %q, want mention of 'watch.poll_interval'", err.Error())
+	}
+}
+
+func TestWatchNegativePollInterval(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+watch:
+  poll_interval: "-30s"
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for negative poll_interval, got nil")
+	}
+	if !strings.Contains(err.Error(), "watch.poll_interval") {
+		t.Errorf("error = %q, want mention of 'watch.poll_interval'", err.Error())
+	}
+}
+
 func TestWatchNotConfigured(t *testing.T) {
 	dir := t.TempDir()
 	path := writeYAML(t, dir, `


### PR DESCRIPTION
Closes #239

## Implementation Notes

### Approach
Added a `Watch` struct to `internal/config/config.go` with a `PollInterval string` field (yaml tag `poll_interval`), and a `Watch *Watch` field (yaml tag `watch`) on `Config`. Validation was added via a `validateWatch` helper called from `validate()`. The pointer type means `nil` is the valid default state, consistent with `WaitForChecks`.

### Key Decisions
- `Watch` is a pointer (`*Watch`) so nil unambiguously means "not configured" — the watch command can then use its hardcoded default `"60s"` without any extra logic.
- Validation only rejects non-empty `poll_interval` strings that don't parse as a `time.Duration`; an empty string is allowed (field omitted in YAML).
- No entry in `defaults()` — nil is the right default and requires no initialization.

### Known Limitations
- The watch command itself is handled in a follow-on issue. This PR is config-only.

### Architecture
Only the `foundation` layer (`internal/config/`) was touched. No new imports or cross-layer dependencies were introduced.