### PR TITLE
feat(config): add RiskThresholds struct for low_risk auto-merge

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,14 @@ type Watch struct {
 	PollInterval string `yaml:"poll_interval"`
 }
 
+// RiskThresholds holds the thresholds used by the low_risk auto-merge
+// classifier. Nil means the classifier uses its built-in defaults
+// (MaxLines: 200, MaxFiles: 10).
+type RiskThresholds struct {
+	MaxLines int `yaml:"max_lines"`
+	MaxFiles int `yaml:"max_files"`
+}
+
 // Config holds all configuration for a godark run.
 type Config struct {
 	Repo       string `yaml:"repo"`
@@ -137,6 +145,10 @@ type Config struct {
 	// Watch configures polling settings for the watch command. Nil means
 	// the watch command uses its hardcoded default poll interval ("60s").
 	Watch *Watch `yaml:"watch"`
+
+	// RiskThresholds configures thresholds for the low_risk auto-merge
+	// classifier. Nil means the classifier uses its built-in defaults.
+	RiskThresholds *RiskThresholds `yaml:"risk_thresholds"`
 }
 
 // Docker holds Docker sandbox configuration.
@@ -263,6 +275,9 @@ func validate(cfg *Config) error {
 	if err := validateWatch(cfg.Watch); err != nil {
 		return err
 	}
+	if err := validateRiskThresholds(cfg.RiskThresholds); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -297,6 +312,20 @@ func validateWatch(w *Watch) error {
 		if d <= 0 {
 			return fmt.Errorf("watch.poll_interval must be a positive duration, got %q", w.PollInterval)
 		}
+	}
+	return nil
+}
+
+// validateRiskThresholds ensures RiskThresholds fields are positive when set.
+func validateRiskThresholds(r *RiskThresholds) error {
+	if r == nil {
+		return nil
+	}
+	if r.MaxLines <= 0 {
+		return fmt.Errorf("risk_thresholds.max_lines must be a positive integer, got %d", r.MaxLines)
+	}
+	if r.MaxFiles <= 0 {
+		return fmt.Errorf("risk_thresholds.max_files must be a positive integer, got %d", r.MaxFiles)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1327,6 +1327,99 @@ build_command: "go build ./..."
 	}
 }
 
+// --- RiskThresholds tests ---
+
+func TestRiskThresholdsDefaultNil(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RiskThresholds != nil {
+		t.Errorf("RiskThresholds = %v, want nil", cfg.RiskThresholds)
+	}
+}
+
+func TestRiskThresholdsValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+risk_thresholds:
+  max_lines: 100
+  max_files: 5
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RiskThresholds == nil {
+		t.Fatal("RiskThresholds = nil, want non-nil")
+	}
+	if cfg.RiskThresholds.MaxLines != 100 {
+		t.Errorf("RiskThresholds.MaxLines = %d, want 100", cfg.RiskThresholds.MaxLines)
+	}
+	if cfg.RiskThresholds.MaxFiles != 5 {
+		t.Errorf("RiskThresholds.MaxFiles = %d, want 5", cfg.RiskThresholds.MaxFiles)
+	}
+}
+
+func TestRiskThresholdsZeroLines(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+risk_thresholds:
+  max_lines: 0
+  max_files: 5
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for max_lines: 0, got nil")
+	}
+	if !strings.Contains(err.Error(), "risk_thresholds.max_lines") {
+		t.Errorf("error = %q, want mention of 'risk_thresholds.max_lines'", err.Error())
+	}
+}
+
+func TestRiskThresholdsNegativeFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+risk_thresholds:
+  max_lines: 100
+  max_files: -1
+`)
+
+	_, err := Load(path, CLIFlags{})
+	if err == nil {
+		t.Fatal("expected error for max_files: -1, got nil")
+	}
+	if !strings.Contains(err.Error(), "risk_thresholds.max_files") {
+		t.Errorf("error = %q, want mention of 'risk_thresholds.max_files'", err.Error())
+	}
+}
+
+func TestRiskThresholdsNotConfigured(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+build_command: "go build ./..."
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RiskThresholds != nil {
+		t.Errorf("RiskThresholds = %v, want nil (not configured)", cfg.RiskThresholds)
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.


### PR DESCRIPTION
## Summary
- Adds `RiskThresholds` struct with `MaxLines` and `MaxFiles` int fields (yaml: `max_lines`, `max_files`)
- Adds `RiskThresholds *RiskThresholds` pointer field to `Config` (yaml: `risk_thresholds`); nil by default
- Adds `validateRiskThresholds` helper that rejects zero or negative values; passes nil through unchanged
- Adds 5 test cases covering all acceptance criteria

Closes #240

## Implementation Notes

### Approach
Config-only change in the `foundation` layer. The `RiskThresholds` pointer field is nil when absent from YAML, matching the issue requirement that the classifier (a follow-on issue) applies its own defaults of `MaxLines: 200 / MaxFiles: 10`. No changes to `defaults()` — the field starts nil.

### Key Decisions
- Used a pointer (`*RiskThresholds`) so YAML absence yields `nil` rather than a zero-value struct, consistent with `WaitForChecks` and `Watch` fields in the same file.
- Validation rejects `<= 0` for both fields (covers zero and negative), matching the issue spec.
- No defaults applied at config load time — the issue explicitly states defaults are applied by the classifier, not the config layer.

### Known Limitations
None — this is config-only per the issue scope. Risk classifier logic is deferred to the follow-on issue.

### Architecture
Only the `foundation` layer (`internal/config/`) is touched. No new imports. No cross-layer dependencies introduced.