### PR TITLE
feat(label): migrate LockLabel to internal/label/ as InProgress

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/phs/dark-factory/internal/harness/templates"
+	"github.com/phs/dark-factory/internal/label"
 	"github.com/phs/dark-factory/internal/lock"
 	"github.com/phs/dark-factory/internal/skills"
 	"github.com/spf13/cobra"
@@ -168,6 +169,6 @@ func createLockLabel(cmd *cobra.Command) error {
 		fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not create lock label: %v\n", err)
 		return nil
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "ensured label %q in %s\n", lock.LockLabel, repo)
+	fmt.Fprintf(cmd.OutOrStdout(), "ensured label %q in %s\n", label.InProgress, repo)
 	return nil
 }

--- a/internal/label/label.go
+++ b/internal/label/label.go
@@ -1,5 +1,8 @@
 package label
 
+// InProgress is the GitHub label applied to issues during an active godark run.
+const InProgress = "godark-in-progress"
+
 // PR lifecycle label constants communicate state to humans at a glance.
 const (
 	AwaitingHumanReview  = "godark:awaiting-human-review"

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,7 +1,7 @@
 // Package lock provides a distributed run lock using GitHub labels as the
 // visible signal and a local JSON file for stale-lock detection metadata.
 //
-// When a godark run starts, it applies the LockLabel to all issues it will
+// When a godark run starts, it applies the lock label to all issues it will
 // process. Other instances see the label and refuse to start. When the run
 // finishes (or is interrupted), the label is removed.
 //
@@ -18,12 +18,10 @@ import (
 	"time"
 
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/label"
 )
 
 const (
-	// LockLabel is the GitHub label applied to issues during an active godark run.
-	LockLabel = "godark-in-progress"
-
 	// LockLabelColor is the hex color (without #) for the coordination label.
 	LockLabelColor = "FF6B35"
 
@@ -57,7 +55,7 @@ type Locker struct {
 func New(repo string, logger *slog.Logger) *Locker {
 	return &Locker{
 		repo:         repo,
-		label:        LockLabel,
+		label:        label.InProgress,
 		lockFilePath: defaultLockFilePath,
 		logger:       logger,
 	}
@@ -164,7 +162,7 @@ func (l *Locker) IsLocked() (bool, *RunInfo, error) {
 // EnsureLabelExists creates the lock label in the repo if it doesn't exist.
 // Intended to be called by `godark init` to pre-create the label.
 func EnsureLabelExists(repo string) error {
-	return github.EnsureLabel(repo, LockLabel, LockLabelColor, LockLabelDescription)
+	return github.EnsureLabel(repo, label.InProgress, LockLabelColor, LockLabelDescription)
 }
 
 func (l *Locker) releaseFromIssues(issueNumbers []int) error {

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/label"
 )
 
 // newTestLocker creates a Locker with a temp-dir lock file path for isolation.
@@ -17,7 +18,7 @@ func newTestLocker(t *testing.T) *Locker {
 	t.Helper()
 	return &Locker{
 		repo:         "owner/repo",
-		label:        LockLabel,
+		label:        label.InProgress,
 		lockFilePath: filepath.Join(t.TempDir(), "lock.json"),
 		logger:       slog.Default(),
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/phs/dark-factory/internal/detect"
 	"github.com/phs/dark-factory/internal/dialogue"
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/label"
 	"github.com/phs/dark-factory/internal/lock"
 	"github.com/phs/dark-factory/internal/logging"
 	"github.com/phs/dark-factory/internal/punchlist"
@@ -306,7 +307,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 		} else {
 			// Subsequent waves: we already hold the lock, just label new issues.
 			for _, n := range batchNums {
-				if err := github.AddIssueLabel(cfg.Repo, n, lock.LockLabel); err != nil {
+				if err := github.AddIssueLabel(cfg.Repo, n, label.InProgress); err != nil {
 					logger.Warn("failed to apply lock label to newly unblocked issue", "issue", n, "error", err)
 				}
 			}


### PR DESCRIPTION
Closes #243

## Summary

- Adds `label.InProgress = "godark-in-progress"` to `internal/label/label.go`
- Removes `LockLabel` constant from `internal/lock/lock.go`
- Updates `internal/lock/` to import and use `label.InProgress`
- Updates `internal/cmd/init.go` to use `label.InProgress`
- Updates `internal/orchestrator/orchestrator.go` to use `label.InProgress`

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `label.InProgress` constant has value `"godark-in-progress"`
- [x] `lock.LockLabel` removed; `internal/lock/` uses `label.InProgress`
- [x] `internal/cmd/init.go` uses `label.InProgress`
- [x] No behavioral changes — pure refactor

## Implementation Notes

### Approach
Moved the `godark-in-progress` label string from a local constant in `internal/lock/` into the `internal/label/` foundation package as `label.InProgress`. Updated all call sites to reference the new location.

### Key Decisions
- Kept `LockLabelColor` and `LockLabelDescription` in `internal/lock/lock.go` since they are lock-specific metadata, not label identity constants.
- The `EnsureLabelExists` function in `internal/lock/` stays there because it combines label identity with lock-specific color/description — only the string constant migrated.

### Known Limitations
None. This is a pure refactor with no behavioral changes.

### Architecture
- `internal/label/` — **foundation** layer: added `InProgress` constant (no new deps)
- `internal/lock/` — **infrastructure** layer: now imports foundation (`internal/label/`), which is permitted
- `internal/cmd/` — **cmd** layer: imports both `internal/label/` and `internal/lock/`, both allowed
- `internal/orchestrator/` — **orchestration** layer: imports `internal/label/` (foundation), allowed

All dependency rules from `docs/architecture.md` are respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)