### PR TITLE
feat(agent): wire auto_merge low_risk into merge decision

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -177,6 +177,10 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	// functional reviewer's quality check: tests are only expected when a spec exists.
 	hasSpec := specGenerated || HasScenarioSpec(cfg.ScenarioDir, issue.Number)
 
+	// fixCycles counts the total number of verify-fix attempts used across all
+	// modules. Used by the risk classifier to assess PR safety.
+	fixCycles := 0
+
 	// Step 3.5: Verify. Runs between guard rails and quality review.
 	if cfg.Modules != nil {
 		// Per-module verification in dependency order.
@@ -223,6 +227,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 						outcome.Err = ctx.Err()
 						return outcome
 					}
+					fixCycles++
 
 					verifyErrors := fmt.Sprintf("Module: %s\n\n%s", modName, formatVerifyErrors(verifyResult))
 					logger.Info("running verify-fix attempt",
@@ -316,6 +321,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 					outcome.Err = ctx.Err()
 					return outcome
 				}
+				fixCycles++
 
 				verifyErrors := formatVerifyErrors(verifyResult)
 				logger.Info("running verify-fix attempt",
@@ -533,12 +539,60 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				return outcome
 			}
 			if cfg.AutoMerge == "low_risk" {
-				// Risk classifier not yet wired; label for human review in the interim.
-				logger.Info("PR approved, skipping merge (auto_merge=low_risk, risk classifier pending)", "pr_number", prNum)
-				applyLifecycleLabel(label.AwaitingHumanReview)
-				outcome.Status = "ready-to-merge"
-				outcome.Retries = attempt
-				return outcome
+				additions, deletions, fileCount, statsErr := github.FetchPRStats(cfg.Repo, prNum)
+				if statsErr != nil {
+					logger.Warn("failed to fetch PR stats for risk classification, labeling for human review",
+						"pr_number", prNum, "error", statsErr)
+					applyLifecycleLabel(label.AwaitingHumanReview)
+					outcome.Status = "ready-to-merge"
+					outcome.Retries = attempt
+					return outcome
+				}
+				changedFiles, filesErr := github.FetchPRChangedFiles(cfg.Repo, prNum)
+				if filesErr != nil {
+					logger.Warn("failed to fetch PR changed files for risk classification, labeling for human review",
+						"pr_number", prNum, "error", filesErr)
+					applyLifecycleLabel(label.AwaitingHumanReview)
+					outcome.Status = "ready-to-merge"
+					outcome.Retries = attempt
+					return outcome
+				}
+
+				var maxLines, maxFiles int
+				if cfg.RiskThresholds != nil {
+					maxLines = cfg.RiskThresholds.MaxLines
+					maxFiles = cfg.RiskThresholds.MaxFiles
+				}
+				riskInput := quality.RiskInput{
+					LinesChanged:   additions + deletions,
+					FilesChanged:   fileCount,
+					ChangedFiles:   changedFiles,
+					ProtectedPaths: cfg.ProtectedPaths,
+					FixCycles:      fixCycles,
+					QualityFlags:   fFlags,
+				}
+				assessment := quality.ClassifyRisk(riskInput, maxLines, maxFiles)
+
+				if hook != nil {
+					if err := hook.WriteRiskAssessment(issue.Number, toRundataRiskAssessment(assessment)); err != nil {
+						logger.Warn("failed to write risk assessment", "error", err)
+					}
+				}
+
+				logger.Info("risk classification result",
+					"issue_number", issue.Number,
+					"pr_number", prNum,
+					"is_low_risk", assessment.IsLowRisk,
+				)
+
+				if !assessment.IsLowRisk {
+					logger.Info("PR is not low-risk, labeling for human review", "pr_number", prNum)
+					applyLifecycleLabel(label.AwaitingHumanReview)
+					outcome.Status = "ready-to-merge"
+					outcome.Retries = attempt
+					return outcome
+				}
+				// PR is low-risk — fall through to merge.
 			}
 			// Step 5.5: Wait for CI checks if configured.
 			if cfg.WaitForChecks != nil {

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -898,6 +898,7 @@ type testRunDataHook struct {
 	verifyResults              []rundata.VerifyStepResult
 	outcomes                   []rundata.Outcome
 	issueStatuses              []rundata.IssueStatus
+	riskAssessments            []rundata.RiskAssessment
 }
 
 func (h *testRunDataHook) WriteSpecGeneratorResult(_ int, _ rundata.StepResult) error {
@@ -934,6 +935,10 @@ func (h *testRunDataHook) WriteOutcome(o rundata.Outcome) error {
 }
 func (h *testRunDataHook) WriteIssueStatus(_ int, s rundata.IssueStatus) error {
 	h.issueStatuses = append(h.issueStatuses, s)
+	return nil
+}
+func (h *testRunDataHook) WriteRiskAssessment(_ int, a rundata.RiskAssessment) error {
+	h.riskAssessments = append(h.riskAssessments, a)
 	return nil
 }
 
@@ -3106,8 +3111,28 @@ func TestProcessIssue_NoneModeLabelsAwaitingReview(t *testing.T) {
 	}
 }
 
-func TestProcessIssue_LowRiskModeLabelsAwaitingReview(t *testing.T) {
-	added, _ := setupGHLabelTracker(t)
+func TestProcessIssue_LowRiskMode_HighRiskLabelsAwaitingReview(t *testing.T) {
+	// High-risk PR (400 lines changed > 200 default threshold) should be labeled
+	// awaiting-human-review and not auto-merged.
+	var addedLabels []string
+	orig := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = orig })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		for i, a := range args {
+			if a == "--add-label" && i+1 < len(args) {
+				addedLabels = append(addedLabels, args[i+1])
+			}
+		}
+		if strings.Contains(joined, "--json additions,deletions,changedFiles") {
+			// Return high-risk stats: 400 total lines changed (> 200 threshold).
+			return []byte(`{"additions":300,"deletions":100,"changedFiles":5}`), nil
+		}
+		if strings.Contains(joined, "pr diff") && strings.Contains(joined, "--name-only") {
+			return []byte("internal/agent/loop.go\n"), nil
+		}
+		return []byte(""), nil
+	}
 
 	cfg := loopConfig()
 	cfg.AutoMerge = "low_risk"
@@ -3125,14 +3150,248 @@ func TestProcessIssue_LowRiskModeLabelsAwaitingReview(t *testing.T) {
 	}
 
 	found := false
-	for _, l := range *added {
+	for _, l := range addedLabels {
 		if l == label.AwaitingHumanReview {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected %q label to be added, got: %v", label.AwaitingHumanReview, *added)
+		t.Errorf("expected %q label to be added for high-risk PR, got: %v", label.AwaitingHumanReview, addedLabels)
+	}
+}
+
+func TestProcessIssue_LowRiskMode_LowRiskMerges(t *testing.T) {
+	// Small PR (10 lines changed, 2 files, no protected paths, no quality flags) is
+	// low-risk and should be auto-merged. The reviewer includes a "Read" trace entry
+	// so the no_diff_read quality gate is satisfied, resulting in no quality flags.
+	var mergeCallCount int
+	orig := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = orig })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "--json additions,deletions,changedFiles") {
+			return []byte(`{"additions":8,"deletions":2,"changedFiles":2}`), nil
+		}
+		if strings.Contains(joined, "pr diff") && strings.Contains(joined, "--name-only") {
+			return []byte("internal/agent/loop.go\ninternal/agent/loop_test.go\n"), nil
+		}
+		return []byte(""), nil
+	}
+
+	cfg := loopConfig()
+	cfg.AutoMerge = "low_risk"
+	cfg.ProtectedPaths = []string{"CLAUDE.md"}
+
+	// Stub Runner directly so we can include a tool trace with a "Read" entry
+	// for the functional reviewer, preventing the no_diff_read quality flag.
+	callIdx := 0
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	reviewerOut := wrapRunnerJSONWithTrace("reviewer output\nREVIEW_RESULT=APPROVED\n", []string{"Read pr diff"})
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2: // quality reviewer
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // functional reviewer
+			return []byte(reviewerOut), []byte(""), 0, nil
+		}
+	}
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr merge") {
+			mergeCallCount++
+		}
+		return []byte(""), nil
+	}
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if mergeCallCount != 1 {
+		t.Errorf("gh pr merge called %d time(s), want 1 for low-risk PR", mergeCallCount)
+	}
+}
+
+func TestProcessIssue_LowRiskMode_ProtectedPathLabels(t *testing.T) {
+	// PR touching a protected path should be labeled awaiting-human-review even
+	// if total line/file counts are within risk thresholds.
+	var addedLabels []string
+	orig := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = orig })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		for i, a := range args {
+			if a == "--add-label" && i+1 < len(args) {
+				addedLabels = append(addedLabels, args[i+1])
+			}
+		}
+		if strings.Contains(joined, "--json additions,deletions,changedFiles") {
+			return []byte(`{"additions":5,"deletions":2,"changedFiles":2}`), nil
+		}
+		if strings.Contains(joined, "pr diff") && strings.Contains(joined, "--name-only") {
+			// One of the changed files is a protected path.
+			return []byte("CLAUDE.md\ninternal/agent/loop.go\n"), nil
+		}
+		return []byte(""), nil
+	}
+
+	cfg := loopConfig()
+	cfg.AutoMerge = "low_risk"
+	cfg.ProtectedPaths = []string{"CLAUDE.md"}
+
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+	}, standardLoopGuard())
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "ready-to-merge" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "ready-to-merge", outcome.Err)
+	}
+
+	found := false
+	for _, l := range addedLabels {
+		if l == label.AwaitingHumanReview {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected %q label for protected-path PR, got: %v", label.AwaitingHumanReview, addedLabels)
+	}
+}
+
+func TestProcessIssue_LowRiskMode_RiskAssessmentWritten(t *testing.T) {
+	// Risk assessment should be written to run data via the hook.
+	// Uses a reviewer output with a "Read" trace entry so no_diff_read is not raised,
+	// ensuring the PR qualifies as low-risk and the assessment records IsLowRisk=true.
+	hook := &testRunDataHook{}
+	orig := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = orig })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "--json additions,deletions,changedFiles") {
+			return []byte(`{"additions":8,"deletions":2,"changedFiles":2}`), nil
+		}
+		if strings.Contains(joined, "pr diff") && strings.Contains(joined, "--name-only") {
+			return []byte("internal/agent/loop.go\n"), nil
+		}
+		return []byte(""), nil
+	}
+
+	cfg := loopConfig()
+	cfg.AutoMerge = "low_risk"
+	cfg.ProtectedPaths = []string{"CLAUDE.md"}
+
+	// Stub Runner with a reviewer output that includes a "Read" trace entry.
+	callIdx := 0
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	reviewerOut := wrapRunnerJSONWithTrace("reviewer output\nREVIEW_RESULT=APPROVED\n", []string{"Read pr diff"})
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1:
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2:
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default:
+			return []byte(reviewerOut), []byte(""), 0, nil
+		}
+	}
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	}
+
+	ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
+
+	if len(hook.riskAssessments) == 0 {
+		t.Fatal("expected risk assessment to be written to hook, but none recorded")
+	}
+	assessment := hook.riskAssessments[0]
+	if !assessment.IsLowRisk {
+		t.Errorf("expected IsLowRisk=true for small PR with no protected paths, got false (gates: %v)", assessment.Gates)
+	}
+}
+
+func TestProcessIssue_AllMode_IgnoresRisk(t *testing.T) {
+	// auto_merge: all should merge regardless of PR size — risk classifier not called.
+	var mergeCallCount int
+	cfg := loopConfig()
+	cfg.AutoMerge = "all"
+
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr merge") {
+			mergeCallCount++
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if mergeCallCount != 1 {
+		t.Errorf("gh pr merge called %d time(s), want 1 when auto_merge=all", mergeCallCount)
 	}
 }
 

--- a/internal/agent/rundata.go
+++ b/internal/agent/rundata.go
@@ -1,6 +1,9 @@
 package agent
 
-import "github.com/phs/dark-factory/internal/rundata"
+import (
+	"github.com/phs/dark-factory/internal/quality"
+	"github.com/phs/dark-factory/internal/rundata"
+)
 
 // ResultToStep converts an agent.Result to a rundata.StepResult, computing
 // DurationSeconds from the timing fields captured during execution.
@@ -22,6 +25,24 @@ func ResultToStep(r *Result) rundata.StepResult {
 		step.DurationSeconds = r.FinishedAt.Sub(r.StartedAt).Seconds()
 	}
 	return step
+}
+
+// toRundataRiskAssessment converts a quality.RiskAssessment to its rundata counterpart
+// for persistence. The quality and rundata packages are both in the domain layer and
+// cannot import each other, so conversion happens here in the orchestration layer.
+func toRundataRiskAssessment(a quality.RiskAssessment) rundata.RiskAssessment {
+	gates := make([]rundata.RiskGate, len(a.Gates))
+	for i, g := range a.Gates {
+		gates[i] = rundata.RiskGate{
+			Name:   g.Name,
+			Passed: g.Passed,
+			Detail: g.Detail,
+		}
+	}
+	return rundata.RiskAssessment{
+		IsLowRisk: a.IsLowRisk,
+		Gates:     gates,
+	}
 }
 
 // verifyToRundata converts a VerifyResult to a rundata.VerifyStepResult.

--- a/internal/agent/runhook.go
+++ b/internal/agent/runhook.go
@@ -15,4 +15,5 @@ type RunDataHook interface {
 	WriteVerifyResult(issueNumber int, step rundata.VerifyStepResult) error
 	WriteOutcome(outcome rundata.Outcome) error
 	WriteIssueStatus(issueNumber int, status rundata.IssueStatus) error
+	WriteRiskAssessment(issueNumber int, assessment rundata.RiskAssessment) error
 }

--- a/internal/github/pr_stats.go
+++ b/internal/github/pr_stats.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// FetchPRStats fetches the total additions, deletions, and changed file count
+// for the given pull request. Uses `gh pr view --json additions,deletions,changedFiles`.
+func FetchPRStats(repo string, prNum int) (additions, deletions, fileCount int, err error) {
+	out, err := CommandRunner("gh", "pr", "view",
+		fmt.Sprintf("%d", prNum),
+		"--repo", repo,
+		"--json", "additions,deletions,changedFiles",
+	)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("gh pr view: %w", err)
+	}
+
+	var pr struct {
+		Additions    int `json:"additions"`
+		Deletions    int `json:"deletions"`
+		ChangedFiles int `json:"changedFiles"`
+	}
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return 0, 0, 0, fmt.Errorf("parsing gh output: %w", err)
+	}
+
+	return pr.Additions, pr.Deletions, pr.ChangedFiles, nil
+}
+
+// FetchPRChangedFiles returns the list of file paths modified by the given pull request.
+// Uses `gh pr diff --name-only`.
+func FetchPRChangedFiles(repo string, prNum int) ([]string, error) {
+	out, err := CommandRunner("gh", "pr", "diff",
+		fmt.Sprintf("%d", prNum),
+		"--repo", repo,
+		"--name-only",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("gh pr diff: %w", err)
+	}
+
+	var files []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}

--- a/internal/github/pr_stats_test.go
+++ b/internal/github/pr_stats_test.go
@@ -1,0 +1,128 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFetchPRStats_Success(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(`{"additions":50,"deletions":20,"changedFiles":3}`), nil
+	}
+
+	additions, deletions, fileCount, err := FetchPRStats("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if additions != 50 {
+		t.Errorf("additions = %d, want 50", additions)
+	}
+	if deletions != 20 {
+		t.Errorf("deletions = %d, want 20", deletions)
+	}
+	if fileCount != 3 {
+		t.Errorf("fileCount = %d, want 3", fileCount)
+	}
+}
+
+func TestFetchPRStats_CLIError(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 1")
+	}
+
+	_, _, _, err := FetchPRStats("owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestFetchPRStats_MalformedJSON(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(`not valid json`), nil
+	}
+
+	_, _, _, err := FetchPRStats("owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestFetchPRChangedFiles_Success(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte("internal/foo/bar.go\ninternal/baz/qux.go\n"), nil
+	}
+
+	files, err := FetchPRChangedFiles("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d: %v", len(files), files)
+	}
+	if files[0] != "internal/foo/bar.go" {
+		t.Errorf("files[0] = %q, want %q", files[0], "internal/foo/bar.go")
+	}
+	if files[1] != "internal/baz/qux.go" {
+		t.Errorf("files[1] = %q, want %q", files[1], "internal/baz/qux.go")
+	}
+}
+
+func TestFetchPRChangedFiles_EmptyOutput(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	files, err := FetchPRChangedFiles("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected 0 files, got %d: %v", len(files), files)
+	}
+}
+
+func TestFetchPRChangedFiles_CLIError(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 1")
+	}
+
+	_, err := FetchPRChangedFiles("owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestFetchPRChangedFiles_StripsBlankLines(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte("file1.go\n\nfile2.go\n"), nil
+	}
+
+	files, err := FetchPRChangedFiles("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files (blank lines stripped), got %d: %v", len(files), files)
+	}
+}

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -245,6 +245,26 @@ func (w *Writer) WriteVerifyResult(issueNum int, step VerifyStepResult) error {
 	return writeJSONMkdirs(path, step)
 }
 
+// RiskGate records the outcome of a single risk gate evaluation.
+type RiskGate struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail"`
+}
+
+// RiskAssessment holds the result of the risk classifier for a PR.
+type RiskAssessment struct {
+	IsLowRisk bool       `json:"is_low_risk"`
+	Gates     []RiskGate `json:"gates"`
+}
+
+// WriteRiskAssessment writes the risk assessment for the given issue.
+// Path: issues/<issueNum>/risk-assessment.json
+func (w *Writer) WriteRiskAssessment(issueNum int, assessment RiskAssessment) error {
+	path := filepath.Join(w.dir, "issues", fmt.Sprintf("%d", issueNum), "risk-assessment.json")
+	return writeJSONMkdirs(path, assessment)
+}
+
 // PunchlistData holds the per-issue punchlist content persisted to punchlist.json.
 type PunchlistData struct {
 	VerificationSteps []string `json:"verification_steps,omitempty"`

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -779,3 +779,39 @@ func TestPathTraversalRejected(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteRiskAssessmentCreatesFile(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	assessment := RiskAssessment{
+		IsLowRisk: true,
+		Gates: []RiskGate{
+			{Name: "max_lines", Passed: true, Detail: "10 lines changed (max 200)"},
+			{Name: "protected_paths", Passed: true, Detail: "no protected paths touched"},
+		},
+	}
+	if err := w.WriteRiskAssessment(42, assessment); err != nil {
+		t.Fatalf("WriteRiskAssessment() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "risk-assessment.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file at %s, got: %v", path, err)
+	}
+
+	var written RiskAssessment
+	if err := json.Unmarshal(data, &written); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+	if written.IsLowRisk != true {
+		t.Errorf("IsLowRisk = %v, want true", written.IsLowRisk)
+	}
+	if len(written.Gates) != 2 {
+		t.Errorf("Gates length = %d, want 2", len(written.Gates))
+	}
+}


### PR DESCRIPTION
Closes #247

## Implementation Notes

### Approach

Replaced the `low_risk` stub in `ProcessIssue` with the actual risk classification flow:

1. After functional review approves a PR with `auto_merge: low_risk`, fetch PR statistics from GitHub: additions, deletions, file count (`FetchPRStats`) and changed file paths (`FetchPRChangedFiles`)
2. Build a `quality.RiskInput` using the PR stats, `fixCycles` (newly tracked), `cfg.ProtectedPaths`, and `fFlags` from the functional reviewer's quality check
3. Call `quality.ClassifyRisk` with thresholds from `cfg.RiskThresholds` (zeros → classifier uses built-in defaults: 200 lines, 10 files)
4. If low-risk → fall through to merge; if not → label `awaiting-human-review` and return `ready-to-merge`
5. Write the risk assessment to run data via the `WriteRiskAssessment` hook

Error fallback: if either GitHub fetch fails, label for human review (conservative, same outcome as high-risk).

### Key Decisions

- **`RiskAssessment`/`RiskGate` types duplicated in `rundata`** rather than importing from `quality`. Both are in the domain layer; domain packages cannot cross-import per architecture rules. This mirrors the existing `quality.Flag` → `rundata.Flag` pattern.
- **`toRundataRiskAssessment` placed in `agent/rundata.go`** alongside `ResultToStep` and `verifyToRundata` — all orchestration-layer conversions from domain types to rundata types live there.
- **`fixCycles` counter** tracks total verify-fix attempts across all modules. Incremented at the start of each fix loop iteration (after the `ctx.Err()` check to avoid counting cancelled runs).
- **Sequential fetches** for `FetchPRStats` and `FetchPRChangedFiles`: consistent with the rest of the agent loop which is uniformly sequential. The added latency (~200ms) is negligible for this use case.
- **`FetchPRStats` uses `gh pr view --json additions,deletions,changedFiles`** for counts; **`FetchPRChangedFiles` uses `gh pr diff --name-only`** for actual file paths. Both are needed: counts for the `max_lines`/`max_files` gates, paths for the `protected_paths` gate.

### Known Limitations

- `auto_merge: all` is unchanged — it merges unconditionally without fetching PR stats, consistent with the issue spec.
- The `fixCycles` counter counts per-module fix cycles additively. If verify runs for 3 modules and each has 2 fix cycles, `fixCycles = 6`. This is intentionally conservative.
- CI check fix cycles (the `WaitForChecks` path) are not counted as fix cycles since they run after the risk assessment point.

### Architecture

Layers touched, all complying with the dependency rules:
- **infrastructure** (`internal/github/pr_stats.go`): new `FetchPRStats` and `FetchPRChangedFiles` using the existing `CommandRunner` seam
- **domain** (`internal/rundata/writer.go`): new `RiskAssessment`/`RiskGate` types and `WriteRiskAssessment` persisting to `issues/<n>/risk-assessment.json`
- **orchestration** (`internal/agent/`): loop.go wires classification; rundata.go provides `toRundataRiskAssessment` conversion; runhook.go adds `WriteRiskAssessment` to the interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)