### PR TITLE
feat(dashboard): add polling to review chain panel in issue detail view

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -72,6 +72,7 @@ type IssueDetailData struct {
 	PRLink          string
 	IssueLink       string
 	RunURL          string // link back to run detail page
+	ReviewChainURL  string // URL for the review chain polling partial
 	ErrorReason     string // failure reason from outcome, shown prominently for failed issues
 	Timeline        []TimelineStepView
 	Punchlist       *rundata.PunchlistData
@@ -418,6 +419,7 @@ func (s *Server) handleIssueDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	issueLink := fmt.Sprintf("https://github.com/%s/%s/issues/%d", owner, repo, issueNum)
 
+	reviewChainURL := fmt.Sprintf("/runs/%s/%s/%s/issues/%d/review-chain", owner, repo, timestamp, issueNum)
 	data := IssueDetailData{
 		Owner:           owner,
 		Repo:            repo,
@@ -430,6 +432,7 @@ func (s *Server) handleIssueDetail(w http.ResponseWriter, r *http.Request) {
 		PRLink:          prLink,
 		IssueLink:       issueLink,
 		RunURL:          runURL,
+		ReviewChainURL:  reviewChainURL,
 		ErrorReason:     found.Outcome.Error,
 		Timeline:        buildTimeline(*found),
 		Punchlist:       found.Punchlist,
@@ -440,6 +443,52 @@ func (s *Server) handleIssueDetail(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	if err := s.tmpl.ExecuteTemplate(&buf, "issue-detail.html", data); err != nil {
 		s.cfg.Logger.Error("rendering issue-detail template", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = buf.WriteTo(w)
+}
+
+func (s *Server) handleReviewChain(w http.ResponseWriter, r *http.Request) {
+	owner := r.PathValue("owner")
+	repo := r.PathValue("repo")
+	timestamp := r.PathValue("timestamp")
+	numberStr := r.PathValue("number")
+
+	issueNum, err := strconv.Atoi(numberStr)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	detail, err := s.reader.LoadRun(owner, repo, timestamp)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			http.NotFound(w, r)
+			return
+		}
+		s.cfg.Logger.Error("loading run for review chain", "error", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	var found *rundata.IssueDetail
+	for i := range detail.Issues {
+		if detail.Issues[i].IssueNumber == issueNum {
+			found = &detail.Issues[i]
+			break
+		}
+	}
+	if found == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	timeline := buildTimeline(*found)
+	var buf bytes.Buffer
+	if err := s.tmpl.ExecuteTemplate(&buf, "review-chain-steps", timeline); err != nil {
+		s.cfg.Logger.Error("rendering review-chain-steps template", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/dashboard/handlers_review_chain_test.go
+++ b/internal/dashboard/handlers_review_chain_test.go
@@ -1,0 +1,224 @@
+package dashboard_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/phs/dark-factory/internal/rundata"
+)
+
+func TestServer_ReviewChain_WithSteps(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{5},
+		StartedAt:    now,
+	})
+
+	writeIssueFiles(t, runDir, 5,
+		rundata.Outcome{IssueNumber: 5, Status: "implemented", PRNumber: 99},
+		rundata.StepResult{Output: "impl trace QUALITY_RESULT=APPROVED", DurationSeconds: 45},
+		rundata.StepResult{Output: "quality trace QUALITY_RESULT=APPROVED", DurationSeconds: 12},
+		rundata.StepResult{Output: "functional trace REVIEW_RESULT=APPROVED", DurationSeconds: 8},
+	)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/5/review-chain", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 500))
+	}
+	body := rr.Body.String()
+
+	if !strings.Contains(body, "Implement") {
+		t.Error("body missing Implement step")
+	}
+	if !strings.Contains(body, "Quality Review") {
+		t.Error("body missing Quality Review step")
+	}
+	if !strings.Contains(body, "Functional Review") {
+		t.Error("body missing Functional Review step")
+	}
+	// Steps with APPROVED should show Passed verdict
+	if !strings.Contains(body, "Passed") {
+		t.Error("body missing Passed verdict")
+	}
+}
+
+func TestServer_ReviewChain_EmptyState(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{7},
+		StartedAt:    now,
+	})
+
+	writeIssueFiles(t, runDir, 7,
+		rundata.Outcome{IssueNumber: 7, Status: "pending"},
+		rundata.StepResult{},
+		rundata.StepResult{},
+		rundata.StepResult{},
+	)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/7/review-chain", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 500))
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "No review chain data recorded") {
+		t.Errorf("body missing empty-state message; got: %q", truncate(body, 300))
+	}
+}
+
+func TestServer_ReviewChain_NotFound_MissingRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	srv := newServer(t, tmpDir)
+
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/nope/20240101-000000/issues/1/review-chain", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestServer_ReviewChain_NotFound_MissingIssue(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/999/review-chain", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestServer_ReviewChain_NotFound_BadIssueNumber(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:      "acme/proj",
+		Milestone: "v1.0",
+		StartedAt: now,
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/notanumber/review-chain", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestServer_ReviewChain_ContentType(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{3},
+		StartedAt:    now,
+	})
+
+	writeIssueFiles(t, runDir, 3,
+		rundata.Outcome{IssueNumber: 3, Status: "implemented"},
+		rundata.StepResult{Output: "done", DurationSeconds: 10},
+		rundata.StepResult{},
+		rundata.StepResult{},
+	)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/3/review-chain", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	ct := rr.Header().Get("Content-Type")
+	if !strings.Contains(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want to contain text/html", ct)
+	}
+}
+
+func TestServer_IssueDetail_HasPollingAttributes(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{5},
+		StartedAt:    now,
+	})
+
+	writeIssueFiles(t, runDir, 5,
+		rundata.Outcome{IssueNumber: 5, Status: "implemented"},
+		rundata.StepResult{Output: "impl trace", DurationSeconds: 45},
+		rundata.StepResult{},
+		rundata.StepResult{},
+	)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/5", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 500))
+	}
+	body := rr.Body.String()
+
+	// Verify HTMX polling attributes are present on the review chain container.
+	if !strings.Contains(body, "review-chain-body") {
+		t.Error("body missing review-chain-body id")
+	}
+	if !strings.Contains(body, "hx-get") {
+		t.Error("body missing hx-get polling attribute")
+	}
+	if !strings.Contains(body, "/review-chain") {
+		t.Error("body missing review-chain URL in hx-get")
+	}
+	if !strings.Contains(body, "every 5s") {
+		t.Error("body missing 5s polling trigger")
+	}
+	if !strings.Contains(body, "htmx.min.js") {
+		t.Error("body missing htmx.min.js script tag")
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -118,6 +118,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /runs/{owner}/{repo}/{timestamp}", s.handleRunDetail)
 	s.mux.HandleFunc("GET /runs/{owner}/{repo}/{timestamp}/issues-table", s.handleIssuesTable)
 	s.mux.HandleFunc("GET /runs/{owner}/{repo}/{timestamp}/issues/{number}", s.handleIssueDetail)
+	s.mux.HandleFunc("GET /runs/{owner}/{repo}/{timestamp}/issues/{number}/review-chain", s.handleReviewChain)
 	s.mux.HandleFunc("GET /runs/{owner}/{repo}/{timestamp}/logs", s.handleRunLogs)
 	s.mux.HandleFunc("GET /runs/{owner}/{repo}/{timestamp}/logs/entries", s.handleRunLogsEntries)
 	s.mux.Handle("GET /static/", http.FileServer(http.FS(content)))

--- a/internal/dashboard/templates/issue-detail.html
+++ b/internal/dashboard/templates/issue-detail.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>godark — Issue #{{.IssueNumber}}</title>
   <link rel="stylesheet" href="/static/style.css">
+  <script src="/static/htmx.min.js"></script>
   <script src="/static/alpine.min.js" defer></script>
 </head>
 <body>
@@ -97,69 +98,12 @@
         <div class="card__header">
           <span class="card__title">Review Chain</span>
         </div>
-        <div class="card__body">
-          {{if .Timeline}}
-          <div class="timeline">
-            {{range .Timeline}}
-            <div class="timeline__item">
-              <div class="timeline__marker timeline__marker--{{.MarkerClass}}"></div>
-              <div class="timeline__content" x-data="{ open: false }">
-                <div class="timeline__header">
-                  <span class="timeline__title">{{.Name}}</span>
-                  <div class="flex gap-2 items-center">
-                    {{if .Flags}}
-                    <div class="quality-flags">
-                      {{range .Flags}}
-                      <span class="quality-flag quality-flag--fail" data-tooltip="{{.Code}}: {{.Message}}">F</span>
-                      {{end}}
-                    </div>
-                    {{end}}
-                    <span class="badge badge--{{.VerdictClass}}">
-                      <span class="badge__dot"></span>
-                      {{.Verdict}}
-                    </span>
-                  </div>
-                </div>
-                <div class="timeline__meta">
-                  <span>{{.Duration}}</span>
-                  <span class="text-muted">&middot;</span>
-                  <span>{{.Cost}}</span>
-                </div>
-                {{if .HasOutput}}
-                <div class="expandable mt-2" x-data="{ outputOpen: false }">
-                  <button class="expandable__trigger" @click="outputOpen = !outputOpen">
-                    <span class="expandable__arrow" :style="outputOpen ? 'transform: rotate(90deg)' : ''">&#9658;</span>
-                    Agent Output
-                  </button>
-                  <div x-show="outputOpen" style="display:none; padding: var(--space-3); background: var(--bg-surface-1); border-top: 1px solid var(--border-muted); overflow-y: auto; max-height: 300px;">
-                    <div class="markdown-body">{{renderMarkdown .Output}}</div>
-                  </div>
-                </div>
-                {{end}}
-                {{if .ToolTrace}}
-                <div class="expandable mt-2" x-data="{ traceOpen: false }">
-                  <button class="expandable__trigger" @click="traceOpen = !traceOpen">
-                    <span class="expandable__arrow" :style="traceOpen ? 'transform: rotate(90deg)' : ''">&#9658;</span>
-                    Tool Trace ({{len .ToolTrace}} calls)
-                  </button>
-                  <div x-show="traceOpen" style="display:none; padding: var(--space-3); background: var(--bg-surface-1); border-top: 1px solid var(--border-muted); overflow-y: auto; max-height: 300px;">
-                    <ol style="margin: 0; padding-left: var(--space-5); font-size: var(--text-sm); font-family: monospace;">
-                      {{range .ToolTrace}}
-                      <li style="margin-bottom: var(--space-1);">{{.}}</li>
-                      {{end}}
-                    </ol>
-                  </div>
-                </div>
-                {{end}}
-              </div>
-            </div>
-            {{end}}
-          </div>
-          {{else}}
-          <div class="empty-state" style="padding: var(--space-10) var(--space-8);">
-            <p class="empty-state__description">No review chain data recorded for this issue.</p>
-          </div>
-          {{end}}
+        <div class="card__body"
+             id="review-chain-body"
+             hx-get="{{.ReviewChainURL}}"
+             hx-trigger="every 5s, visibilitychange[document.visibilityState==='visible'] from:document"
+             hx-swap="innerHTML">
+          {{template "review-chain-steps" .Timeline}}
         </div>
       </div>
 
@@ -281,3 +225,68 @@
   </div>
 </body>
 </html>
+
+{{define "review-chain-steps"}}
+{{if .}}
+<div class="timeline">
+  {{range .}}
+  <div class="timeline__item">
+    <div class="timeline__marker timeline__marker--{{.MarkerClass}}"></div>
+    <div class="timeline__content" x-data="{ open: false }">
+      <div class="timeline__header">
+        <span class="timeline__title">{{.Name}}</span>
+        <div class="flex gap-2 items-center">
+          {{if .Flags}}
+          <div class="quality-flags">
+            {{range .Flags}}
+            <span class="quality-flag quality-flag--fail" data-tooltip="{{.Code}}: {{.Message}}">F</span>
+            {{end}}
+          </div>
+          {{end}}
+          <span class="badge badge--{{.VerdictClass}}">
+            <span class="badge__dot"></span>
+            {{.Verdict}}
+          </span>
+        </div>
+      </div>
+      <div class="timeline__meta">
+        <span>{{.Duration}}</span>
+        <span class="text-muted">&middot;</span>
+        <span>{{.Cost}}</span>
+      </div>
+      {{if .HasOutput}}
+      <div class="expandable mt-2" x-data="{ outputOpen: false }">
+        <button class="expandable__trigger" @click="outputOpen = !outputOpen">
+          <span class="expandable__arrow" :style="outputOpen ? 'transform: rotate(90deg)' : ''">&#9658;</span>
+          Agent Output
+        </button>
+        <div x-show="outputOpen" style="display:none; padding: var(--space-3); background: var(--bg-surface-1); border-top: 1px solid var(--border-muted); overflow-y: auto; max-height: 300px;">
+          <div class="markdown-body">{{renderMarkdown .Output}}</div>
+        </div>
+      </div>
+      {{end}}
+      {{if .ToolTrace}}
+      <div class="expandable mt-2" x-data="{ traceOpen: false }">
+        <button class="expandable__trigger" @click="traceOpen = !traceOpen">
+          <span class="expandable__arrow" :style="traceOpen ? 'transform: rotate(90deg)' : ''">&#9658;</span>
+          Tool Trace ({{len .ToolTrace}} calls)
+        </button>
+        <div x-show="traceOpen" style="display:none; padding: var(--space-3); background: var(--bg-surface-1); border-top: 1px solid var(--border-muted); overflow-y: auto; max-height: 300px;">
+          <ol style="margin: 0; padding-left: var(--space-5); font-size: var(--text-sm); font-family: monospace;">
+            {{range .ToolTrace}}
+            <li style="margin-bottom: var(--space-1);">{{.}}</li>
+            {{end}}
+          </ol>
+        </div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+</div>
+{{else}}
+<div class="empty-state" style="padding: var(--space-10) var(--space-8);">
+  <p class="empty-state__description">No review chain data recorded for this issue.</p>
+</div>
+{{end}}
+{{end}}


### PR DESCRIPTION
Closes #309

## Summary

- Extract the review chain timeline into a reusable `review-chain-steps` named template
- Add a new partial endpoint `GET /runs/{owner}/{repo}/{timestamp}/issues/{number}/review-chain` serving only the timeline HTML
- Add HTMX polling (every 5s + visibilitychange) to the review chain card body so it refreshes in real time
- Add `htmx.min.js` to `issue-detail.html` head (was previously missing, blocking HTMX from working on that page)
- Add `ReviewChainURL` field to `IssueDetailData` for use in the template

## Test plan

- [x] `TestServer_ReviewChain_WithSteps` — partial returns 200 with timeline steps rendered
- [x] `TestServer_ReviewChain_EmptyState` — partial returns empty-state message when no steps recorded
- [x] `TestServer_ReviewChain_NotFound_MissingRun` — 404 when run doesn't exist
- [x] `TestServer_ReviewChain_NotFound_MissingIssue` — 404 when issue number not in run
- [x] `TestServer_ReviewChain_NotFound_BadIssueNumber` — 404 on non-numeric issue number
- [x] `TestServer_ReviewChain_ContentType` — response has `text/html` content type
- [x] `TestServer_IssueDetail_HasPollingAttributes` — full page includes `hx-get`, `every 5s`, `review-chain-body` id, and `htmx.min.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)