### PR TITLE
feat: surface failure reason in dashboard and outcome.json

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -36,14 +36,27 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	// Write outcome data on every return path.
 	defer func() {
 		if hook != nil {
-			if err := hook.WriteOutcome(rundata.Outcome{
+			o := rundata.Outcome{
 				IssueNumber: outcome.IssueNumber,
 				Title:       issue.Title,
 				Description: issue.Body,
 				Status:      outcome.Status,
 				PRNumber:    outcome.PRNumber,
-			}); err != nil {
+			}
+			if outcome.Err != nil {
+				o.Error = outcome.Err.Error()
+			}
+			if err := hook.WriteOutcome(o); err != nil {
 				logger.Warn("failed to write outcome", "error", err)
+			}
+			// Update status.json to reflect the final state so it doesn't
+			// stay stale at "implementing" or "in_review".
+			if outcome.Status != "" {
+				if err := hook.WriteIssueStatus(outcome.IssueNumber, rundata.IssueStatus{
+					Status: outcome.Status,
+				}); err != nil {
+					logger.Warn("failed to update final issue status", "error", err)
+				}
 			}
 		}
 	}()

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -1053,6 +1053,50 @@ func TestProcessIssue_HookCalledOnOutcome(t *testing.T) {
 	}
 }
 
+func TestProcessIssue_HookOutcomeIncludesError(t *testing.T) {
+	hook := &testRunDataHook{}
+	// Force a failure by making the implementer agent fail.
+	setupLoopTest(t, []string{}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		return []byte(""), nil
+	})
+
+	cfg := loopConfig()
+	// Use a prompt that will cause the agent to fail by timing out.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately to force failure
+
+	ProcessIssue(ctx, loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
+
+	if len(hook.outcomes) != 1 {
+		t.Fatalf("WriteOutcome called %d times, want 1", len(hook.outcomes))
+	}
+	if hook.outcomes[0].Status != "failed" {
+		t.Errorf("outcome status = %q, want %q", hook.outcomes[0].Status, "failed")
+	}
+	if hook.outcomes[0].Error == "" {
+		t.Error("outcome error is empty, want failure reason persisted")
+	}
+
+	// Verify status.json is updated to reflect the final state.
+	var foundFinalStatus bool
+	for _, s := range hook.issueStatuses {
+		if s.Status == "failed" {
+			foundFinalStatus = true
+			break
+		}
+	}
+	if !foundFinalStatus {
+		t.Error("status.json was not updated to 'failed'")
+	}
+}
+
 func TestProcessIssue_NilHookSafe(t *testing.T) {
 	setupLoopTest(t, []string{
 		"implementer output",

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -56,6 +56,7 @@ type IssueRowView struct {
 	Cost          string // formatted total cost, e.g. "$0.0042" or "—"
 	URL           string // link to issue detail page
 	AwaitingHuman bool   // true when outcome status is "ready-to-merge"
+	ErrorReason   string // failure reason from outcome, shown inline for failed issues
 }
 
 // IssueDetailData is the data passed to the issue-detail template.
@@ -66,10 +67,12 @@ type IssueDetailData struct {
 	IssueNumber     int
 	Title           string
 	Description     string
+	Status          string // outcome status, e.g. "failed", "implemented"
 	PRNumber        int
 	PRLink          string
 	IssueLink       string
 	RunURL          string // link back to run detail page
+	ErrorReason     string // failure reason from outcome, shown prominently for failed issues
 	Timeline        []TimelineStepView
 	Punchlist       *rundata.PunchlistData
 	Dialogue        []rundata.DialogueEntry
@@ -422,10 +425,12 @@ func (s *Server) handleIssueDetail(w http.ResponseWriter, r *http.Request) {
 		IssueNumber:     issueNum,
 		Title:           found.Outcome.Title,
 		Description:     found.Outcome.Description,
+		Status:          found.Outcome.Status,
 		PRNumber:        found.Outcome.PRNumber,
 		PRLink:          prLink,
 		IssueLink:       issueLink,
 		RunURL:          runURL,
+		ErrorReason:     found.Outcome.Error,
 		Timeline:        buildTimeline(*found),
 		Punchlist:       found.Punchlist,
 		Dialogue:        found.Dialogue,
@@ -472,6 +477,7 @@ func issueToRowView(issue rundata.IssueDetail, owner, repo, timestamp string) Is
 		Cost:          formatCost(totalCost),
 		URL:           issueURL,
 		AwaitingHuman: issue.Outcome.Status == "ready-to-merge",
+		ErrorReason:   issue.Outcome.Error,
 	}
 }
 

--- a/internal/dashboard/templates/issue-detail.html
+++ b/internal/dashboard/templates/issue-detail.html
@@ -163,6 +163,18 @@
         </div>
       </div>
 
+      {{if and (eq .Status "failed") .ErrorReason}}
+      <!-- Error Reason Banner -->
+      <div class="card animate-in animate-in-2" style="border-left: 3px solid var(--color-danger, #f87171); background: rgba(248,113,113,0.06);">
+        <div class="card__header">
+          <span class="card__title">Error</span>
+        </div>
+        <div class="card__body" style="padding: var(--space-4) var(--space-5);">
+          <code style="font-size: var(--text-sm); word-break: break-word;">{{.ErrorReason}}</code>
+        </div>
+      </div>
+      {{end}}
+
       {{if .FailureAnalysis}}
       <!-- Failure Analysis -->
       <div class="card animate-in animate-in-2">

--- a/internal/dashboard/templates/run-detail.html
+++ b/internal/dashboard/templates/run-detail.html
@@ -175,6 +175,9 @@
       <span class="badge__dot"></span>
       {{.Status}}
     </span>
+    {{if .ErrorReason}}
+    <div style="font-size: var(--text-xs); color: var(--text-muted); margin-top: 2px; max-width: 28ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="{{.ErrorReason}}">{{.ErrorReason}}</div>
+    {{end}}
   </td>
   <td>
     {{if .PRNumber}}

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -66,6 +66,7 @@ type Outcome struct {
 	Description string `json:"description,omitempty"`
 	Status      string `json:"status"`
 	PRNumber    int    `json:"pr_number"`
+	Error       string `json:"error,omitempty"`
 }
 
 // Writer manages a per-run directory and writes JSON files for each agent loop step.


### PR DESCRIPTION
## Summary
- Add `error` field to `rundata.Outcome` struct so failure reasons are persisted to `outcome.json`
- Update `status.json` to reflect final state on every return path (no more stale "in_review")
- Show error reason in dashboard: inline in run detail table rows and as a prominent banner on issue detail page

## What was broken
When an issue failed (e.g., merge blocked by branch protection), the only place to find the reason was `debug.log`. The dashboard showed "Failed" with no context, `outcome.json` had no error field, and `status.json` stayed stuck at "in_review".

## What changed
- **`internal/rundata/writer.go`**: Added `Error string` field to `Outcome` struct
- **`internal/agent/loop.go`**: Defer block now writes `outcome.Err` to the outcome and updates `status.json` with the final status
- **`internal/dashboard/handlers.go`**: Added `ErrorReason` to `IssueRowView` and `IssueDetailData`, wired from `Outcome.Error`
- **`internal/dashboard/templates/run-detail.html`**: Shows truncated error under the status badge for failed rows (with full text on hover)
- **`internal/dashboard/templates/issue-detail.html`**: Shows error banner above failure analysis for failed issues

Note: CLI output already surfaced `outcome.Err` — no changes needed there.

Closes #281

## Test plan
- [x] New `TestProcessIssue_HookOutcomeIncludesError` verifies error is persisted and status updated
- [x] All existing agent, dashboard, and rundata tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)