### PR TITLE
feat(prompts): use BaseBranch in never-commit-directly rule

### DIFF
--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -816,3 +816,101 @@ func TestSpecGeneratorPrompt_BaseBranchEmpty_CheckoutWithoutOrigin(t *testing.T)
 		t.Error("spec_generator prompt should not reference 'origin/' when BaseBranch is empty")
 	}
 }
+
+func TestImplementerPrompt_BaseBranchSet_NeverCommitToBaseBranch(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		BuildCommand:   "make build",
+		TestCommand:    "make test",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "test-issue",
+		BaseBranch:     "feature/foo",
+	}
+	rendered, err := RenderPrompt(p.Implementer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "Never commit directly to feature/foo") {
+		t.Error("implementer prompt should contain 'Never commit directly to feature/foo' when BaseBranch is set")
+	}
+}
+
+func TestImplementerPrompt_BaseBranchEmpty_NeverCommitToMain(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		BuildCommand:   "make build",
+		TestCommand:    "make test",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "test-issue",
+		BaseBranch:     "",
+	}
+	rendered, err := RenderPrompt(p.Implementer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "Never commit directly to main") {
+		t.Error("implementer prompt should contain 'Never commit directly to main' when BaseBranch is empty")
+	}
+}
+
+func TestSpecGeneratorPrompt_BaseBranchSet_NeverCommitToBaseBranch(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		Slug:           "test-issue",
+		BaseBranch:     "feature/foo",
+	}
+	rendered, err := RenderPrompt(p.SpecGenerator, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "Never commit directly to feature/foo") {
+		t.Error("spec_generator prompt should contain 'Never commit directly to feature/foo' when BaseBranch is set")
+	}
+}
+
+func TestSpecGeneratorPrompt_BaseBranchEmpty_NeverCommitToMain(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		Slug:           "test-issue",
+		BaseBranch:     "",
+	}
+	rendered, err := RenderPrompt(p.SpecGenerator, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "Never commit directly to main") {
+		t.Error("spec_generator prompt should contain 'Never commit directly to main' when BaseBranch is empty")
+	}
+}

--- a/prompts/implementer.txt
+++ b/prompts/implementer.txt
@@ -26,7 +26,7 @@ CRITICAL RULES:
 {{- else}}
 - Create a feature branch: git checkout -b {{.IssueNumber}}-{{.Slug}}
 {{- end}}
-- Never commit directly to main
+- Never commit directly to {{if .BaseBranch}}{{.BaseBranch}}{{else}}main{{end}}
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
 - Do NOT modify files in {{.ScenarioDir}} or {{.ReviewDir}}
 {{- if .GeneratedPaths}}

--- a/prompts/spec_generator.txt
+++ b/prompts/spec_generator.txt
@@ -16,7 +16,7 @@ CRITICAL RULES:
 {{- else}}
 - Create a feature branch: git checkout -b {{.IssueNumber}}-{{.Slug}}
 {{- end}}
-- Never commit directly to main
+- Never commit directly to {{if .BaseBranch}}{{.BaseBranch}}{{else}}main{{end}}
 - Do NOT modify any protected paths: {{.ProtectedPaths}}
 - Do NOT modify existing files in {{.ScenarioDir}}
 


### PR DESCRIPTION
Closes #313

## Summary
- Replace hardcoded `main` in `prompts/implementer.txt` with `{{if .BaseBranch}}{{.BaseBranch}}{{else}}main{{end}}`
- Same replacement in `prompts/spec_generator.txt`
- Add 4 unit tests covering all acceptance criteria from the issue

## Test plan
- [ ] `TestImplementerPrompt_BaseBranchSet_NeverCommitToBaseBranch` — rendered prompt contains "Never commit directly to feature/foo" when BaseBranch is "feature/foo"
- [ ] `TestImplementerPrompt_BaseBranchEmpty_NeverCommitToMain` — rendered prompt contains "Never commit directly to main" when BaseBranch is ""
- [ ] `TestSpecGeneratorPrompt_BaseBranchSet_NeverCommitToBaseBranch` — same as implementer with BaseBranch set
- [ ] `TestSpecGeneratorPrompt_BaseBranchEmpty_NeverCommitToMain` — same as implementer with empty BaseBranch
- [ ] All existing `internal/agent` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)