### PR TITLE
fix(run): surface config errors in --tag resolution instead of masking them

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -57,7 +57,10 @@ each unblocked issue through the implement → review → merge loop.`,
 			repo := flags.Repo
 			if repo == nil {
 				cfgOnly, err := config.Load(configPath, config.CLIFlags{Config: configPath})
-				if err == nil && cfgOnly.Repo != "" {
+				if err != nil {
+					return fmt.Errorf("loading config to resolve --tag: %w", err)
+				}
+				if cfgOnly.Repo != "" {
 					r := cfgOnly.Repo
 					repo = &r
 				}

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -173,3 +173,30 @@ func TestNoSandboxWarning(t *testing.T) {
 		t.Errorf("stderr = %q, want warning containing 'without sandbox'", out.String())
 	}
 }
+
+// TestTagResolutionSurfacesConfigError verifies that config.Load returns a
+// real error when the config file is syntactically valid YAML but fails
+// validation (e.g. wait_for_checks as a flat list instead of the struct
+// format). This is the error that the tag resolution code in RunE now surfaces
+// via "loading config to resolve --tag: ..." instead of silently swallowing it
+// and emitting the misleading "--repo is required when using --tag" message.
+func TestTagResolutionSurfacesConfigError(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "godark.yaml")
+	// This config has repo set correctly but wait_for_checks in the old flat-list
+	// format, which fails config validation.
+	err := os.WriteFile(p, []byte("repo: owner/repo\nwait_for_checks:\n  - test\n  - lint\n"), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = config.Load(p, config.CLIFlags{})
+	if err == nil {
+		t.Fatal("expected config.Load to return an error for invalid wait_for_checks format, got nil")
+	}
+	// The error should not be a "repo is required" message — it should describe
+	// the actual config problem so users can fix their godark.yaml.
+	if strings.Contains(err.Error(), "repo is required") {
+		t.Errorf("config.Load error should describe the real problem, got: %v", err)
+	}
+}

--- a/internal/skills/godark-configure-project/SKILL.md
+++ b/internal/skills/godark-configure-project/SKILL.md
@@ -73,9 +73,9 @@ findings for user confirmation before writing.
    - Identify jobs that represent required checks (any job that runs tests,
      linting, building, or static analysis — e.g. jobs named `test`, `build`,
      `lint`, `ci`, `check`, `verify`, `validate`).
-   - Prepare a `wait_for_checks:` list with the GitHub Actions check names.
-     The check name for a job is typically the job key or its `name:` field
-     if set.
+   - Prepare a `wait_for_checks:` block with `timeout` (e.g. `"10m"`) and
+     `required` (list of check names). The check name for a job is typically
+     the job key or its `name:` field if set.
 
 6. **Detect Docker Compose usage** — Check for `docker-compose.yml`,
    `docker-compose.yaml`, `docker-compose*.yml`, or `compose.yml` files at
@@ -130,9 +130,11 @@ required_env:
   - SECRET_TOKEN
 
 wait_for_checks:
-  - test
-  - lint
-  - build
+  timeout: "10m"
+  required:
+    - test
+    - lint
+    - build
 
 runtime:
   no_sandbox: true  # required for integration tests run via Docker Compose


### PR DESCRIPTION
## Summary

- Surface real `config.Load` errors during `--tag` resolution instead of silently swallowing them and showing the misleading `--repo is required when using --tag` message.
- Update the `godark-configure-project` skill template to emit the correct `wait_for_checks` struct format (`timeout` + `required` list) instead of the old flat-list format that fails config validation.

## Implementation Notes

### Approach

**Fix 1 (`internal/cmd/run.go`):** The tag resolution fallback that reads the config to discover `repo` previously used `if err == nil && ...`, which discarded any `config.Load` failure. Changed to an explicit `if err != nil { return fmt.Errorf("loading config to resolve --tag: %w", err) }` guard so the real error (e.g. "wait_for_checks.timeout is not a valid duration") is shown to the user instead of the confusing `--repo is required` message.

**Fix 2 (`internal/skills/godark-configure-project/SKILL.md`):** The `## Format` YAML example and the step 5 prose both described `wait_for_checks` as a flat list. Updated both to the struct format the config parser actually expects (`timeout:` + `required:` list).

### Key Decisions

The fix follows the issue's proposed diff exactly — no additional refactoring. Error wrapping uses the project's standard `fmt.Errorf("context: %w", err)` pattern.

### Known Limitations

The RunE function is not easily unit-tested in isolation (it calls `github.ResolveMilestoneByTag`). The test instead directly verifies that `config.Load` returns a descriptive error for the old flat-list `wait_for_checks` format — documenting the class of error that was previously swallowed.

### Architecture

- `internal/cmd/` — `cmd` layer (top of dependency tree). No new imports.
- `internal/skills/` — `content` layer (static skill definitions). No runtime code.

Both are the correct layers for their respective changes. No cross-layer dependency rules are affected.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)