### PR TITLE
fix: use correct gh pr checks JSON fields

### DIFF
--- a/internal/agent/checks.go
+++ b/internal/agent/checks.go
@@ -60,10 +60,13 @@ func WaitForChecks(ctx context.Context, repo string, prNum int,
 }
 
 // checkEntry is used to parse gh pr checks JSON output.
+// gh pr checks --json exposes: name, state, bucket (not "conclusion").
+// state values: SUCCESS, FAILURE, PENDING, QUEUED, etc.
+// bucket values: pass, fail, pending, skipping.
 type checkEntry struct {
-	Name       string `json:"name"`
-	State      string `json:"state"`
-	Conclusion string `json:"conclusion"`
+	Name   string `json:"name"`
+	State  string `json:"state"`
+	Bucket string `json:"bucket"`
 }
 
 // pollChecks queries GitHub PR checks and returns any failed required checks,
@@ -74,7 +77,7 @@ type checkEntry struct {
 func pollChecks(repo string, prNum int, required []string, logger *slog.Logger) ([]CheckFailure, bool, error) {
 	out, err := GuardRunner("gh", "pr", "checks", strconv.Itoa(prNum),
 		"--repo", repo,
-		"--json", "name,state,conclusion",
+		"--json", "name,state,bucket",
 	)
 	if err != nil {
 		return nil, false, fmt.Errorf("gh pr checks: %w", err)
@@ -103,22 +106,20 @@ func pollChecks(repo string, prNum int, required []string, logger *slog.Logger) 
 			continue
 		}
 
-		state := strings.ToUpper(c.State)
-		conclusion := strings.ToUpper(c.Conclusion)
+		bucket := strings.ToLower(c.Bucket)
 
-		switch {
-		case state == "COMPLETED" && conclusion == "SUCCESS":
-			logger.Info("required check passed", "check", name)
-		case state == "COMPLETED":
-			// Any non-success conclusion is a failure.
-			logger.Warn("required check failed", "check", name, "conclusion", c.Conclusion)
+		switch bucket {
+		case "pass", "skipping":
+			logger.Info("required check passed", "check", name, "state", c.State)
+		case "fail":
+			logger.Warn("required check failed", "check", name, "state", c.State)
 			failures = append(failures, CheckFailure{
 				Name:   name,
-				Output: fmt.Sprintf("Check %q completed with conclusion %q", name, c.Conclusion),
+				Output: fmt.Sprintf("Check %q failed (state %q)", name, c.State),
 			})
 		default:
-			// pending, queued, in_progress, or unknown — keep waiting.
-			logger.Info("required check still running", "check", name, "state", c.State)
+			// pending or unknown — keep waiting.
+			logger.Info("required check still running", "check", name, "bucket", c.Bucket, "state", c.State)
 			pendingCount++
 		}
 	}

--- a/internal/agent/checks_test.go
+++ b/internal/agent/checks_test.go
@@ -23,7 +23,7 @@ func stubPollInterval(t *testing.T, d time.Duration) {
 func checksJSON(entries []checkEntry) []byte {
 	var parts []string
 	for _, e := range entries {
-		parts = append(parts, fmt.Sprintf(`{"name":%q,"state":%q,"conclusion":%q}`, e.Name, e.State, e.Conclusion))
+		parts = append(parts, fmt.Sprintf(`{"name":%q,"state":%q,"bucket":%q}`, e.Name, e.State, e.Bucket))
 	}
 	return []byte("[" + strings.Join(parts, ",") + "]")
 }
@@ -34,8 +34,8 @@ func TestWaitForChecks_AllPass(t *testing.T) {
 	stubPollInterval(t, time.Millisecond)
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "COMPLETED", Conclusion: "SUCCESS"},
-			{Name: "ci/test", State: "COMPLETED", Conclusion: "SUCCESS"},
+			{Name: "ci/build", State: "SUCCESS", Bucket: "pass"},
+			{Name: "ci/test", State: "SUCCESS", Bucket: "pass"},
 		}), nil
 	})
 
@@ -55,7 +55,7 @@ func TestWaitForChecks_CheckFails(t *testing.T) {
 	stubPollInterval(t, time.Millisecond)
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "COMPLETED", Conclusion: "FAILURE"},
+			{Name: "ci/build", State: "FAILURE", Bucket: "fail"},
 		}), nil
 	})
 
@@ -81,7 +81,7 @@ func TestWaitForChecks_Timeout(t *testing.T) {
 	stubPollInterval(t, time.Millisecond)
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "queued", Conclusion: ""},
+			{Name: "ci/build", State: "PENDING", Bucket: "pending"},
 		}), nil
 	})
 
@@ -101,7 +101,7 @@ func TestWaitForChecks_ContextCancelled(t *testing.T) {
 	stubPollInterval(t, time.Millisecond)
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "queued", Conclusion: ""},
+			{Name: "ci/build", State: "PENDING", Bucket: "pending"},
 		}), nil
 	})
 
@@ -121,8 +121,8 @@ func TestWaitForChecks_UnrequiredCheckFails(t *testing.T) {
 	stubPollInterval(t, time.Millisecond)
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "COMPLETED", Conclusion: "SUCCESS"},
-			{Name: "ci/optional", State: "COMPLETED", Conclusion: "FAILURE"},
+			{Name: "ci/build", State: "SUCCESS", Bucket: "pass"},
+			{Name: "ci/optional", State: "FAILURE", Bucket: "fail"},
 		}), nil
 	})
 
@@ -147,12 +147,12 @@ func TestWaitForChecks_PendingThenPass(t *testing.T) {
 		if callCount == 1 {
 			// First poll: check still pending.
 			return checksJSON([]checkEntry{
-				{Name: "ci/build", State: "in_progress", Conclusion: ""},
+				{Name: "ci/build", State: "PENDING", Bucket: "pending"},
 			}), nil
 		}
 		// Second poll: check passed.
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "COMPLETED", Conclusion: "SUCCESS"},
+			{Name: "ci/build", State: "SUCCESS", Bucket: "pass"},
 		}), nil
 	})
 
@@ -183,7 +183,7 @@ func TestWaitForChecks_CheckNotPresentInitially(t *testing.T) {
 		}
 		// Second poll: check is now present and passed.
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "COMPLETED", Conclusion: "SUCCESS"},
+			{Name: "ci/build", State: "SUCCESS", Bucket: "pass"},
 		}), nil
 	})
 
@@ -221,8 +221,8 @@ func TestWaitForChecks_FailFastOnFailure(t *testing.T) {
 	stubPollInterval(t, time.Millisecond)
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "COMPLETED", Conclusion: "FAILURE"},
-			{Name: "ci/test", State: "in_progress", Conclusion: ""},
+			{Name: "ci/build", State: "FAILURE", Bucket: "fail"},
+			{Name: "ci/test", State: "PENDING", Bucket: "pending"},
 		}), nil
 	})
 
@@ -246,7 +246,7 @@ func TestWaitForChecks_NilLogger(t *testing.T) {
 	stubPollInterval(t, time.Millisecond)
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return checksJSON([]checkEntry{
-			{Name: "ci/build", State: "COMPLETED", Conclusion: "SUCCESS"},
+			{Name: "ci/build", State: "SUCCESS", Bucket: "pass"},
 		}), nil
 	})
 
@@ -340,7 +340,7 @@ func TestProcessIssue_WaitForChecks_AllPass(t *testing.T) {
 		}
 		if name == "gh" && strings.Contains(joined, "pr checks") {
 			return checksJSON([]checkEntry{
-				{Name: "ci/build", State: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "ci/build", State: "SUCCESS", Bucket: "pass"},
 			}), nil
 		}
 		return []byte(""), nil
@@ -423,7 +423,7 @@ func TestProcessIssue_WaitForChecks_Timeout(t *testing.T) {
 		if name == "gh" && strings.Contains(joined, "pr checks") {
 			// Always return pending to trigger timeout.
 			return checksJSON([]checkEntry{
-				{Name: "ci/build", State: "queued", Conclusion: ""},
+				{Name: "ci/build", State: "PENDING", Bucket: "pending"},
 			}), nil
 		}
 		return []byte(""), nil
@@ -477,12 +477,12 @@ func TestProcessIssue_WaitForChecks_FixSucceeds(t *testing.T) {
 			if checksCallCount == 1 {
 				// First poll: check fails.
 				return checksJSON([]checkEntry{
-					{Name: "ci/build", State: "COMPLETED", Conclusion: "FAILURE"},
+					{Name: "ci/build", State: "FAILURE", Bucket: "fail"},
 				}), nil
 			}
 			// Second poll (after fix): check passes.
 			return checksJSON([]checkEntry{
-				{Name: "ci/build", State: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "ci/build", State: "SUCCESS", Bucket: "pass"},
 			}), nil
 		}
 		return []byte(""), nil
@@ -536,7 +536,7 @@ func TestProcessIssue_WaitForChecks_FixExhausted(t *testing.T) {
 		if name == "gh" && strings.Contains(joined, "pr checks") {
 			// Always fail.
 			return checksJSON([]checkEntry{
-				{Name: "ci/build", State: "COMPLETED", Conclusion: "FAILURE"},
+				{Name: "ci/build", State: "FAILURE", Bucket: "fail"},
 			}), nil
 		}
 		return []byte(""), nil
@@ -587,7 +587,7 @@ func TestProcessIssue_WaitForChecks_NoVerifyFix(t *testing.T) {
 		}
 		if name == "gh" && strings.Contains(joined, "pr checks") {
 			return checksJSON([]checkEntry{
-				{Name: "ci/build", State: "COMPLETED", Conclusion: "FAILURE"},
+				{Name: "ci/build", State: "FAILURE", Bucket: "fail"},
 			}), nil
 		}
 		return []byte(""), nil
@@ -603,5 +603,26 @@ func TestProcessIssue_WaitForChecks_NoVerifyFix(t *testing.T) {
 	}
 	if outcome.Err == nil || !strings.Contains(outcome.Err.Error(), "CI checks failed") {
 		t.Errorf("Err = %v, want it to contain 'CI checks failed'", outcome.Err)
+	}
+}
+
+// TestWaitForChecks_SkippingCheck verifies that a check with bucket "skipping"
+// is treated as passing (not a failure or pending).
+func TestWaitForChecks_SkippingCheck(t *testing.T) {
+	stubPollInterval(t, time.Millisecond)
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		return checksJSON([]checkEntry{
+			{Name: "ci/build", State: "SUCCESS", Bucket: "pass"},
+			{Name: "ci/optional", State: "SKIPPED", Bucket: "skipping"},
+		}), nil
+	})
+
+	failures, err := WaitForChecks(context.Background(), "owner/repo", 42,
+		[]string{"ci/build", "ci/optional"}, time.Minute, testLogger(t))
+	if err != nil {
+		t.Fatalf("WaitForChecks() error = %v", err)
+	}
+	if len(failures) != 0 {
+		t.Errorf("expected no failures for skipped check, got %v", failures)
 	}
 }


### PR DESCRIPTION
## Summary

- `gh pr checks --json` does not support `conclusion` — replaced with `bucket` (pass/fail/pending/skipping)
- The invalid field caused exit status 1, which `pollChecks` treated as fatal, preventing auto-merge from ever reaching `gh pr merge`
- Updated all tests to use the correct field schema; added coverage for `skipping` bucket

## Test plan

- [x] All 20 checks-related tests pass
- [x] Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)