### PR TITLE
docs: Phase 17 - Configurable Base Branch planning

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -792,6 +792,31 @@ published.
 
 ---
 
+## Phase 17: Configurable Base Branch
+
+**Goal**: godark supports branching off and merging into a configurable base
+branch instead of always targeting the repo's default branch. Teams that require
+peer review on merges to main can run godark autonomously on sub-branches under
+a parent feature branch, then submit the parent for human review.
+
+**Milestone**: `Phase 17` | **Label**: `phase-17`
+
+- Add `base_branch` config field to `godark.yaml` and `--base-branch` CLI flag,
+  defaulting to the repo's default branch when unset
+- Pass `--base` flag to `gh pr create` so PRs target the configured base branch
+- Replace hardcoded "main" references in prompt templates with a
+  `{{.BaseBranch}}` template variable
+- Update orchestrator post-merge pull to use the configured base branch instead
+  of hardcoded `origin main`
+- Track base branch in run data for audit trail
+- Surface base branch name in the status dashboard on run detail pages
+
+**Issues**: #311-#316
+
+**Planning doc**: `docs/planning/phase-17-configurable-base-branch.md`
+
+---
+
 ### Future considerations (not yet scoped)
 - Linter config generation from `architecture.json` (per-language)
 - Multi-cluster deployment and geographic distribution

--- a/docs/planning/phase-17-configurable-base-branch.md
+++ b/docs/planning/phase-17-configurable-base-branch.md
@@ -1,0 +1,259 @@
+# Phase 17: Configurable Base Branch
+
+> **Goal:** godark supports branching off and merging into a configurable base
+> branch instead of always targeting the repo's default branch. Teams that
+> require peer review on merges to main can run godark autonomously on
+> sub-branches under a parent feature branch, then submit the parent for human
+> review.
+
+## Milestone
+
+`Phase 17`
+
+---
+
+## Issue 311: Add `base_branch` config field and CLI flag
+
+### Description
+
+Add a `BaseBranch` field to `Config` and a `--base-branch` flag to the
+`implement` (and `run`) commands. When set, godark creates feature branches off
+this branch and targets PRs against it instead of the repo's default branch.
+When empty (default), behavior is unchanged - PRs target the repo's default
+branch.
+
+### Key constraints
+
+- Modify `internal/config/config.go`:
+  - Add `BaseBranch string` field with yaml tag `base_branch` to `Config`
+  - Add `BaseBranch *string` to `CLIFlags`
+  - Add `BaseBranch` handling in `applyFlags()`
+  - Default: `""` (empty string means use repo default branch)
+  - No validation needed - empty means "not configured"
+- Modify `internal/cmd/implement.go`:
+  - Add `--base-branch` flag
+  - Wire `cmd.Flags().Changed("base-branch")` into `CLIFlags`
+- Modify `internal/cmd/run.go`:
+  - Same `--base-branch` flag and wiring
+
+### Acceptance criteria
+
+- [ ] `Config` has `BaseBranch` field, empty by default
+- [ ] Setting `base_branch: feature/foo` in YAML is reflected in parsed config
+- [ ] `--base-branch feature/foo` CLI flag overrides YAML value
+- [ ] Existing tests pass (no regressions)
+
+### Test cases
+
+- **Config default**: New config has empty `BaseBranch`
+- **YAML override**: Setting `base_branch: "my-feature"` in YAML is reflected
+  in parsed config
+- **CLI flag override**: `--base-branch` flag overrides YAML value
+- **CLI flag not set**: When flag is not passed, YAML value is preserved
+
+---
+
+## Issue 312: Pass `--base` flag to `gh pr create`
+
+**Blocked by**: #311
+
+### Description
+
+When `BaseBranch` is configured, the implementer agent needs to create PRs
+targeting that branch instead of the repo default. Pass `BaseBranch` through
+to the `PromptData` struct and update the implementer prompt template to
+include `--base {{.BaseBranch}}` in the `gh pr create` command when set.
+
+The agent also needs to branch off the base branch rather than whatever HEAD
+happens to be. Update the branch creation instructions in the prompt to
+`git fetch origin && git checkout -b <branch> origin/{{.BaseBranch}}` when
+`BaseBranch` is set.
+
+### Key constraints
+
+- Modify `internal/agent/prompt.go`:
+  - Add `BaseBranch string` to `PromptData`
+- Modify the call sites that construct `PromptData` (in `internal/agent/`)
+  to populate `BaseBranch` from `cfg.BaseBranch`
+- Modify `prompts/implementer.txt`:
+  - Update branch creation to base off `{{.BaseBranch}}` when set
+  - Update `gh pr create` to include `--base {{.BaseBranch}}` when set
+- Modify `prompts/spec_generator.txt`:
+  - Same branch creation update
+
+### Acceptance criteria
+
+- [ ] `PromptData` has `BaseBranch` field
+- [ ] Implementer prompt includes `--base <branch>` in `gh pr create` when
+  `BaseBranch` is non-empty
+- [ ] Implementer prompt branches off `origin/<BaseBranch>` when set
+- [ ] When `BaseBranch` is empty, prompt behavior is unchanged (no `--base`
+  flag, branches off current HEAD)
+- [ ] Spec generator prompt branches off `origin/<BaseBranch>` when set
+
+### Test cases
+
+- **Render with BaseBranch set**: `RenderPrompt` with `BaseBranch: "feature/foo"`
+  produces prompt containing `--base feature/foo`
+- **Render with BaseBranch empty**: `RenderPrompt` with empty `BaseBranch`
+  produces prompt without `--base` flag
+- **Branch creation with BaseBranch**: Prompt contains
+  `git checkout -b <branch> origin/feature/foo` when set
+- **Branch creation without BaseBranch**: Prompt contains
+  `git checkout -b <branch>` (current behavior) when empty
+
+---
+
+## Issue 313: Replace hardcoded "main" in prompt templates
+
+**Blocked by**: #312
+
+### Description
+
+The implementer and spec generator prompts contain `Never commit directly to
+main`. Replace this with `Never commit directly to {{.BaseBranch}}` when set,
+falling back to `main` when empty. This prevents agents from accidentally
+pushing to the configured base branch.
+
+### Key constraints
+
+- Modify `prompts/implementer.txt`:
+  - Replace `Never commit directly to main` with a conditional that uses
+    `{{.BaseBranch}}` when non-empty, `main` otherwise
+- Modify `prompts/spec_generator.txt`:
+  - Same replacement
+- No Go code changes needed (BaseBranch already in PromptData from prior issue)
+
+### Acceptance criteria
+
+- [ ] Implementer prompt says "Never commit directly to feature/foo" when
+  `BaseBranch` is `"feature/foo"`
+- [ ] Implementer prompt says "Never commit directly to main" when
+  `BaseBranch` is empty
+- [ ] Spec generator prompt has the same behavior
+
+### Test cases
+
+- **Implementer with BaseBranch**: Rendered prompt contains
+  "Never commit directly to feature/foo"
+- **Implementer without BaseBranch**: Rendered prompt contains
+  "Never commit directly to main"
+- **Spec generator with BaseBranch**: Same as implementer tests
+
+---
+
+## Issue 314: Update `PullAfterMerge` to use configured base branch
+
+**Blocked by**: #311
+
+### Description
+
+`orchestrator.PullAfterMerge` currently hardcodes `git pull --rebase origin
+main`. Update it to accept the base branch as a parameter and use that instead.
+Update all call sites (`implement.go`, `run.go`) to pass `cfg.BaseBranch`
+through, falling back to `"main"` when empty.
+
+### Key constraints
+
+- Modify `internal/orchestrator/orchestrator.go`:
+  - Change `PullAfterMerge(logger)` signature to
+    `PullAfterMerge(branch string, logger *slog.Logger)`
+  - Replace hardcoded `"main"` with the `branch` parameter
+  - Update the warning message to reference the actual branch name
+- Modify `internal/cmd/implement.go`:
+  - Pass `cfg.BaseBranch` (or `"main"` if empty) to `PullAfterMerge`
+- Modify `internal/cmd/run.go` (if it calls `PullAfterMerge`):
+  - Same change
+- Update any existing tests for `PullAfterMerge`
+
+### Acceptance criteria
+
+- [ ] `PullAfterMerge` pulls from the specified branch, not hardcoded "main"
+- [ ] When `BaseBranch` is empty, callers pass "main" (preserving current
+  behavior)
+- [ ] Warning message references the actual branch name
+- [ ] Existing `PullAfterMerge` tests updated and passing
+
+### Test cases
+
+- **Pull from custom branch**: `PullAfterMerge("feature/foo", logger)` runs
+  `git pull --rebase origin feature/foo`
+- **Pull from main**: `PullAfterMerge("main", logger)` runs
+  `git pull --rebase origin main`
+- **Dirty repo warning**: Warning message references the configured branch name,
+  not hardcoded "main"
+
+---
+
+## Issue 315: Track base branch in run data
+
+**Blocked by**: #311
+
+### Description
+
+Record the configured `BaseBranch` in `RunMeta` so that run data captures which
+branch was targeted. This supports audit trail and makes it possible for the
+dashboard to display the base branch.
+
+### Key constraints
+
+- Modify `internal/rundata/writer.go`:
+  - Add `BaseBranch string` field to `RunMeta` with json tag
+    `base_branch,omitempty`
+  - Update `New()` to accept and store the base branch
+- Modify call sites that create `rundata.Writer` (`implement.go`, `run.go`):
+  - Pass `cfg.BaseBranch` to the writer constructor
+- Existing run data files without `base_branch` should deserialize cleanly
+  (omitempty handles this)
+
+### Acceptance criteria
+
+- [ ] `RunMeta` has `BaseBranch` field
+- [ ] `run.json` includes `base_branch` when configured
+- [ ] `run.json` omits `base_branch` when empty (backwards compatible)
+- [ ] Existing run data without `base_branch` loads without error
+
+### Test cases
+
+- **Write with base branch**: Creating a writer with `BaseBranch: "feature/foo"`
+  produces `run.json` containing `"base_branch":"feature/foo"`
+- **Write without base branch**: Creating a writer with empty `BaseBranch`
+  produces `run.json` without `base_branch` key
+- **Read old data**: Loading run data that lacks `base_branch` field succeeds
+  with empty `BaseBranch`
+
+---
+
+## Issue 316: Surface base branch in dashboard run detail page
+
+**Blocked by**: #315
+
+### Description
+
+Display the configured base branch on the run detail page in the status
+dashboard. When `BaseBranch` is non-empty, show it in the run metadata section
+(next to repo, milestone, etc.). When empty, show nothing (default branch
+behavior is implied).
+
+### Key constraints
+
+- Modify `internal/dashboard/handlers.go`:
+  - `RunDetailData` already embeds `RunMeta` which will have `BaseBranch` -
+    no struct changes needed
+- Modify `internal/dashboard/templates/run-detail.html`:
+  - Add conditional display of base branch in the metadata section
+  - Only show when `BaseBranch` is non-empty
+- No backend logic changes beyond what the rundata issue provides
+
+### Acceptance criteria
+
+- [ ] Run detail page shows "Base branch: feature/foo" when configured
+- [ ] Run detail page does not show base branch info when empty
+- [ ] Display is positioned near existing metadata (repo, milestone, timestamp)
+
+### Test cases
+
+- **Detail page with base branch**: Run with `BaseBranch: "feature/foo"` renders
+  page containing "feature/foo"
+- **Detail page without base branch**: Run with empty `BaseBranch` does not
+  render any base branch element

--- a/tests/scenarios/phase-17/config-base-branch.md
+++ b/tests/scenarios/phase-17/config-base-branch.md
@@ -1,0 +1,31 @@
+# Scenario: Config base_branch field and CLI flag
+
+Relates to: Issue #311
+
+## Setup
+- The `internal/config/` package is tested via Go unit tests
+- YAML config files with various `base_branch` values
+- CLIFlags struct with BaseBranch pointer field
+
+## Cases
+
+### Config default
+Parse a minimal `godark.yaml` with only `repo:` set.
+- `Config.BaseBranch` is an empty string
+
+### YAML override
+Parse a `godark.yaml` with `base_branch: "my-feature"`.
+- `Config.BaseBranch` is `"my-feature"`
+
+### CLI flag override
+Parse a `godark.yaml` with `base_branch: "yaml-branch"` and CLIFlags with `BaseBranch` set to `"cli-branch"`.
+- `Config.BaseBranch` is `"cli-branch"`
+
+### CLI flag not set
+Parse a `godark.yaml` with `base_branch: "yaml-branch"` and CLIFlags with `BaseBranch` as nil.
+- `Config.BaseBranch` is `"yaml-branch"`
+
+### Empty string is valid
+Parse a `godark.yaml` with `base_branch: ""`.
+- `Config.BaseBranch` is an empty string
+- No validation error is returned

--- a/tests/scenarios/phase-17/dashboard-base-branch.md
+++ b/tests/scenarios/phase-17/dashboard-base-branch.md
@@ -1,0 +1,19 @@
+# Scenario: Dashboard displays base branch on run detail page
+
+Relates to: Issue #316
+
+## Setup
+- The `internal/dashboard/` server with test run data
+- Run data with and without `BaseBranch` set in `RunMeta`
+
+## Cases
+
+### Detail page shows base branch when configured
+Request the run detail page for a run with `BaseBranch: "feature/foo"`.
+- Response body contains "feature/foo"
+- Base branch is displayed near the repo and milestone metadata
+
+### Detail page hides base branch when empty
+Request the run detail page for a run with empty `BaseBranch`.
+- Response body does not contain a base branch label or empty value
+- No visual element for base branch is rendered

--- a/tests/scenarios/phase-17/pr-base-branch-targeting.md
+++ b/tests/scenarios/phase-17/pr-base-branch-targeting.md
@@ -1,0 +1,38 @@
+# Scenario: PR base branch targeting in prompts
+
+Relates to: Issue #312
+
+## Setup
+- The `internal/agent/` package prompt rendering with `PromptData`
+- Implementer and spec generator prompt templates
+- `PromptData` with `BaseBranch` field populated from config
+
+## Cases
+
+### PromptData has BaseBranch field
+Construct a `PromptData` with `BaseBranch: "feature/foo"`.
+- The struct accepts and stores the value
+
+### Implementer prompt includes --base when set
+Render the implementer prompt with `BaseBranch: "feature/foo"`.
+- Rendered output contains `--base feature/foo` in the `gh pr create` instruction
+
+### Implementer prompt omits --base when empty
+Render the implementer prompt with `BaseBranch: ""`.
+- Rendered output does not contain `--base` in the `gh pr create` instruction
+
+### Branch creation bases off configured branch
+Render the implementer prompt with `BaseBranch: "feature/foo"` and `BranchExists: false`.
+- Rendered output contains `origin/feature/foo` in the branch creation instruction
+
+### Branch creation unchanged when empty
+Render the implementer prompt with `BaseBranch: ""` and `BranchExists: false`.
+- Rendered output contains `git checkout -b` without an `origin/` base reference
+
+### Spec generator branches off configured branch
+Render the spec generator prompt with `BaseBranch: "feature/foo"`.
+- Rendered output contains `origin/feature/foo` in the branch creation instruction
+
+### Spec generator unchanged when empty
+Render the spec generator prompt with `BaseBranch: ""`.
+- Rendered output does not contain `origin/` base reference in branch creation

--- a/tests/scenarios/phase-17/prompt-base-branch-reference.md
+++ b/tests/scenarios/phase-17/prompt-base-branch-reference.md
@@ -1,0 +1,27 @@
+# Scenario: Prompt templates reference configured base branch
+
+Relates to: Issue #313
+
+## Setup
+- Implementer and spec generator prompt templates
+- `PromptData` with `BaseBranch` field (added in prior issue)
+
+## Cases
+
+### Implementer warns against committing to configured branch
+Render the implementer prompt with `BaseBranch: "feature/foo"`.
+- Rendered output contains "Never commit directly to feature/foo"
+- Rendered output does not contain "Never commit directly to main"
+
+### Implementer defaults to main when empty
+Render the implementer prompt with `BaseBranch: ""`.
+- Rendered output contains "Never commit directly to main"
+
+### Spec generator warns against committing to configured branch
+Render the spec generator prompt with `BaseBranch: "feature/foo"`.
+- Rendered output contains "Never commit directly to feature/foo"
+- Rendered output does not contain "Never commit directly to main"
+
+### Spec generator defaults to main when empty
+Render the spec generator prompt with `BaseBranch: ""`.
+- Rendered output contains "Never commit directly to main"

--- a/tests/scenarios/phase-17/pull-after-merge-base-branch.md
+++ b/tests/scenarios/phase-17/pull-after-merge-base-branch.md
@@ -1,0 +1,25 @@
+# Scenario: PullAfterMerge uses configured base branch
+
+Relates to: Issue #314
+
+## Setup
+- The `internal/orchestrator/` package with stubbed `CommandRunner`
+- `PullAfterMerge` function accepting a branch parameter
+
+## Cases
+
+### Pull from custom branch
+Call `PullAfterMerge("feature/foo", logger)`.
+- `CommandRunner` is called with `"git", "pull", "--rebase", "origin", "feature/foo"`
+
+### Pull from main
+Call `PullAfterMerge("main", logger)`.
+- `CommandRunner` is called with `"git", "pull", "--rebase", "origin", "main"`
+
+### Dirty repo warning references configured branch
+Call `PullAfterMerge("feature/foo", logger)` when the working tree is dirty.
+- Warning message contains "feature/foo", not hardcoded "main"
+
+### Caller passes main when config is empty
+In `implement.go`, when `cfg.BaseBranch` is `""`, the caller passes `"main"` to `PullAfterMerge`.
+- `PullAfterMerge` receives `"main"` as the branch argument

--- a/tests/scenarios/phase-17/rundata-base-branch.md
+++ b/tests/scenarios/phase-17/rundata-base-branch.md
@@ -1,0 +1,26 @@
+# Scenario: Base branch tracked in run data
+
+Relates to: Issue #315
+
+## Setup
+- The `internal/rundata/` package writer and reader
+- Temporary directories for run data output
+
+## Cases
+
+### Write with base branch
+Create a `Writer` with `BaseBranch: "feature/foo"` and write `run.json`.
+- The `run.json` file contains `"base_branch":"feature/foo"`
+
+### Write without base branch
+Create a `Writer` with empty `BaseBranch` and write `run.json`.
+- The `run.json` file does not contain the key `"base_branch"`
+
+### Read data with base branch
+Load a `run.json` that includes `"base_branch":"feature/foo"`.
+- `RunMeta.BaseBranch` is `"feature/foo"`
+
+### Read old data without base branch
+Load a `run.json` that does not have a `base_branch` field.
+- `RunMeta.BaseBranch` is an empty string
+- No error is returned


### PR DESCRIPTION
## Summary
- Adds Phase 17 (Configurable Base Branch) to the roadmap with 6 issues (#311-#316)
- Adds planning doc with full specs for each issue
- Adds scenario specs for all 6 issues

## Context
Teams that require peer review on merges to main need godark to work on sub-branches under a parent feature branch. This phase adds a `base_branch` config field so godark branches off and merges into a configurable branch instead of always targeting main.

## Test plan
- [ ] Docs render correctly on GitHub
- [ ] All 6 issues are created and linked to milestone Phase 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)