### PR TITLE
fix: validate Go runtime version includes patch component

### DIFF
--- a/internal/sandbox/dockerfile.go
+++ b/internal/sandbox/dockerfile.go
@@ -106,6 +106,12 @@ func GenerateDockerfile(cfg DockerConfig, logger *slog.Logger) (string, error) {
 		if runtimeVersion == "" {
 			return "", fmt.Errorf("Go runtime requires a version (Runtime.Version must be set)")
 		}
+		// Go download URLs require a full major.minor.patch version (e.g. "1.25.4").
+		// A version like "1.25" produces a 404 on go.dev/dl.
+		parts := strings.Split(runtimeVersion, ".")
+		if len(parts) < 3 {
+			return "", fmt.Errorf("Go runtime.version %q must include a patch component (e.g. %s.0)", runtimeVersion, runtimeVersion)
+		}
 	case "flutter":
 		// pubspec.yaml's environment.sdk is a Dart SDK constraint (e.g.
 		// ^3.11.0), not a Flutter version. Flutter tags don't correspond

--- a/internal/sandbox/dockerfile_test.go
+++ b/internal/sandbox/dockerfile_test.go
@@ -126,15 +126,28 @@ func TestGenerateDockerfileCustomImage(t *testing.T) {
 func TestGenerateDockerfileGoRuntimeWithVersion(t *testing.T) {
 	cfg := DefaultDockerConfig()
 	cfg.Runtime.Name = "go"
-	cfg.Runtime.Version = "1.22"
+	cfg.Runtime.Version = "1.22.4"
 
 	df, err := GenerateDockerfile(cfg, slog.Default())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(df, "go1.22.linux-amd64.tar.gz") {
+	if !strings.Contains(df, "go1.22.4.linux-amd64.tar.gz") {
 		t.Error("Dockerfile missing custom Go version URL")
+	}
+}
+
+func TestGenerateDockerfileGoVersionMissingPatch(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.Runtime = config.Runtime{Name: "go", Version: "1.25"}
+
+	_, err := GenerateDockerfile(cfg, slog.Default())
+	if err == nil {
+		t.Fatal("expected error for Go version without patch component, got nil")
+	}
+	if !strings.Contains(err.Error(), "patch component") {
+		t.Errorf("error message should mention patch component, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Go download URLs require a full `major.minor.patch` version (e.g. `1.25.4`), but godark accepted versions like `"1.25"` which produce a 404 during `docker build`
- Adds early validation in `GenerateDockerfile` that rejects Go versions missing a patch component, with a clear error message suggesting the fix
- Updates existing test to use a full patch version and adds a new test for the rejection case

## Test plan
- [x] `go test ./internal/sandbox/` - all tests pass
- [ ] Verify `godark implement` with a full Go patch version builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)