### PR TITLE
fix(dialogue): preserve execution order in dialogue entries

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -12,7 +12,6 @@ import (
 	"github.com/phs/dark-factory/internal/agent"
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/detect"
-	"github.com/phs/dark-factory/internal/dialogue"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/lock"
 	"github.com/phs/dark-factory/internal/logging"
@@ -188,8 +187,7 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 					logger.Warn("failed to fetch PR comment bodies for dialogue",
 						"issue_number", issueNumber, "error", fetchErr)
 				} else {
-					implNotes, reviewNotes, qualityNotes := dialogue.ParseComments(bodies)
-					dialogueEntries := orchestrator.BuildDialogueEntries(implNotes, reviewNotes, qualityNotes)
+					dialogueEntries := orchestrator.BuildDialogueEntries(bodies)
 					if len(dialogueEntries) > 0 {
 						if err := writer.WriteDialogue(issueNumber, dialogueEntries); err != nil {
 							logger.Warn("failed to write dialogue",

--- a/internal/dialogue/dialogue.go
+++ b/internal/dialogue/dialogue.go
@@ -98,6 +98,42 @@ func ParseComments(bodies []string) ([]ImplementationNotes, []ReviewNotes, []Qua
 	return implNotes, reviewNotes, qualityNotes
 }
 
+// Entry is a single turn in the agent dialogue, preserving execution order.
+type Entry struct {
+	Role  string // "implementer", "quality_reviewer", or "reviewer"
+	Round int    // 1-indexed round within this role
+	Body  string // raw comment text
+}
+
+// ParseCommentsInOrder scans comment bodies in their original order (which
+// matches GitHub's chronological ordering) and returns one Entry per
+// recognised structured comment. The Round field reflects how many times
+// that particular role has appeared so far, so two implementer comments
+// get rounds 1 and 2 regardless of what comes between them.
+func ParseCommentsInOrder(bodies []string) []Entry {
+	roundCounters := map[string]int{}
+	var entries []Entry
+	for _, body := range bodies {
+		var role string
+		if ParseImplementationNotes(body) != nil {
+			role = "implementer"
+		} else if ParseQualityReviewNotes(body) != nil {
+			role = "quality_reviewer"
+		} else if ParseReviewNotes(body) != nil {
+			role = "reviewer"
+		} else {
+			continue
+		}
+		roundCounters[role]++
+		entries = append(entries, Entry{
+			Role:  role,
+			Round: roundCounters[role],
+			Body:  body,
+		})
+	}
+	return entries
+}
+
 // parseSections scans body for the given top-level header and returns a map of
 // subsection header → trimmed content. Returns nil if the top-level header is
 // not found.

--- a/internal/dialogue/dialogue_test.go
+++ b/internal/dialogue/dialogue_test.go
@@ -242,3 +242,147 @@ func TestParseComments_NoMatchingComments(t *testing.T) {
 		t.Errorf("len(reviewNotes) = %d, want 0", len(reviewNotes))
 	}
 }
+
+// ParseCommentsInOrder tests
+
+const qualityComment = `## Quality Review Notes
+
+### Issues Found
+- Missing error handling.
+
+### Changes Requested
+Yes
+`
+
+func implComment(approach string) string {
+	return "## Implementation Notes\n\n### Approach\n" + approach + "\n\n### Key Decisions\nDecision.\n\n### Known Limitations\nNone.\n\n### Architecture\nDomain.\n"
+}
+
+func reviewComment(approved string) string {
+	return "## Review Notes\n\n### Approved\n" + approved + "\n\n### Changes Requested\n\n### Architecture Compliance\nGood.\n"
+}
+
+func checkEntry(t *testing.T, got Entry, wantRole string, wantRound int, wantBody string) {
+	t.Helper()
+	if got.Role != wantRole {
+		t.Errorf("Role = %q, want %q", got.Role, wantRole)
+	}
+	if got.Round != wantRound {
+		t.Errorf("Round = %d, want %d", got.Round, wantRound)
+	}
+	if got.Body != wantBody {
+		t.Errorf("Body = %q, want %q", got.Body, wantBody)
+	}
+}
+
+func TestParseCommentsInOrder_Empty(t *testing.T) {
+	entries := ParseCommentsInOrder([]string{})
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestParseCommentsInOrder_NoRetries(t *testing.T) {
+	// Impl, Quality (pass), Functional (pass) → 3 entries in order
+	impl := implComment("First implementation.")
+	quality := qualityComment
+	review := reviewComment("Approved.")
+	entries := ParseCommentsInOrder([]string{impl, quality, review})
+
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+	checkEntry(t, entries[0], "implementer", 1, impl)
+	checkEntry(t, entries[1], "quality_reviewer", 1, quality)
+	checkEntry(t, entries[2], "reviewer", 1, review)
+}
+
+func TestParseCommentsInOrder_QualityRetry(t *testing.T) {
+	// Impl, Quality (fail), Impl (fix), Quality (pass), Functional (pass)
+	impl1 := implComment("First implementation.")
+	impl2 := implComment("Fixed implementation.")
+	quality1 := qualityComment
+	quality2 := qualityComment
+	review1 := reviewComment("Approved.")
+
+	entries := ParseCommentsInOrder([]string{impl1, quality1, impl2, quality2, review1})
+
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+	checkEntry(t, entries[0], "implementer", 1, impl1)
+	checkEntry(t, entries[1], "quality_reviewer", 1, quality1)
+	checkEntry(t, entries[2], "implementer", 2, impl2)
+	checkEntry(t, entries[3], "quality_reviewer", 2, quality2)
+	checkEntry(t, entries[4], "reviewer", 1, review1)
+}
+
+func TestParseCommentsInOrder_MultipleRetries(t *testing.T) {
+	// Impl, Quality (fail), Impl, Quality (fail), Impl, Quality (pass), Functional (pass)
+	impl1 := implComment("First.")
+	impl2 := implComment("Second.")
+	impl3 := implComment("Third.")
+	quality1 := qualityComment
+	quality2 := qualityComment
+	quality3 := qualityComment
+	review1 := reviewComment("Approved.")
+
+	entries := ParseCommentsInOrder([]string{impl1, quality1, impl2, quality2, impl3, quality3, review1})
+
+	if len(entries) != 7 {
+		t.Fatalf("expected 7 entries, got %d", len(entries))
+	}
+	checkEntry(t, entries[0], "implementer", 1, impl1)
+	checkEntry(t, entries[1], "quality_reviewer", 1, quality1)
+	checkEntry(t, entries[2], "implementer", 2, impl2)
+	checkEntry(t, entries[3], "quality_reviewer", 2, quality2)
+	checkEntry(t, entries[4], "implementer", 3, impl3)
+	checkEntry(t, entries[5], "quality_reviewer", 3, quality3)
+	checkEntry(t, entries[6], "reviewer", 1, review1)
+}
+
+func TestParseCommentsInOrder_MissingQualityReview(t *testing.T) {
+	// No quality reviewer configured → Impl, Functional only
+	impl := implComment("Only implementation.")
+	review := reviewComment("Approved.")
+	entries := ParseCommentsInOrder([]string{impl, review})
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	checkEntry(t, entries[0], "implementer", 1, impl)
+	checkEntry(t, entries[1], "reviewer", 1, review)
+}
+
+func TestParseCommentsInOrder_RoundNumbers(t *testing.T) {
+	// Two implementer entries → rounds 1 and 2; single functional → round 1
+	impl1 := implComment("Round one.")
+	impl2 := implComment("Round two.")
+	quality := qualityComment
+	review := reviewComment("Approved.")
+
+	entries := ParseCommentsInOrder([]string{impl1, quality, impl2, review})
+
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+	if entries[0].Round != 1 {
+		t.Errorf("entries[0].Round = %d, want 1", entries[0].Round)
+	}
+	if entries[2].Round != 2 {
+		t.Errorf("entries[2].Round = %d, want 2", entries[2].Round)
+	}
+	if entries[3].Round != 1 {
+		t.Errorf("entries[3].Round = %d, want 1", entries[3].Round)
+	}
+}
+
+func TestParseCommentsInOrder_NonStructuredCommentsIgnored(t *testing.T) {
+	impl := implComment("Implementation.")
+	entries := ParseCommentsInOrder([]string{"Just a comment.", impl, "Another comment."})
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	checkEntry(t, entries[0], "implementer", 1, impl)
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -339,8 +339,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 					logger.Warn("failed to fetch PR comment bodies for dialogue",
 						"issue_number", issue.Number, "error", fetchErr)
 				} else {
-					implNotes, reviewNotes, qualityNotes := dialogue.ParseComments(bodies)
-					entries := BuildDialogueEntries(implNotes, reviewNotes, qualityNotes)
+					entries := BuildDialogueEntries(bodies)
 					if len(entries) > 0 {
 						if err := writer.WriteDialogue(issue.Number, entries); err != nil {
 							logger.Warn("failed to write dialogue",
@@ -487,41 +486,18 @@ var processIssueFn = agent.ProcessIssue
 // Replaceable for testing.
 var fetchPRCommentBodiesFn = github.FetchPRCommentBodies
 
-// BuildDialogueEntries interleaves implementation, quality review, and
-// functional review notes by round, returning a slice of DialogueEntry
-// values suitable for persisting.
-func BuildDialogueEntries(implNotes []dialogue.ImplementationNotes, reviewNotes []dialogue.ReviewNotes, qualityNotes []dialogue.QualityReviewNotes) []rundata.DialogueEntry {
-	maxRounds := len(implNotes)
-	if len(reviewNotes) > maxRounds {
-		maxRounds = len(reviewNotes)
-	}
-	if len(qualityNotes) > maxRounds {
-		maxRounds = len(qualityNotes)
-	}
-
-	var entries []rundata.DialogueEntry
-	for round := 1; round <= maxRounds; round++ {
-		i := round - 1
-		if i < len(implNotes) {
-			entries = append(entries, rundata.DialogueEntry{
-				Role:  "implementer",
-				Round: round,
-				Body:  implNotes[i].Raw,
-			})
-		}
-		if i < len(qualityNotes) {
-			entries = append(entries, rundata.DialogueEntry{
-				Role:  "quality_reviewer",
-				Round: round,
-				Body:  qualityNotes[i].Raw,
-			})
-		}
-		if i < len(reviewNotes) {
-			entries = append(entries, rundata.DialogueEntry{
-				Role:  "reviewer",
-				Round: round,
-				Body:  reviewNotes[i].Raw,
-			})
+// BuildDialogueEntries parses PR comment bodies in their original chronological
+// order and returns a slice of DialogueEntry values suitable for persisting.
+// Round numbers within each role are sequential (implementer round 1, 2, …)
+// regardless of interleaving with other roles.
+func BuildDialogueEntries(bodies []string) []rundata.DialogueEntry {
+	parsed := dialogue.ParseCommentsInOrder(bodies)
+	entries := make([]rundata.DialogueEntry, len(parsed))
+	for i, e := range parsed {
+		entries[i] = rundata.DialogueEntry{
+			Role:  e.Role,
+			Round: e.Round,
+			Body:  e.Body,
 		}
 	}
 	return entries

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/phs/dark-factory/internal/agent"
 	"github.com/phs/dark-factory/internal/config"
-	"github.com/phs/dark-factory/internal/dialogue"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/logging"
 	"github.com/phs/dark-factory/internal/rundata"
@@ -611,37 +610,29 @@ func TestProcessIssues_FinalizeRunCalled(t *testing.T) {
 	}
 }
 
-func TestBuildDialogueEntries_SingleRound(t *testing.T) {
-	implNotes := []dialogue.ImplementationNotes{
-		{Raw: "impl body 1"},
-	}
-	reviewNotes := []dialogue.ReviewNotes{
-		{Raw: "review body 1"},
-	}
+const testImplBody1 = "## Implementation Notes\n\n### Approach\nFirst implementation.\n\n### Key Decisions\nDecision A.\n\n### Known Limitations\nNone.\n\n### Architecture\nDomain layer.\n"
+const testImplBody2 = "## Implementation Notes\n\n### Approach\nFixed implementation.\n\n### Key Decisions\nDecision B.\n\n### Known Limitations\nNone.\n\n### Architecture\nDomain layer.\n"
+const testQualityBody = "## Quality Review Notes\n\n### Issues Found\nNeeds fixes.\n\n### Changes Requested\nYes.\n"
+const testReviewBody = "## Review Notes\n\n### Approved\nLooks good.\n\n### Changes Requested\n\n### Architecture Compliance\nCompliant.\n"
 
-	entries := BuildDialogueEntries(implNotes, reviewNotes, nil)
+func TestBuildDialogueEntries_SingleRound(t *testing.T) {
+	bodies := []string{testImplBody1, testReviewBody}
+	entries := BuildDialogueEntries(bodies)
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 entries, got %d", len(entries))
 	}
-	if entries[0].Role != "implementer" || entries[0].Round != 1 || entries[0].Body != "impl body 1" {
+	if entries[0].Role != "implementer" || entries[0].Round != 1 || entries[0].Body != testImplBody1 {
 		t.Errorf("entries[0]: got {%s, %d, %q}", entries[0].Role, entries[0].Round, entries[0].Body)
 	}
-	if entries[1].Role != "reviewer" || entries[1].Round != 1 || entries[1].Body != "review body 1" {
+	if entries[1].Role != "reviewer" || entries[1].Round != 1 || entries[1].Body != testReviewBody {
 		t.Errorf("entries[1]: got {%s, %d, %q}", entries[1].Role, entries[1].Round, entries[1].Body)
 	}
 }
 
 func TestBuildDialogueEntries_MultipleRounds(t *testing.T) {
-	implNotes := []dialogue.ImplementationNotes{
-		{Raw: "impl 1"},
-		{Raw: "impl 2"},
-	}
-	reviewNotes := []dialogue.ReviewNotes{
-		{Raw: "review 1"},
-		{Raw: "review 2"},
-	}
-
-	entries := BuildDialogueEntries(implNotes, reviewNotes, nil)
+	// Quality retry: impl1 → quality(fail) → impl2 → review(pass)
+	bodies := []string{testImplBody1, testQualityBody, testImplBody2, testReviewBody}
+	entries := BuildDialogueEntries(bodies)
 	if len(entries) != 4 {
 		t.Fatalf("expected 4 entries, got %d", len(entries))
 	}
@@ -650,10 +641,10 @@ func TestBuildDialogueEntries_MultipleRounds(t *testing.T) {
 		round int
 		body  string
 	}{
-		{"implementer", 1, "impl 1"},
-		{"reviewer", 1, "review 1"},
-		{"implementer", 2, "impl 2"},
-		{"reviewer", 2, "review 2"},
+		{"implementer", 1, testImplBody1},
+		{"quality_reviewer", 1, testQualityBody},
+		{"implementer", 2, testImplBody2},
+		{"reviewer", 1, testReviewBody},
 	}
 	for i, w := range want {
 		if entries[i].Role != w.role || entries[i].Round != w.round || entries[i].Body != w.body {
@@ -665,7 +656,7 @@ func TestBuildDialogueEntries_MultipleRounds(t *testing.T) {
 }
 
 func TestBuildDialogueEntries_Empty(t *testing.T) {
-	entries := BuildDialogueEntries(nil, nil, nil)
+	entries := BuildDialogueEntries(nil)
 	if len(entries) != 0 {
 		t.Errorf("expected 0 entries for empty input, got %d", len(entries))
 	}


### PR DESCRIPTION
## Summary

- Replace the round-zipping `BuildDialogueEntries` implementation with an in-order parser that preserves the original PR comment sequence
- Add `dialogue.Entry` and `ParseCommentsInOrder()` to the domain layer; `orchestrator.BuildDialogueEntries` now accepts `[]string` and delegates to it
- Remove the redundant `dialogue.ParseComments` intermediary from both call sites

## Implementation Notes

### Approach
Used **Option A** from the issue: preserve the original comment order from `FetchPRCommentBodies` and parse each comment's type inline.

`dialogue.ParseCommentsInOrder` iterates comments in chronological order (as returned by GitHub), identifies the role for each structured comment, and increments a per-role round counter. This gives correct round numbers (implementer round 1, 2, …) regardless of what other comment types appear between them.

The conversion from `dialogue.Entry` to `rundata.DialogueEntry` happens in `orchestrator.BuildDialogueEntries`, which sits at the orchestration layer and is allowed to depend on both domain packages.

### Key Decisions
- Defined `dialogue.Entry` in the domain layer rather than returning `rundata.DialogueEntry` directly, to respect the architecture constraint that domain packages may not depend on each other.
- Changed `BuildDialogueEntries` signature from `(implNotes, reviewNotes, qualityNotes)` typed slices to `(bodies []string)` raw comment strings. This eliminates the now-redundant intermediate `ParseComments` call at both call sites and makes the function's contract clearer.
- Kept `ParseComments` (returning three typed slices) unchanged — it is tested and may be useful elsewhere.

### Known Limitations
None. All acceptance criteria and test cases from the issue are covered.

### Architecture
- **`internal/dialogue/`** (domain layer): Added `Entry` struct and `ParseCommentsInOrder`. No new dependencies — still only depends on stdlib.
- **`internal/orchestrator/`** (orchestration layer): Updated `BuildDialogueEntries` to delegate to `dialogue.ParseCommentsInOrder` and convert to `rundata.DialogueEntry`. The orchestration layer is permitted to depend on both `dialogue` and `rundata`.
- **`internal/cmd/`** (cmd layer): Removed intermediate `dialogue.ParseComments` call and unused `dialogue` import. The cmd layer already depended on `orchestrator`.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)