### PR TITLE
docs(arch): add internal/label/ to foundation layer in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ content.
 
 ### foundation
 
-**Paths:** `internal/config/`, `internal/logging/`
+**Paths:** `internal/config/`, `internal/logging/`, `internal/label/`
 
 **Purpose:** Zero-dependency utilities that any layer may import. Configuration
 loading and structured logging.


### PR DESCRIPTION
## Summary

- `docs/architecture.json` already includes `internal/label/` in the foundation layer (added in PR #259)
- `docs/architecture.md` was out of sync — this PR updates it to match the JSON
- `godark vet architecture` passes with "All checks passed"

## Implementation Notes

### Approach
The machine-readable `docs/architecture.json` was already updated with `internal/label/` in the foundation layer as part of PR #259 (feat(label)). This PR syncs the human-readable `docs/architecture.md` to match, ensuring both files reflect the same layer definitions.

### Key Decisions
- Only `docs/architecture.md` needed updating; `docs/architecture.json` was already correct
- The `godark vet architecture` command reads from `architecture.json` (machine-readable), which was already correct — vet passes

### Known Limitations
- None. The architecture.json change was already merged; this PR closes the tracking issue with the corresponding docs sync.

### Architecture
- **Foundation layer** — `internal/label/` is a zero-dependency utility package providing PR lifecycle label constants and state machine logic; it belongs in foundation alongside `internal/config/` and `internal/logging/`
- No layer dependency rules were changed; only documentation was updated

Closes #242