### PR TITLE
feat(agent): pass --base flag to gh pr create when BaseBranch is set

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -138,6 +138,7 @@ func newPromptData(issue github.Issue, cfg *config.Config, slug string) PromptDa
 		ArchitectureJSON:       readFileOrEmpty(cfg.ArchitectureJSON),
 		ConventionsDocContent:  readFileOrEmpty(cfg.ConventionsDoc),
 		ModuleContext:          buildModuleContext(cfg.Modules),
+		BaseBranch:             cfg.BaseBranch,
 	}
 }
 

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -51,6 +51,10 @@ type PromptData struct {
 	// ReviewFeedback holds human reviewer comments injected directly into the
 	// retry prompt. Non-empty only for watch-initiated fix cycles.
 	ReviewFeedback string
+	// BaseBranch, when non-empty, is the target branch for PRs. Prompts use
+	// this to branch off origin/<BaseBranch> and pass --base <BaseBranch> to
+	// gh pr create.
+	BaseBranch string
 }
 
 // loadPromptFile reads a prompt from the config path if set, otherwise from

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -660,3 +660,159 @@ func TestRenderPrompt_VerifyErrorsField(t *testing.T) {
 		t.Errorf("RenderPrompt() = %q, want %q", result, "errors: "+errText)
 	}
 }
+
+func TestImplementerPrompt_BaseBranchSet_IncludesBaseFlag(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		BuildCommand:   "make build",
+		TestCommand:    "make test",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "test-issue",
+		BaseBranch:     "feature/foo",
+	}
+	rendered, err := RenderPrompt(p.Implementer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "--base feature/foo") {
+		t.Error("implementer prompt should contain '--base feature/foo' when BaseBranch is set")
+	}
+}
+
+func TestImplementerPrompt_BaseBranchEmpty_NoBaseFlag(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		BuildCommand:   "make build",
+		TestCommand:    "make test",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "test-issue",
+		BaseBranch:     "",
+	}
+	rendered, err := RenderPrompt(p.Implementer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if strings.Contains(rendered, "--base") {
+		t.Error("implementer prompt should not contain '--base' when BaseBranch is empty")
+	}
+}
+
+func TestImplementerPrompt_BaseBranchSet_CheckoutFromOrigin(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		BuildCommand:   "make build",
+		TestCommand:    "make test",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "test-issue",
+		BaseBranch:     "feature/foo",
+	}
+	rendered, err := RenderPrompt(p.Implementer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "git checkout -b 1-test-issue origin/feature/foo") {
+		t.Error("implementer prompt should contain 'git checkout -b <branch> origin/feature/foo' when BaseBranch is set")
+	}
+}
+
+func TestImplementerPrompt_BaseBranchEmpty_CheckoutWithoutOrigin(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		BuildCommand:   "make build",
+		TestCommand:    "make test",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "test-issue",
+		BaseBranch:     "",
+	}
+	rendered, err := RenderPrompt(p.Implementer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "git checkout -b 1-test-issue") {
+		t.Error("implementer prompt should contain 'git checkout -b <branch>' when BaseBranch is empty")
+	}
+	if strings.Contains(rendered, "origin/") {
+		t.Error("implementer prompt should not reference 'origin/' when BaseBranch is empty")
+	}
+}
+
+func TestSpecGeneratorPrompt_BaseBranchSet_CheckoutFromOrigin(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		Slug:           "test-issue",
+		BaseBranch:     "feature/foo",
+	}
+	rendered, err := RenderPrompt(p.SpecGenerator, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "git checkout -b 1-test-issue origin/feature/foo") {
+		t.Error("spec_generator prompt should contain 'git checkout -b <branch> origin/feature/foo' when BaseBranch is set")
+	}
+}
+
+func TestSpecGeneratorPrompt_BaseBranchEmpty_CheckoutWithoutOrigin(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		Slug:           "test-issue",
+		BaseBranch:     "",
+	}
+	rendered, err := RenderPrompt(p.SpecGenerator, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "git checkout -b 1-test-issue") {
+		t.Error("spec_generator prompt should contain 'git checkout -b <branch>' when BaseBranch is empty")
+	}
+	if strings.Contains(rendered, "origin/") {
+		t.Error("spec_generator prompt should not reference 'origin/' when BaseBranch is empty")
+	}
+}

--- a/prompts/implementer.txt
+++ b/prompts/implementer.txt
@@ -21,6 +21,8 @@ Before writing any code:
 CRITICAL RULES:
 {{- if .BranchExists}}
 - Check out the existing feature branch: git fetch origin && git checkout {{.IssueNumber}}-{{.Slug}}
+{{- else if .BaseBranch}}
+- Create a feature branch: git fetch origin && git checkout -b {{.IssueNumber}}-{{.Slug}} origin/{{.BaseBranch}}
 {{- else}}
 - Create a feature branch: git checkout -b {{.IssueNumber}}-{{.Slug}}
 {{- end}}
@@ -41,7 +43,11 @@ Implementation steps:
 4. Run tests: {{.TestCommand}}
 {{- end}}
 5. Commit with message including "Closes #{{.IssueNumber}}"
+{{- if .BaseBranch}}
+6. Push the branch and open a pull request targeting {{.BaseBranch}}: gh pr create --base {{.BaseBranch}} ...
+{{- else}}
 6. Push the branch and open a pull request
+{{- end}}
 
 When opening the pull request, post a PR comment with the following format so
 the reviewer agent can find your notes:

--- a/prompts/spec_generator.txt
+++ b/prompts/spec_generator.txt
@@ -11,7 +11,11 @@ Before writing the spec:
 3. Read existing scenario specs in {{.ScenarioDir}} to understand the expected format
 
 CRITICAL RULES:
+{{- if .BaseBranch}}
+- Create a feature branch: git fetch origin && git checkout -b {{.IssueNumber}}-{{.Slug}} origin/{{.BaseBranch}}
+{{- else}}
 - Create a feature branch: git checkout -b {{.IssueNumber}}-{{.Slug}}
+{{- end}}
 - Never commit directly to main
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
 - Do NOT modify existing files in {{.ScenarioDir}}


### PR DESCRIPTION
## Summary

- Add `BaseBranch string` to `PromptData` and wire it from `cfg.BaseBranch` in `newPromptData()`
- Update `prompts/implementer.txt`: branch off `origin/<BaseBranch>` and pass `--base <BaseBranch>` to `gh pr create` when set
- Update `prompts/spec_generator.txt`: branch off `origin/<BaseBranch>` when set
- Add 6 unit tests covering both set and empty `BaseBranch` for all new behaviours

## Test plan

- [x] `TestImplementerPrompt_BaseBranchSet_IncludesBaseFlag` — `--base feature/foo` present
- [x] `TestImplementerPrompt_BaseBranchEmpty_NoBaseFlag` — no `--base` when empty
- [x] `TestImplementerPrompt_BaseBranchSet_CheckoutFromOrigin` — `git checkout -b <branch> origin/feature/foo`
- [x] `TestImplementerPrompt_BaseBranchEmpty_CheckoutWithoutOrigin` — `git checkout -b <branch>` only
- [x] `TestSpecGeneratorPrompt_BaseBranchSet_CheckoutFromOrigin`
- [x] `TestSpecGeneratorPrompt_BaseBranchEmpty_CheckoutWithoutOrigin`
- [x] All existing tests continue to pass (`go test ./...`)

Closes #312

## Implementation Notes

### Approach
Used Go template `{{else if .BaseBranch}}` and `{{if .BaseBranch}}` conditionals in the prompt templates to add `BaseBranch`-aware behaviour while keeping the existing code path completely unchanged when `BaseBranch` is empty.

### Key Decisions
- Added `BaseBranch` to `PromptData` rather than computing it inline in templates — consistent with how all other config values flow through the data struct.
- The `newPromptData()` helper is the single wiring point; all four callers (Implement, Retry, VerifyFix, GenerateSpec) inherit the field automatically.
- Template syntax uses `{{else if .BaseBranch}}` for the branch-creation block so the three cases (branch exists, base branch set, neither) are mutually exclusive and clear.

### Known Limitations
- The `ImplementerRetry` and `VerifyFix` prompts don't have branch-creation instructions, so they need no change.
- The `--base` flag text in the implementer prompt includes `...` as a placeholder for the rest of the `gh pr create` arguments — the agent fills those in at runtime.

### Architecture
Only the `orchestration` layer (`internal/agent/`) and the `content` layer (`prompts/`) were touched. `BaseBranch` already existed in `internal/config/` (foundation layer, added in #320) — this change simply threads it through to `PromptData` and into the templates, respecting the existing dependency flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)