### PR TITLE
feat(quality): add risk classifier for auto-merge gate evaluation

### DIFF
--- a/internal/quality/risk.go
+++ b/internal/quality/risk.go
@@ -97,19 +97,19 @@ func evalProtectedPathsGate(changedFiles, protectedPaths []string) RiskGate {
 func evalFixCyclesGate(fixCycles int) RiskGate {
 	passed := fixCycles == 0
 	detail := fmt.Sprintf("%d fix cycle(s) used", fixCycles)
-	return RiskGate{Name: "fix_cycles", Passed: passed, Detail: detail}
+	return RiskGate{Name: "no_fix_cycles", Passed: passed, Detail: detail}
 }
 
 func evalQualityFlagsGate(flags []Flag) RiskGate {
 	if len(flags) == 0 {
-		return RiskGate{Name: "quality_flags", Passed: true, Detail: "no quality flags raised"}
+		return RiskGate{Name: "no_quality_flags", Passed: true, Detail: "no quality flags raised"}
 	}
 	codes := make([]string, len(flags))
 	for i, f := range flags {
 		codes[i] = f.Code
 	}
 	return RiskGate{
-		Name:   "quality_flags",
+		Name:   "no_quality_flags",
 		Passed: false,
 		Detail: fmt.Sprintf("%d quality flag(s) raised: %s", len(flags), strings.Join(codes, ", ")),
 	}

--- a/internal/quality/risk_test.go
+++ b/internal/quality/risk_test.go
@@ -77,7 +77,7 @@ func TestClassifyRisk_FixCyclesUsed(t *testing.T) {
 	if got.IsLowRisk {
 		t.Error("expected IsLowRisk: false, got true")
 	}
-	assertGateFailed(t, got.Gates, "fix_cycles")
+	assertGateFailed(t, got.Gates, "no_fix_cycles")
 }
 
 func TestClassifyRisk_QualityFlagsRaised(t *testing.T) {
@@ -91,7 +91,7 @@ func TestClassifyRisk_QualityFlagsRaised(t *testing.T) {
 	if got.IsLowRisk {
 		t.Error("expected IsLowRisk: false, got true")
 	}
-	assertGateFailed(t, got.Gates, "quality_flags")
+	assertGateFailed(t, got.Gates, "no_quality_flags")
 }
 
 func TestClassifyRisk_MultipleGatesFail(t *testing.T) {
@@ -133,7 +133,7 @@ func TestClassifyRisk_AllGatesPresent(t *testing.T) {
 	input := RiskInput{}
 	got := ClassifyRisk(input, 200, 10)
 
-	wantGates := []string{"max_lines", "max_files", "protected_paths", "fix_cycles", "quality_flags"}
+	wantGates := []string{"max_lines", "max_files", "protected_paths", "no_fix_cycles", "no_quality_flags"}
 	if len(got.Gates) != len(wantGates) {
 		t.Fatalf("expected %d gates, got %d", len(wantGates), len(got.Gates))
 	}


### PR DESCRIPTION
Closes #245

## Summary
- Adds `internal/quality/risk.go` with `RiskInput`, `RiskAssessment`, `RiskGate` types and `ClassifyRisk` function
- Implements five independent risk gates: max_lines, max_files, protected_paths, fix_cycles, quality_flags
- Adds `internal/quality/risk_test.go` covering all test cases specified in the issue

## Test plan
- [x] All pass: small PR, no protected paths, no fix cycles, no flags → `IsLowRisk: true`
- [x] Lines exceeded: 201 lines → `IsLowRisk: false`, `max_lines` gate failed
- [x] Files exceeded: 11 files → `IsLowRisk: false`, `max_files` gate failed
- [x] Protected path touched: file matches protected path prefix → `IsLowRisk: false`
- [x] Fix cycles used: `FixCycles: 1` → `IsLowRisk: false`
- [x] Quality flags raised: one flag → `IsLowRisk: false`
- [x] Multiple gates fail: lines and files both exceeded → both gates reported as failed
- [x] Default thresholds: passing 0/0 applies 200/10 defaults

## Implementation Notes

### Approach
Describe what approach you took and why.

`ClassifyRisk` evaluates all five gates unconditionally and collects them into the `Gates` slice, then derives `IsLowRisk` from whether all gates passed. This ensures the full gate state is always recorded for human audit, even when multiple gates fail.

### Key Decisions
- All five gates are always evaluated (not short-circuited), so the full assessment is captured even when `IsLowRisk` is already false after the first failed gate.
- Protected path matching uses `strings.HasPrefix` consistently with the existing pattern in the codebase.
- Default thresholds (200 lines, 10 files) are applied when the caller passes 0 for either parameter, matching the issue specification of "used when config is nil".
- The `Flag` type reused from `quality.go` — no new types introduced for `QualityFlags`.

### Known Limitations
- `RiskAssessment` is not yet wired into run data (deferred to a later issue per the spec).

### Architecture
- Touches only `internal/quality/` which is in the **domain** layer.
- No new dependencies introduced — the file only uses `fmt` and `strings` from the standard library.
- The `Flag` type referenced in `RiskInput.QualityFlags` already exists in the same package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)