### PR TITLE
feat(dashboard): surface base branch in run detail page

### DIFF
--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -1361,3 +1361,70 @@ func TestServer_IssueDetail_SpecGeneratorAbsentOmitted(t *testing.T) {
 		t.Error("body should not contain Spec Generator step when no spec-generator.json exists")
 	}
 }
+
+func TestServer_RunDetail_BaseBranch_Shown(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		BaseBranch:   "feature/foo",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+	})
+
+	writeIssueFiles(t, runDir, 1,
+		rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+		rundata.StepResult{Output: "ok", DurationSeconds: 5},
+		rundata.StepResult{},
+		rundata.StepResult{},
+	)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts, nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "feature/foo") {
+		t.Errorf("body missing base branch; got: %q", truncate(body, 500))
+	}
+}
+
+func TestServer_RunDetail_BaseBranch_Hidden_When_Empty(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+	})
+
+	writeIssueFiles(t, runDir, 1,
+		rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+		rundata.StepResult{Output: "ok", DurationSeconds: 5},
+		rundata.StepResult{},
+		rundata.StepResult{},
+	)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts, nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "Base branch") {
+		t.Errorf("body should not contain 'Base branch' when BaseBranch is empty; got: %q", truncate(body, 500))
+	}
+}

--- a/internal/dashboard/templates/run-detail.html
+++ b/internal/dashboard/templates/run-detail.html
@@ -70,7 +70,7 @@
     <main class="main">
       <div class="page-header animate-in">
         <h1 class="page-header__title">{{.Meta.Repo}}</h1>
-        <p class="page-header__subtitle">{{.Meta.Milestone}} &middot; {{.Timestamp}}</p>
+        <p class="page-header__subtitle">{{.Meta.Milestone}} &middot; {{.Timestamp}}{{if .Meta.BaseBranch}} &middot; Base branch: {{.Meta.BaseBranch}}{{end}}</p>
       </div>
 
       {{if and .Meta.Summary .Meta.Summary.AbortReason}}


### PR DESCRIPTION
Closes #316

## Summary
- Add conditional display of `BaseBranch` in the run detail page subtitle
- No backend changes — `RunDetailData` already embeds `RunMeta` which carries `BaseBranch`
- Two new tests: one asserting the value renders when set, one asserting nothing renders when empty

## Test plan
- [x] `TestServer_RunDetail_BaseBranch_Shown` — run with `BaseBranch: "feature/foo"` renders page containing `"feature/foo"`
- [x] `TestServer_RunDetail_BaseBranch_Hidden_When_Empty` — run with empty `BaseBranch` does not render `"Base branch"` text

## Implementation Notes

### Approach
`RunDetailData` already embeds `rundata.RunMeta`, and `RunMeta.BaseBranch` is populated from `run.json` by the existing reader. The only change needed was a single-line conditional in the template subtitle.

### Key Decisions
- Appended `· Base branch: <value>` inline to the existing subtitle (`{{.Meta.Milestone}} · {{.Timestamp}}`), matching the style of the existing metadata display. No new HTML elements or CSS classes were introduced, keeping the change minimal.

### Known Limitations
None. The feature is complete per the acceptance criteria.

### Architecture
Only the **presentation** layer (`internal/dashboard/`) was touched:
- `internal/dashboard/templates/run-detail.html` — template change only
- `internal/dashboard/handlers_detail_test.go` — new tests

No new dependencies introduced. The presentation layer correctly reads from the domain model (`rundata.RunMeta`) without depending on orchestration, service, or infrastructure layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)