### PR TITLE
feat(rundata): track base branch in run data

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -100,7 +100,7 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 
 		// Create RunDataWriter first to get the run directory for the log file.
 		var hook agent.RunDataHook
-		writer, writerErr := rundata.New(cfg.Repo, "", issueNums)
+		writer, writerErr := rundata.New(cfg.Repo, "", issueNums, cfg.BaseBranch)
 		var logDir string
 		if writerErr != nil {
 			// Fall back to a private temp directory so each run is isolated.

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -201,7 +201,7 @@ func handleChangesRequested(ctx context.Context, cfg *config.Config, prompts *ag
 	feedback := buildFeedback(review.Body, watchFetchReviewCommentsFn, cfg.Repo, pr.Number, review.ID, logger)
 
 	// Create a run data writer for this watch-initiated fix cycle.
-	writer, writerErr := watchNewWriterFn(cfg.Repo, "", []int{issueNum})
+	writer, writerErr := watchNewWriterFn(cfg.Repo, "", []int{issueNum}, cfg.BaseBranch)
 	if writerErr != nil {
 		logger.Warn("failed to create run data writer", "err", writerErr)
 	}

--- a/internal/cmd/watch_test.go
+++ b/internal/cmd/watch_test.go
@@ -43,7 +43,7 @@ func stubWatchSeams(t *testing.T) {
 		return &agent.Result{SessionID: "sess-stub"}, nil
 	}
 	watchFindSessionIDFn = func(_ string, _ int) (string, error) { return "", nil }
-	watchNewWriterFn = func(repo, milestone string, issueNumbers []int) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string) (*rundata.Writer, error) { return nil, nil }
 	watchFetchReviewCommentsFn = func(_ string, _ int, _ int) ([]string, error) { return nil, nil }
 	watchFetchIssueFn = func(_ string, _ int) (github.Issue, error) {
 		return github.Issue{Number: 42, Title: "test issue"}, nil
@@ -317,7 +317,7 @@ func TestHandleChangesRequested_FeedbackFed(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn
@@ -363,7 +363,7 @@ func TestHandleChangesRequested_SessionResumed(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn
@@ -408,7 +408,7 @@ func TestHandleChangesRequested_LabelsSwapped(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn
@@ -483,7 +483,7 @@ func TestHandleChangesRequested_NoSessionID(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn
@@ -529,10 +529,10 @@ func TestHandleChangesRequested_RunDataWritten(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(repo, milestone string, issueNumbers []int) (*rundata.Writer, error) {
+	watchNewWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string) (*rundata.Writer, error) {
 		writerCreated = true
 		// Use a custom base dir to verify the call actually happened.
-		w, err := rundata.NewWithBase(base, repo, milestone, issueNumbers)
+		w, err := rundata.NewWithBase(base, repo, milestone, issueNumbers, baseBranch)
 		return w, err
 	}
 	defer func() { watchNewWriterFn = origNewWriter }()
@@ -589,7 +589,7 @@ func TestHandleChangesRequested_MultipleCommentsConcatenated(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -89,7 +89,7 @@ func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone
 	if !dryRun {
 		issueNums := issueNumbers(issues)
 		var writerErr error
-		writer, writerErr = newRunDataWriterFn(cfg.Repo, milestone, issueNums)
+		writer, writerErr = newRunDataWriterFn(cfg.Repo, milestone, issueNums, cfg.BaseBranch)
 		if writerErr != nil {
 			logger.Warn("failed to create run data writer, run data will not be recorded", "error", writerErr)
 		} else if runLogger, logErr := logging.NewLogger(writer.Dir()); logErr == nil {
@@ -537,8 +537,8 @@ func BuildDialogueEntries(bodies []string) []rundata.DialogueEntry {
 }
 
 // newRunDataWriterFn creates a new RunDataWriter. Replaceable for testing.
-var newRunDataWriterFn = func(repo, milestone string, issueNumbers []int) (*rundata.Writer, error) {
-	return rundata.New(repo, milestone, issueNumbers)
+var newRunDataWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string) (*rundata.Writer, error) {
+	return rundata.New(repo, milestone, issueNumbers, baseBranch)
 }
 
 // CommandRunner executes a command and returns its combined output.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -246,7 +246,7 @@ func TestAllBlocked(t *testing.T) {
 	// Run creates a RunDataWriter when dryRun=false; disable it for this test.
 	origWriter := newRunDataWriterFn
 	t.Cleanup(func() { newRunDataWriterFn = origWriter })
-	newRunDataWriterFn = func(repo, milestone string, issueNums []int) (*rundata.Writer, error) {
+	newRunDataWriterFn = func(repo, milestone string, issueNums []int, baseBranch string) (*rundata.Writer, error) {
 		return nil, fmt.Errorf("disabled in test")
 	}
 
@@ -589,7 +589,7 @@ func TestProcessIssues_FinalizeRunCalled(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	writer, err := rundata.New("owner/repo", "test-milestone", []int{10, 11})
+	writer, err := rundata.New("owner/repo", "test-milestone", []int{10, 11}, "")
 	if err != nil {
 		t.Fatalf("rundata.New: %v", err)
 	}
@@ -713,7 +713,7 @@ func TestProcessIssues_WritesDialogue(t *testing.T) {
 
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
-	writer, err := rundata.New("owner/repo", "test-milestone", []int{5})
+	writer, err := rundata.New("owner/repo", "test-milestone", []int{5}, "")
 	if err != nil {
 		t.Fatalf("rundata.New: %v", err)
 	}

--- a/internal/rundata/reader_test.go
+++ b/internal/rundata/reader_test.go
@@ -490,7 +490,7 @@ func TestReadDialogueMissingFile(t *testing.T) {
 func TestReadDialogueRoundTrip(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("HOME", base)
-	w, err := New("owner/repo", "Phase 7", []int{5})
+	w, err := New("owner/repo", "Phase 7", []int{5}, "")
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -13,6 +13,7 @@ import (
 type RunMeta struct {
 	Repo         string      `json:"repo"`
 	Milestone    string      `json:"milestone"`
+	BaseBranch   string      `json:"base_branch,omitempty"`
 	IssueNumbers []int       `json:"issue_numbers"`
 	IssueDeps    []IssueDep  `json:"issue_deps,omitempty"`
 	StartedAt    time.Time   `json:"started_at"`
@@ -81,17 +82,17 @@ type Writer struct {
 // directory under ~/.godark/runs/<owner>/<repo>/<YYYYMMDD-HHMMSS>/ and writes
 // an initial run.json. Repo must be in "owner/name" format; components
 // containing ".." or path separators are rejected.
-func New(repo, milestone string, issueNumbers []int) (*Writer, error) {
+func New(repo, milestone string, issueNumbers []int, baseBranch string) (*Writer, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("getting home dir: %w", err)
 	}
-	return NewWithBase(filepath.Join(home, ".godark", "runs"), repo, milestone, issueNumbers)
+	return NewWithBase(filepath.Join(home, ".godark", "runs"), repo, milestone, issueNumbers, baseBranch)
 }
 
 // NewWithBase creates a new Writer using a custom base directory instead of
 // the default ~/.godark/runs/. Intended for testing.
-func NewWithBase(baseDir, repo, milestone string, issueNumbers []int) (*Writer, error) {
+func NewWithBase(baseDir, repo, milestone string, issueNumbers []int, baseBranch string) (*Writer, error) {
 	owner, repoName, err := validateRepo(repo)
 	if err != nil {
 		return nil, err
@@ -115,6 +116,7 @@ func NewWithBase(baseDir, repo, milestone string, issueNumbers []int) (*Writer, 
 	meta := RunMeta{
 		Repo:         repo,
 		Milestone:    milestone,
+		BaseBranch:   baseBranch,
 		IssueNumbers: issueNumbers,
 		StartedAt:    now,
 	}

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -14,7 +14,7 @@ import (
 func newWithBase(t *testing.T, base, repo, milestone string, issueNumbers []int) (*Writer, error) {
 	t.Helper()
 	t.Setenv("HOME", base)
-	return New(repo, milestone, issueNumbers)
+	return New(repo, milestone, issueNumbers, "")
 }
 
 func TestRunDirectoryCreated(t *testing.T) {
@@ -773,7 +773,7 @@ func TestPathTraversalRejected(t *testing.T) {
 	for _, repo := range cases {
 		base := t.TempDir()
 		t.Setenv("HOME", base)
-		_, err := New(repo, "Phase 7", []int{1})
+		_, err := New(repo, "Phase 7", []int{1}, "")
 		if err == nil {
 			t.Errorf("New(%q) should return error for path traversal, got nil", repo)
 		}
@@ -813,5 +813,67 @@ func TestWriteRiskAssessmentCreatesFile(t *testing.T) {
 	}
 	if len(written.Gates) != 2 {
 		t.Errorf("Gates length = %d, want 2", len(written.Gates))
+	}
+}
+
+func TestBaseBranchWrittenToRunJSON(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("HOME", base)
+	w, err := New("owner/repo", "Phase 7", []int{1}, "feature/foo")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(w.Dir(), "run.json"))
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+
+	var meta RunMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("parsing run.json: %v", err)
+	}
+
+	if meta.BaseBranch != "feature/foo" {
+		t.Errorf("BaseBranch = %q, want %q", meta.BaseBranch, "feature/foo")
+	}
+}
+
+func TestBaseBranchOmittedWhenEmpty(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("HOME", base)
+	w, err := New("owner/repo", "Phase 7", []int{1}, "")
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(w.Dir(), "run.json"))
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+	if _, ok := raw["base_branch"]; ok {
+		t.Error("base_branch key should be omitted from JSON when empty")
+	}
+}
+
+func TestBaseBranchMissingInOldDataDeserializesCleanly(t *testing.T) {
+	// Simulate old run.json without base_branch field.
+	oldJSON := []byte(`{"repo":"owner/repo","milestone":"Phase 7","issue_numbers":[1],"started_at":"2024-01-01T00:00:00Z"}`)
+
+	var meta RunMeta
+	if err := json.Unmarshal(oldJSON, &meta); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+
+	if meta.BaseBranch != "" {
+		t.Errorf("BaseBranch = %q, want empty string for old data", meta.BaseBranch)
+	}
+	if meta.Repo != "owner/repo" {
+		t.Errorf("Repo = %q, want %q", meta.Repo, "owner/repo")
 	}
 }


### PR DESCRIPTION
Closes #315

## Summary

- Adds `BaseBranch string` field (json tag `base_branch,omitempty`) to `RunMeta` in `internal/rundata/writer.go`
- Updates `New()` and `NewWithBase()` to accept and store `baseBranch`
- Threads `cfg.BaseBranch` through all call sites: `implement.go`, `watch.go`, and `orchestrator.go`
- Adds three new test cases covering write-with, write-without, and backwards-compat deserialization

## Test plan

- [ ] `TestBaseBranchWrittenToRunJSON` — verifies `run.json` contains `"base_branch":"feature/foo"` when configured
- [ ] `TestBaseBranchOmittedWhenEmpty` — verifies `base_branch` key is absent when empty
- [ ] `TestBaseBranchMissingInOldDataDeserializesCleanly` — verifies old run data without `base_branch` loads cleanly
- [ ] All existing rundata, orchestrator, and cmd tests continue to pass

## Implementation Notes

### Approach
Added `BaseBranch string` with `json:"base_branch,omitempty"` to `RunMeta`. The `omitempty` tag ensures backwards compatibility: old `run.json` files lacking the field deserialize with an empty `BaseBranch`, and new files with an empty configured branch omit the key entirely. The field is stored in the initial `run.json` write; subsequent `FinalizeRun` and `WriteIssueDeps` operations preserve it automatically through JSON round-trips.

### Key Decisions
- No `baseBranch` field added to the `Writer` struct itself — `RunMeta` in `run.json` is the single source of truth, and round-trip JSON reads/writes preserve it automatically.
- `newRunDataWriterFn` in `orchestrator.go` had its signature updated to include `baseBranch` (consistent with the pattern used for other parameters).
- `watchNewWriterFn` in `watch.go` was set to `rundata.New` directly, so its inferred type updates automatically.

### Known Limitations
None. All acceptance criteria from the issue are satisfied.

### Architecture
Only the `domain` layer (`internal/rundata`) and the `cmd`/`orchestration` layers above it were modified. No layer dependency rules were violated: `cmd` and `orchestration` may depend on `domain`, and `rundata` (domain) has no upward dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)