### PR TITLE
feat(lint): add misspell linter to .golangci.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,6 +5,7 @@ linters:
     - gosec
     - cyclop
     - funlen
+    - misspell
   settings:
     cyclop:
       max-complexity: 18


### PR DESCRIPTION
## Summary

- Add `misspell` to the `linters.enable` list in `.golangci.yml`
- Verified `golangci-lint run ./...` passes with zero issues
- No misspellings found in the codebase

## Test plan

- [ ] `golangci-lint run ./...` reports zero issues
- [ ] All existing tests pass with `go test ./...`

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)