### PR TITLE
feat(config): add base_branch config field and --base-branch CLI flag

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -61,6 +61,10 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			v, _ := cmd.Flags().GetString("auto-merge")
 			flags.AutoMerge = &v
 		}
+		if cmd.Flags().Changed("base-branch") {
+			v, _ := cmd.Flags().GetString("base-branch")
+			flags.BaseBranch = &v
+		}
 
 		cfg, err := config.Load(configPath, flags)
 		if err != nil {
@@ -390,6 +394,7 @@ func init() {
 	f.String("config", "godark.yaml", "Path to configuration file")
 	f.String("punchlist", "", "Write manual testing punchlist to this file (always printed to stdout)")
 	f.String("issues", "", "Comma-separated list of issue numbers (e.g. 160,161,162)")
+	f.String("base-branch", "", "Base branch for PRs (overrides repo default branch)")
 
 	rootCmd.AddCommand(implementCmd)
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -43,6 +43,10 @@ each unblocked issue through the implement → review → merge loop.`,
 			v, _ := cmd.Flags().GetString("auto-merge")
 			flags.AutoMerge = &v
 		}
+		if cmd.Flags().Changed("base-branch") {
+			v, _ := cmd.Flags().GetString("base-branch")
+			flags.BaseBranch = &v
+		}
 
 		// Parse milestone/issue locally — these are per-run params, not config.
 		var milestone string
@@ -133,6 +137,7 @@ func init() {
 	f.String("auto-merge", "none", "Merge strategy after approval: none (human merges), low_risk (auto-merge small/safe PRs), all (auto-merge everything)")
 	f.String("config", "godark.yaml", "Path to configuration file")
 	f.String("punchlist", "", "Write manual testing punchlist to this file (always printed to stdout)")
+	f.String("base-branch", "", "Base branch for PRs (overrides repo default branch)")
 
 	rootCmd.AddCommand(runCmd)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,8 +137,9 @@ type Config struct {
 
 	NoSandbox              bool   `yaml:"no_sandbox"`
 	AutoMerge              string `yaml:"auto_merge"`
+	BaseBranch             string `yaml:"base_branch"`
 	QualityStrictnessDecay bool   `yaml:"quality_strictness_decay"`
-	EnforceArchitecture    bool `yaml:"enforce_architecture"`
+	EnforceArchitecture    bool   `yaml:"enforce_architecture"`
 
 	// AuthPreference controls which Anthropic auth token is preferred when both
 	// ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN are set.
@@ -205,6 +206,7 @@ type CLIFlags struct {
 	MaxRetries *int
 	NoSandbox  *bool
 	AutoMerge  *string
+	BaseBranch *string
 	Config     string
 }
 
@@ -275,6 +277,9 @@ func applyFlags(cfg *Config, flags CLIFlags) {
 	}
 	if flags.AutoMerge != nil {
 		cfg.AutoMerge = *flags.AutoMerge
+	}
+	if flags.BaseBranch != nil {
+		cfg.BaseBranch = *flags.BaseBranch
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1546,6 +1546,72 @@ func TestNotifyMissingEnvVarResolvesToEmpty(t *testing.T) {
 	}
 }
 
+// --- BaseBranch tests ---
+
+func TestBaseBranchDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.BaseBranch != "" {
+		t.Errorf("BaseBranch = %q, want empty string", cfg.BaseBranch)
+	}
+}
+
+func TestBaseBranchFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+base_branch: my-feature
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.BaseBranch != "my-feature" {
+		t.Errorf("BaseBranch = %q, want %q", cfg.BaseBranch, "my-feature")
+	}
+}
+
+func TestBaseBranchFlagOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+base_branch: yaml-branch
+`)
+
+	v := "flag-branch"
+	cfg, err := Load(path, CLIFlags{BaseBranch: &v})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.BaseBranch != "flag-branch" {
+		t.Errorf("BaseBranch = %q, want %q (flag should override)", cfg.BaseBranch, "flag-branch")
+	}
+}
+
+func TestBaseBranchFlagNotSetPreservesYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+base_branch: yaml-branch
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.BaseBranch != "yaml-branch" {
+		t.Errorf("BaseBranch = %q, want %q (YAML value should be preserved)", cfg.BaseBranch, "yaml-branch")
+	}
+}
+
 // TestClaudeFlagsIgnored verifies that a YAML file containing the legacy
 // claude_flags field loads without error. The field is silently ignored for
 // backward compatibility.


### PR DESCRIPTION
Closes #311

## Summary
- Adds `BaseBranch string` field (yaml: `base_branch`) to `Config`
- Adds `BaseBranch *string` to `CLIFlags` with `applyFlags()` handling
- Adds `--base-branch` flag to `implement` and `run` commands
- Default is `""` — existing behavior unchanged

## Implementation Notes

### Approach
Following the same pointer-in-CLIFlags pattern used by `Repo`, `AutoMerge`, and `NoSandbox`: `BaseBranch *string` in `CLIFlags` lets `applyFlags()` distinguish "flag not passed" (nil) from "flag passed as empty string" (pointer to ""). The `cmd.Flags().Changed("base-branch")` guard ensures the YAML value is preserved when the flag is absent.

### Key Decisions
- No validation added — the issue spec explicitly states "No validation needed - empty means 'not configured'"
- Flag description is consistent with existing flag descriptions in the same commands
- Field placement in `Config` is adjacent to `AutoMerge` for logical grouping of workflow-control fields

### Known Limitations
- `BaseBranch` is stored in config but not yet consumed by the branch-creation or PR-targeting logic (that wiring is presumably a follow-on issue)

### Architecture
Only two layers are touched:
- **foundation** (`internal/config/`) — `Config` struct and `CLIFlags` struct additions; no new dependencies
- **cmd** (`internal/cmd/`) — flag registration and wiring; cmd may depend on foundation per architecture rules

No cross-layer dependency violations introduced.