### PR TITLE
feat: re-run verify after quality-gate retry

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -197,206 +197,10 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	fixCycles := 0
 
 	// Step 3.5: Verify. Runs between guard rails and quality review.
-	if cfg.Modules != nil {
-		// Per-module verification in dependency order.
-		sortedMods, err := topologicalSortModules(cfg.Modules)
-		if err != nil {
-			outcome.Status = "failed"
-			outcome.Err = fmt.Errorf("sorting modules for verify: %w", err)
-			return outcome
-		}
-
-		var verifyRunner CommandRunner
-		if cfg.NoSandbox {
-			verifyRunner = newHostRunner()
-		} else {
-			verifyRunner = sandboxCommandRunner(cfg.Docker.Image, cfg.Repo, branch, authEnv, logger)
-		}
-
-		moduleFailed := false
-		var failedModName string
-
-		for _, modName := range sortedMods {
-			mod := cfg.Modules[modName]
-			moduleChecks := buildModuleVerifyChecks(modName, mod, cfg)
-			if len(moduleChecks) == 0 {
-				continue
-			}
-
-			logger.Info("running verify step for module",
-				"issue_number", issue.Number,
-				"module", modName,
-				"check_count", len(moduleChecks),
-			)
-			verifyResult := RunVerify(ctx, moduleChecks, verifyRunner)
-			if hook != nil {
-				if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, 0, false)); err != nil {
-					logger.Warn("failed to write verify result", "error", err)
-				}
-			}
-
-			if !verifyResult.AllPassed && prompts.VerifyFix != "" && cfg.Verify.MaxFixAttempts > 0 {
-				for fixAttempt := 0; fixAttempt < cfg.Verify.MaxFixAttempts; fixAttempt++ {
-					if ctx.Err() != nil {
-						outcome.Status = "failed"
-						outcome.Err = ctx.Err()
-						return outcome
-					}
-					fixCycles++
-
-					verifyErrors := fmt.Sprintf("Module: %s\n\n%s", modName, formatVerifyErrors(verifyResult))
-					logger.Info("running verify-fix attempt",
-						"issue_number", issue.Number,
-						"module", modName,
-						"attempt", fixAttempt+1,
-						"max_attempts", cfg.Verify.MaxFixAttempts,
-					)
-
-					fixResult, err := VerifyFix(ctx, issue, prNum, verifyErrors, sessionID, cfg, prompts, authEnv, logger)
-					if err != nil {
-						outcome.Status = "failed"
-						outcome.Err = fmt.Errorf("verify-fix agent: %w", err)
-						return outcome
-					}
-					if fixResult.TimedOut {
-						outcome.Status = "failed"
-						outcome.Err = fmt.Errorf("verify-fix agent timed out")
-						return outcome
-					}
-					sessionID = fixResult.SessionID
-
-					if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
-						outcome.Status = "failed"
-						outcome.Err = driftErr
-						return outcome
-					}
-
-					verifyResult = RunVerify(ctx, moduleChecks, verifyRunner)
-					if hook != nil {
-						if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, fixAttempt+1, true)); err != nil {
-							logger.Warn("failed to write verify result", "error", err)
-						}
-					}
-					if verifyResult.AllPassed {
-						break
-					}
-				}
-			}
-
-			if verifyResult.AllPassed {
-				logger.Info("verify step passed for module", "issue_number", issue.Number, "module", modName)
-			} else {
-				var failedNames []string
-				for _, cr := range verifyResult.Checks {
-					if !cr.Passed {
-						failedNames = append(failedNames, cr.Name)
-					}
-				}
-				logger.Warn("verify step failed for module",
-					"issue_number", issue.Number,
-					"module", modName,
-					"failed_checks", failedNames,
-				)
-				moduleFailed = true
-				failedModName = modName
-				break // Stop processing dependent modules.
-			}
-		}
-
-		if moduleFailed {
-			if cfg.Verify.Blocking {
-				outcome.Status = "failed"
-				outcome.Err = fmt.Errorf("verify failed for module %s", failedModName)
-				return outcome
-			}
-			logger.Warn("module verify failed (non-blocking), proceeding to review",
-				"issue_number", issue.Number,
-				"module", failedModName,
-			)
-		}
-	} else if verifyChecks := buildVerifyChecks(cfg); len(verifyChecks) > 0 {
-		var verifyRunner CommandRunner
-		if cfg.NoSandbox {
-			verifyRunner = newHostRunner()
-		} else {
-			verifyRunner = sandboxCommandRunner(cfg.Docker.Image, cfg.Repo, branch, authEnv, logger)
-		}
-		logger.Info("running verify step", "issue_number", issue.Number, "check_count", len(verifyChecks))
-		verifyResult := RunVerify(ctx, verifyChecks, verifyRunner)
-		if hook != nil {
-			if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, 0, false)); err != nil {
-				logger.Warn("failed to write verify result", "error", err)
-			}
-		}
-
-		if !verifyResult.AllPassed && prompts.VerifyFix != "" && cfg.Verify.MaxFixAttempts > 0 {
-			for fixAttempt := 0; fixAttempt < cfg.Verify.MaxFixAttempts; fixAttempt++ {
-				if ctx.Err() != nil {
-					outcome.Status = "failed"
-					outcome.Err = ctx.Err()
-					return outcome
-				}
-				fixCycles++
-
-				verifyErrors := formatVerifyErrors(verifyResult)
-				logger.Info("running verify-fix attempt",
-					"issue_number", issue.Number,
-					"attempt", fixAttempt+1,
-					"max_attempts", cfg.Verify.MaxFixAttempts,
-				)
-
-				fixResult, err := VerifyFix(ctx, issue, prNum, verifyErrors, sessionID, cfg, prompts, authEnv, logger)
-				if err != nil {
-					outcome.Status = "failed"
-					outcome.Err = fmt.Errorf("verify-fix agent: %w", err)
-					return outcome
-				}
-				if fixResult.TimedOut {
-					outcome.Status = "failed"
-					outcome.Err = fmt.Errorf("verify-fix agent timed out")
-					return outcome
-				}
-				sessionID = fixResult.SessionID
-
-				// Re-check drift after each fix attempt.
-				if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
-					outcome.Status = "failed"
-					outcome.Err = driftErr
-					return outcome
-				}
-
-				// Re-run verify.
-				verifyResult = RunVerify(ctx, verifyChecks, verifyRunner)
-				if hook != nil {
-					if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, fixAttempt+1, true)); err != nil {
-						logger.Warn("failed to write verify result", "error", err)
-					}
-				}
-				if verifyResult.AllPassed {
-					break
-				}
-			}
-		}
-
-		if verifyResult.AllPassed {
-			logger.Info("verify step passed", "issue_number", issue.Number)
-		} else {
-			var failedNames []string
-			for _, cr := range verifyResult.Checks {
-				if !cr.Passed {
-					failedNames = append(failedNames, cr.Name)
-				}
-			}
-			if cfg.Verify.Blocking {
-				outcome.Status = "failed"
-				outcome.Err = fmt.Errorf("verify failed: %s", strings.Join(failedNames, ", "))
-				return outcome
-			}
-			logger.Warn("verify step failed (non-blocking), proceeding to review",
-				"issue_number", issue.Number,
-				"failed_checks", failedNames,
-			)
-		}
+	if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles); verifyErr != nil {
+		outcome.Status = "failed"
+		outcome.Err = verifyErr
+		return outcome
 	}
 
 	// Step 4: Quality review gate (if prompt is configured).
@@ -470,6 +274,14 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
 					outcome.Status = "failed"
 					outcome.Err = driftErr
+					return outcome
+				}
+
+				// Re-run verify after quality-gate retry so that changes introduced
+				// by the retry agent are caught before the next quality review cycle.
+				if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles); verifyErr != nil {
+					outcome.Status = "failed"
+					outcome.Err = fmt.Errorf("verify after quality-gate retry: %w", verifyErr)
 					return outcome
 				}
 
@@ -780,6 +592,207 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	outcome.Status = "needs-human-review"
 	outcome.Retries = maxAttempts - 1
 	return outcome
+}
+
+// runVerifyPhase executes the verify step and optional verify-fix cycles.
+// It handles both module-based (cfg.Modules != nil) and single-module verify paths.
+// Returns nil on pass or non-blocking failure (logs a warning in that case).
+// Returns a non-nil error on blocking failure, context cancellation, or agent error.
+// sessionID and fixCycles are updated in-place when verify-fix agents run.
+func runVerifyPhase(
+	ctx context.Context,
+	issue github.Issue,
+	prNum int,
+	branch string,
+	baseSHA string,
+	cfg *config.Config,
+	prompts *Prompts,
+	authEnv map[string]string,
+	logger *slog.Logger,
+	hook RunDataHook,
+	sessionID *string,
+	fixCycles *int,
+) error {
+	if cfg.Modules != nil {
+		// Per-module verification in dependency order.
+		sortedMods, err := topologicalSortModules(cfg.Modules)
+		if err != nil {
+			return fmt.Errorf("sorting modules for verify: %w", err)
+		}
+
+		var verifyRunner CommandRunner
+		if cfg.NoSandbox {
+			verifyRunner = newHostRunner()
+		} else {
+			verifyRunner = sandboxCommandRunner(cfg.Docker.Image, cfg.Repo, branch, authEnv, logger)
+		}
+
+		moduleFailed := false
+		var failedModName string
+
+		for _, modName := range sortedMods {
+			mod := cfg.Modules[modName]
+			moduleChecks := buildModuleVerifyChecks(modName, mod, cfg)
+			if len(moduleChecks) == 0 {
+				continue
+			}
+
+			logger.Info("running verify step for module",
+				"issue_number", issue.Number,
+				"module", modName,
+				"check_count", len(moduleChecks),
+			)
+			verifyResult := RunVerify(ctx, moduleChecks, verifyRunner)
+			if hook != nil {
+				if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, 0, false)); err != nil {
+					logger.Warn("failed to write verify result", "error", err)
+				}
+			}
+
+			if !verifyResult.AllPassed && prompts.VerifyFix != "" && cfg.Verify.MaxFixAttempts > 0 {
+				for fixAttempt := 0; fixAttempt < cfg.Verify.MaxFixAttempts; fixAttempt++ {
+					if ctx.Err() != nil {
+						return ctx.Err()
+					}
+					*fixCycles++
+
+					verifyErrors := fmt.Sprintf("Module: %s\n\n%s", modName, formatVerifyErrors(verifyResult))
+					logger.Info("running verify-fix attempt",
+						"issue_number", issue.Number,
+						"module", modName,
+						"attempt", fixAttempt+1,
+						"max_attempts", cfg.Verify.MaxFixAttempts,
+					)
+
+					fixResult, err := VerifyFix(ctx, issue, prNum, verifyErrors, *sessionID, cfg, prompts, authEnv, logger)
+					if err != nil {
+						return fmt.Errorf("verify-fix agent: %w", err)
+					}
+					if fixResult.TimedOut {
+						return fmt.Errorf("verify-fix agent timed out")
+					}
+					*sessionID = fixResult.SessionID
+
+					if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
+						return driftErr
+					}
+
+					verifyResult = RunVerify(ctx, moduleChecks, verifyRunner)
+					if hook != nil {
+						if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, fixAttempt+1, true)); err != nil {
+							logger.Warn("failed to write verify result", "error", err)
+						}
+					}
+					if verifyResult.AllPassed {
+						break
+					}
+				}
+			}
+
+			if verifyResult.AllPassed {
+				logger.Info("verify step passed for module", "issue_number", issue.Number, "module", modName)
+			} else {
+				var failedNames []string
+				for _, cr := range verifyResult.Checks {
+					if !cr.Passed {
+						failedNames = append(failedNames, cr.Name)
+					}
+				}
+				logger.Warn("verify step failed for module",
+					"issue_number", issue.Number,
+					"module", modName,
+					"failed_checks", failedNames,
+				)
+				moduleFailed = true
+				failedModName = modName
+				break // Stop processing dependent modules.
+			}
+		}
+
+		if moduleFailed {
+			if cfg.Verify.Blocking {
+				return fmt.Errorf("verify failed for module %s", failedModName)
+			}
+			logger.Warn("module verify failed (non-blocking), proceeding to review",
+				"issue_number", issue.Number,
+				"module", failedModName,
+			)
+		}
+	} else if verifyChecks := buildVerifyChecks(cfg); len(verifyChecks) > 0 {
+		var verifyRunner CommandRunner
+		if cfg.NoSandbox {
+			verifyRunner = newHostRunner()
+		} else {
+			verifyRunner = sandboxCommandRunner(cfg.Docker.Image, cfg.Repo, branch, authEnv, logger)
+		}
+		logger.Info("running verify step", "issue_number", issue.Number, "check_count", len(verifyChecks))
+		verifyResult := RunVerify(ctx, verifyChecks, verifyRunner)
+		if hook != nil {
+			if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, 0, false)); err != nil {
+				logger.Warn("failed to write verify result", "error", err)
+			}
+		}
+
+		if !verifyResult.AllPassed && prompts.VerifyFix != "" && cfg.Verify.MaxFixAttempts > 0 {
+			for fixAttempt := 0; fixAttempt < cfg.Verify.MaxFixAttempts; fixAttempt++ {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				*fixCycles++
+
+				verifyErrors := formatVerifyErrors(verifyResult)
+				logger.Info("running verify-fix attempt",
+					"issue_number", issue.Number,
+					"attempt", fixAttempt+1,
+					"max_attempts", cfg.Verify.MaxFixAttempts,
+				)
+
+				fixResult, err := VerifyFix(ctx, issue, prNum, verifyErrors, *sessionID, cfg, prompts, authEnv, logger)
+				if err != nil {
+					return fmt.Errorf("verify-fix agent: %w", err)
+				}
+				if fixResult.TimedOut {
+					return fmt.Errorf("verify-fix agent timed out")
+				}
+				*sessionID = fixResult.SessionID
+
+				// Re-check drift after each fix attempt.
+				if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
+					return driftErr
+				}
+
+				// Re-run verify.
+				verifyResult = RunVerify(ctx, verifyChecks, verifyRunner)
+				if hook != nil {
+					if err := hook.WriteVerifyResult(issue.Number, verifyToRundata(verifyResult, fixAttempt+1, true)); err != nil {
+						logger.Warn("failed to write verify result", "error", err)
+					}
+				}
+				if verifyResult.AllPassed {
+					break
+				}
+			}
+		}
+
+		if verifyResult.AllPassed {
+			logger.Info("verify step passed", "issue_number", issue.Number)
+		} else {
+			var failedNames []string
+			for _, cr := range verifyResult.Checks {
+				if !cr.Passed {
+					failedNames = append(failedNames, cr.Name)
+				}
+			}
+			if cfg.Verify.Blocking {
+				return fmt.Errorf("verify failed: %s", strings.Join(failedNames, ", "))
+			}
+			logger.Warn("verify step failed (non-blocking), proceeding to review",
+				"issue_number", issue.Number,
+				"failed_checks", failedNames,
+			)
+		}
+	}
+	return nil
 }
 
 // checkDriftAndClose checks for protected path modifications and closes the

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -3609,3 +3609,184 @@ func TestProcessIssue_QualityEscalationLabelsAwaitingReview(t *testing.T) {
 		t.Errorf("expected %q label to be added on quality escalation, got: %v", label.AwaitingHumanReview, *added)
 	}
 }
+
+// TestProcessIssue_VerifyRerunsAfterQualityGateRetry verifies that when the
+// quality reviewer requests changes and the retry agent runs, verify is
+// re-executed before the next quality review cycle.
+func TestProcessIssue_VerifyRerunsAfterQualityGateRetry(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	shCallCount := 0
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			shCallCount++
+			return []byte(""), nil // all verify runs pass
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2: // quality reviewer — requests changes
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		case 3: // retry agent
+			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
+		case 4: // quality reviewer — approves after retry+verify
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // functional reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	cfg := verifyLoopConfig(true)
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want implemented (err: %v)", outcome.Status, outcome.Err)
+	}
+	// Expect 2 verify runs: one initial (before quality review) and one after
+	// the quality-gate retry.
+	if shCallCount != 2 {
+		t.Errorf("shCallCount = %d, want 2 (initial verify + verify after quality-gate retry)", shCallCount)
+	}
+}
+
+// TestProcessIssue_VerifyBlockingFailsAfterQualityGateRetry verifies that when
+// verify fails (blocking) after a quality-gate retry, the run is marked failed.
+func TestProcessIssue_VerifyBlockingFailsAfterQualityGateRetry(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	shCallCount := 0
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			shCallCount++
+			if shCallCount == 1 {
+				// Initial verify passes.
+				return []byte(""), nil
+			}
+			// Verify after quality-gate retry fails.
+			return []byte("build error"), fmt.Errorf("exit status 1")
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2: // quality reviewer — requests changes
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		default: // retry agent
+			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
+		}
+	}
+
+	cfg := verifyLoopConfig(true) // Blocking = true
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "failed" {
+		t.Errorf("Status = %q, want failed when verify blocks after quality-gate retry (err: %v)", outcome.Status, outcome.Err)
+	}
+	if outcome.Err == nil || !strings.Contains(outcome.Err.Error(), "verify") {
+		t.Errorf("Err = %v, want error containing 'verify'", outcome.Err)
+	}
+}
+
+// TestProcessIssue_VerifyNonBlockingContinuesAfterQualityGateRetry verifies
+// that when verify fails (non-blocking) after a quality-gate retry, the
+// quality review cycle continues rather than aborting.
+func TestProcessIssue_VerifyNonBlockingContinuesAfterQualityGateRetry(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		if name == "sh" && len(args) > 0 && args[0] == "-c" {
+			// All verify runs fail (non-blocking — proceeds to review).
+			return []byte("build error"), fmt.Errorf("exit status 1")
+		}
+		return []byte(""), nil
+	}
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // implementer
+			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
+		case 2: // quality reviewer — requests changes
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		case 3: // retry agent
+			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
+		case 4: // quality reviewer — approves (verify non-blocking, so we get here)
+			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+		default: // functional reviewer
+			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	cfg := verifyLoopConfig(false) // Blocking = false → proceeds despite verify failure
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want implemented when verify is non-blocking after quality-gate retry (err: %v)", outcome.Status, outcome.Err)
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts the existing verify-phase logic from `ProcessIssue` into a `runVerifyPhase` helper in `internal/agent/loop.go`
- Calls `runVerifyPhase` after each quality-gate retry (CHANGES_REQUESTED path), so changes made by the retry agent are validated before the next quality review cycle
- Existing initial verify step is unchanged in behaviour; the refactor is a pure extraction

## Implementation Notes

### Approach
The verify logic that runs between guard rails and quality review was extracted into `runVerifyPhase`. This function handles both module-based (`cfg.Modules != nil`) and single-module verify paths, including optional verify-fix cycles. The extracted helper is called in two places:
1. After the initial implement step (replacing the previous inline code)
2. After each quality-gate retry — the new addition per this issue

### Key Decisions
- **Extraction rather than duplication**: The inline verify block was ~180 lines. Duplicating it in the quality gate retry case would have made the code harder to maintain. Extraction into a helper eliminates the duplication with no behavioral change to existing paths.
- **Error wrapping in retry path**: Errors from `runVerifyPhase` in the quality-gate retry case are wrapped with `"verify after quality-gate retry: %w"` to give operators a clear signal about where the failure occurred.
- **`fixCycles` accumulation**: Fix cycles from quality-gate retry verify runs are accumulated into the same `fixCycles` counter as the initial verify, so the risk classifier sees the full picture.
- **No new config fields**: Existing `verify.blocking` and `verify.max_fix_attempts` settings govern both the initial and post-retry verify runs.

### Known Limitations
- Non-blocking verify failures after a quality-gate retry log a warning and let the next quality review cycle proceed. This mirrors the initial verify's non-blocking behavior but may result in quality reviews on code that doesn't build — this is intentional per the issue spec and the existing non-blocking verify contract.

### Architecture
Only the **orchestration** layer (`internal/agent/loop.go`) was modified. No new layer dependencies were introduced. The `runVerifyPhase` helper is unexported and lives in the same package.

Closes #308