### PR TITLE
Fix missing dialogue entries for approved reviews

### DIFF
--- a/internal/github/prs.go
+++ b/internal/github/prs.go
@@ -5,18 +5,22 @@ import (
 	"fmt"
 )
 
-// FetchPRCommentBodies returns the body text of all comments on the given PR.
+// FetchPRCommentBodies returns the PR body followed by the body text of all
+// comments on the given PR. The PR body is included first because the
+// implementer agent may embed its Implementation Notes in the PR description
+// rather than posting a separate comment.
 func FetchPRCommentBodies(repo string, prNum int) ([]string, error) {
 	out, err := CommandRunner("gh", "pr", "view",
 		fmt.Sprintf("%d", prNum),
 		"--repo", repo,
-		"--json", "comments",
+		"--json", "body,comments",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("gh pr view: %w", err)
 	}
 
 	var pr struct {
+		Body     string `json:"body"`
 		Comments []struct {
 			Body string `json:"body"`
 		} `json:"comments"`
@@ -25,9 +29,13 @@ func FetchPRCommentBodies(repo string, prNum int) ([]string, error) {
 		return nil, fmt.Errorf("parsing gh output: %w", err)
 	}
 
-	bodies := make([]string, len(pr.Comments))
-	for i, c := range pr.Comments {
-		bodies[i] = c.Body
+	// PR body first (may contain Implementation Notes), then comments in order.
+	bodies := make([]string, 0, 1+len(pr.Comments))
+	if pr.Body != "" {
+		bodies = append(bodies, pr.Body)
+	}
+	for _, c := range pr.Comments {
+		bodies = append(bodies, c.Body)
 	}
 	return bodies, nil
 }

--- a/internal/github/prs_test.go
+++ b/internal/github/prs_test.go
@@ -10,21 +10,44 @@ func TestFetchPRCommentBodies_Success(t *testing.T) {
 	defer func() { CommandRunner = orig }()
 
 	CommandRunner = func(name string, args ...string) ([]byte, error) {
-		return []byte(`{"comments":[{"body":"First comment"},{"body":"Second comment"}]}`), nil
+		return []byte(`{"body":"PR description","comments":[{"body":"First comment"},{"body":"Second comment"}]}`), nil
 	}
 
 	bodies, err := FetchPRCommentBodies("owner/repo", 42)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(bodies) != 2 {
-		t.Fatalf("expected 2 bodies, got %d", len(bodies))
+	if len(bodies) != 3 {
+		t.Fatalf("expected 3 bodies, got %d", len(bodies))
 	}
-	if bodies[0] != "First comment" {
-		t.Errorf("bodies[0]: got %q, want %q", bodies[0], "First comment")
+	if bodies[0] != "PR description" {
+		t.Errorf("bodies[0]: got %q, want %q", bodies[0], "PR description")
 	}
-	if bodies[1] != "Second comment" {
-		t.Errorf("bodies[1]: got %q, want %q", bodies[1], "Second comment")
+	if bodies[1] != "First comment" {
+		t.Errorf("bodies[1]: got %q, want %q", bodies[1], "First comment")
+	}
+	if bodies[2] != "Second comment" {
+		t.Errorf("bodies[2]: got %q, want %q", bodies[2], "Second comment")
+	}
+}
+
+func TestFetchPRCommentBodies_EmptyPRBody(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(`{"body":"","comments":[{"body":"A comment"}]}`), nil
+	}
+
+	bodies, err := FetchPRCommentBodies("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 body (empty PR body excluded), got %d", len(bodies))
+	}
+	if bodies[0] != "A comment" {
+		t.Errorf("bodies[0]: got %q, want %q", bodies[0], "A comment")
 	}
 }
 

--- a/internal/harness/templates/prompts/reviewer.txt
+++ b/internal/harness/templates/prompts/reviewer.txt
@@ -45,13 +45,25 @@ Based on your findings:
 - If ANY tests fail or acceptance criteria are not met:
   Delete the {{.ReviewDir}} directory, request changes on the PR with specific feedback, and print REVIEW_RESULT=CHANGES_REQUESTED
 
-When requesting changes, post a PR comment with the following format so the
-implementer agent can find your challenges:
+ALWAYS post a PR comment with the following format, regardless of your verdict.
+This comment is required for the dialogue trail visible in the run dashboard.
+
+- If the PR is approved, use this format:
 
 ## Review Notes
 
-### Approved / Changes Requested
-State whether the PR is approved or changes are requested, with a brief summary.
+### Approved
+State that the PR is approved, with a brief summary of what you validated.
+
+### Architecture Compliance
+Confirm that no violations were found{{if .ArchitectureDocContent}} (per architecture rules above){{end}}.
+
+- If changes are requested, use this format:
+
+## Review Notes
+
+### Changes Requested
+State that changes are requested, with a brief summary.
 
 ### Architecture Compliance
 Describe any architecture compliance violations found{{if .ArchitectureDocContent}} (per architecture rules above){{end}},
@@ -60,6 +72,8 @@ or confirm that no violations were found.
 List each specific issue that must be fixed. For each issue: describe what is
 wrong, what the correct behavior should be, and which acceptance criterion or
 scenario it violates.
+
+After posting the comment, print your verdict.
 
 CRITICAL: You MUST print exactly one of these lines:
   REVIEW_RESULT=APPROVED

--- a/prompts/quality_reviewer.txt
+++ b/prompts/quality_reviewer.txt
@@ -39,11 +39,18 @@ Based on your findings, always write your full analysis (security, correctness,
 performance, code craft) to your output — even if you also post a PR comment.
 This analysis is captured for operational review in the run dashboard.
 
-- If the code has NO significant quality issues:
-  Print QUALITY_RESULT=APPROVED
-- If the code has security, performance, or quality issues that should be fixed:
-  Post a PR comment with the following format so the implementer agent can find
-  your feedback, then print QUALITY_RESULT=CHANGES_REQUESTED
+ALWAYS post a PR comment with the following format, regardless of your verdict.
+This comment is required for the dialogue trail visible in the run dashboard.
+
+- If the code has NO significant quality issues, use this format:
+
+## Quality Review Notes
+
+### Approved
+Summarise what you audited and confirm that no significant issues were found.
+
+- If the code has security, performance, or quality issues that should be fixed,
+  use this format:
 
 ## Quality Review Notes
 
@@ -54,6 +61,8 @@ State that changes are requested, with a brief summary.
 List each specific issue that must be fixed. For each issue: describe what is
 wrong, what the correct behavior should be, and which quality criterion it
 violates (security, performance, idiom, or code craft).
+
+After posting the comment, print your verdict.
 
 CRITICAL: You MUST print exactly one of these lines:
   QUALITY_RESULT=APPROVED

--- a/prompts/reviewer.txt
+++ b/prompts/reviewer.txt
@@ -58,13 +58,25 @@ a PR comment. This analysis is captured for operational review in the run dashbo
 - If ANY tests fail or acceptance criteria are not met:
   Delete the {{.ReviewDir}} directory, request changes on the PR with specific feedback, and print REVIEW_RESULT=CHANGES_REQUESTED
 
-When requesting changes, post a PR comment with the following format so the
-implementer agent can find your challenges:
+ALWAYS post a PR comment with the following format, regardless of your verdict.
+This comment is required for the dialogue trail visible in the run dashboard.
+
+- If the PR is approved, use this format:
 
 ## Review Notes
 
-### Approved / Changes Requested
-State whether the PR is approved or changes are requested, with a brief summary.
+### Approved
+State that the PR is approved, with a brief summary of what you validated.
+
+### Architecture Compliance
+Confirm that no violations were found{{if .ArchitectureDocContent}} (per architecture rules above){{end}}.
+
+- If changes are requested, use this format:
+
+## Review Notes
+
+### Changes Requested
+State that changes are requested, with a brief summary.
 
 ### Architecture Compliance
 Describe any architecture compliance violations found{{if .ArchitectureDocContent}} (per architecture rules above){{end}},
@@ -73,6 +85,8 @@ or confirm that no violations were found.
 List each specific issue that must be fixed. For each issue: describe what is
 wrong, what the correct behavior should be, and which acceptance criterion or
 scenario it violates.
+
+After posting the comment, print your verdict.
 
 CRITICAL: You MUST print exactly one of these lines:
   REVIEW_RESULT=APPROVED


### PR DESCRIPTION
## Summary

- **Quality reviewer and functional reviewer prompts** only instructed agents to post structured PR comments (`## Quality Review Notes` / `## Review Notes`) when requesting changes. On approval, no comment was posted — leaving the dashboard dialogue box with missing entries.
- **`FetchPRCommentBodies`** only fetched PR comments, not the PR body. Implementer notes embedded in the PR description were silently dropped.
- **Reviewer prompt** used `### Approved / Changes Requested` as a subsection header, which didn't match either parser field (`### Approved` or `### Changes Requested`).

All three prompts (quality reviewer, functional reviewer, harness reviewer variant) now require a structured comment on every verdict. `FetchPRCommentBodies` now prepends the PR body to captured dialogue.

## Test plan

- [x] `go test ./internal/github/` — updated tests for PR body inclusion + empty body exclusion
- [x] `go test ./internal/orchestrator/` — existing dialogue builder tests pass
- [x] `go test ./internal/dashboard/` — dialogue rendering tests pass
- [x] `go test ./...` — full suite green via pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)