### PR TITLE
docs: document docker.install_commands config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ docker:
   user: ""                 # non-root user inside the container
   node_version: ""         # Node.js major version to install (default: 20)
   extra_packages: []       # additional apt packages to install
+  install_commands: []     # shell commands to run during image build (after runtime setup)
 
 # Prompt template overrides (paths to custom prompt files)
 prompts:

--- a/internal/harness/templates/godark.md
+++ b/internal/harness/templates/godark.md
@@ -132,6 +132,7 @@ notify:
 | `docker.image` | Base image (default: `ubuntu:22.04`) |
 | `docker.dockerfile` | Custom Dockerfile path (overrides auto-generated one) |
 | `docker.extra_packages` | Additional apt packages to install |
+| `docker.install_commands` | Shell commands to run during image build (after runtime setup) |
 | `docker.node_version` | Node.js major version to install (default: `20`) |
 
 ## Common troubleshooting


### PR DESCRIPTION
## Summary

- Add `docker.install_commands` to the README config skeleton
- Add `docker.install_commands` to the godark.md reference table (installed by `godark init`)

Follows up on #304 which added the feature but didn't update docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)