### PR TITLE
feat(doctor): add golangci-lint check when lint_command references it

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/detect"
 	"github.com/phs/dark-factory/internal/doctor"
 	"github.com/spf13/cobra"
@@ -30,7 +31,13 @@ Checks performed:
 			runtime = dp.Runtime.Name
 		}
 
-		checks := doctor.Checks(runtime)
+		// Best-effort config load to obtain lint_command.
+		lintCommand := ""
+		if cfg, err := config.Load("godark.yaml", config.CLIFlags{}); err == nil {
+			lintCommand = cfg.LintCommand
+		}
+
+		checks := doctor.Checks(runtime, lintCommand)
 		passed := doctor.Run(os.Stdout, checks)
 		if !passed {
 			return fmt.Errorf("pre-flight checks failed")

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -50,7 +50,8 @@ func runtimeVersionCmd(runtime string) (string, []string) {
 
 // Checks returns the full ordered list of pre-flight checks. If runtime is
 // non-empty, a toolchain availability check for that runtime is included.
-func Checks(runtime string) []*Check {
+// If lintCommand contains "golangci-lint", a check for that tool is appended.
+func Checks(runtime, lintCommand string) []*Check {
 	checks := []*Check{
 		{
 			Name: "Docker daemon running",
@@ -110,6 +111,17 @@ func Checks(runtime string) []*Check {
 			return err == nil
 		},
 	})
+
+	if strings.Contains(lintCommand, "golangci-lint") {
+		checks = append(checks, &Check{
+			Name: "golangci-lint installed",
+			Fix:  "Install golangci-lint: `brew install golangci-lint` or see https://golangci-lint.run/usage/install/",
+			run: func(ctx context.Context) bool {
+				_, err := CommandRunner(ctx, "golangci-lint", "--version")
+				return err == nil
+			},
+		})
+	}
 
 	return checks
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -50,7 +50,7 @@ func TestRun_AllPass(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	checks := Checks("go")
+	checks := Checks("go", "")
 	passed := Run(&buf, checks)
 
 	if !passed {
@@ -83,7 +83,7 @@ func TestRun_SomeFail(t *testing.T) {
 	EnvLookup = func(key string) string { return "" } // API key missing
 
 	var buf bytes.Buffer
-	checks := Checks("") // no runtime check
+	checks := Checks("", "") // no runtime check, no lint command
 	passed := Run(&buf, checks)
 
 	if passed {
@@ -117,7 +117,7 @@ func TestRun_NoShortCircuit(t *testing.T) {
 	EnvLookup = func(key string) string { return "" }
 
 	var buf bytes.Buffer
-	checks := Checks("go")
+	checks := Checks("go", "")
 	passed := Run(&buf, checks)
 
 	if passed {
@@ -133,7 +133,7 @@ func TestRun_NoShortCircuit(t *testing.T) {
 func TestChecks_WithRuntime(t *testing.T) {
 	runtimes := []string{"go", "flutter", "node", "rust", "elixir", "python"}
 	for _, rt := range runtimes {
-		checks := Checks(rt)
+		checks := Checks(rt, "")
 		// With a runtime we expect 6 checks (4 base + runtime toolchain + python3).
 		if len(checks) != 6 {
 			t.Errorf("runtime=%s: expected 6 checks, got %d", rt, len(checks))
@@ -152,7 +152,7 @@ func TestChecks_WithRuntime(t *testing.T) {
 }
 
 func TestChecks_NoRuntime(t *testing.T) {
-	checks := Checks("")
+	checks := Checks("", "")
 	// Without a runtime: 5 checks (4 base + python3).
 	if len(checks) != 5 {
 		t.Errorf("expected 5 checks without runtime, got %d", len(checks))
@@ -160,10 +160,108 @@ func TestChecks_NoRuntime(t *testing.T) {
 }
 
 func TestChecks_UnknownRuntime(t *testing.T) {
-	checks := Checks("cobol")
+	checks := Checks("cobol", "")
 	// Unknown runtime falls back to 5 checks (no toolchain check added).
 	if len(checks) != 5 {
 		t.Errorf("expected 5 checks for unknown runtime, got %d", len(checks))
+	}
+}
+
+func TestChecks_GolangciLint_Included(t *testing.T) {
+	checks := Checks("", "golangci-lint run ./...")
+	// With golangci-lint in lint_command: 6 checks (5 base + golangci-lint).
+	if len(checks) != 6 {
+		t.Errorf("expected 6 checks with golangci-lint lint_command, got %d", len(checks))
+	}
+	found := false
+	for _, c := range checks {
+		if c.Name == "golangci-lint installed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected golangci-lint check to be included")
+	}
+}
+
+func TestChecks_GolangciLint_NotIncluded(t *testing.T) {
+	checks := Checks("", "staticcheck ./...")
+	// Without golangci-lint in lint_command: 5 checks (no golangci-lint check).
+	if len(checks) != 5 {
+		t.Errorf("expected 5 checks without golangci-lint lint_command, got %d", len(checks))
+	}
+}
+
+func TestRun_GolangciLint_Pass(t *testing.T) {
+	orig := CommandRunner
+	origEnv := EnvLookup
+	defer func() {
+		CommandRunner = orig
+		EnvLookup = origEnv
+	}()
+
+	CommandRunner = stubRunner(
+		"docker info",
+		"gh --version",
+		"gh auth",
+		"python3 --version",
+		"golangci-lint --version",
+	)
+	EnvLookup = func(key string) string {
+		if key == "ANTHROPIC_API_KEY" {
+			return "sk-test"
+		}
+		return ""
+	}
+
+	var buf bytes.Buffer
+	checks := Checks("", "golangci-lint run ./...")
+	passed := Run(&buf, checks)
+
+	if !passed {
+		t.Errorf("expected all checks to pass, output:\n%s", buf.String())
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[PASS] golangci-lint installed") {
+		t.Errorf("expected golangci-lint PASS in output:\n%s", out)
+	}
+}
+
+func TestRun_GolangciLint_Fail(t *testing.T) {
+	orig := CommandRunner
+	origEnv := EnvLookup
+	defer func() {
+		CommandRunner = orig
+		EnvLookup = origEnv
+	}()
+
+	// golangci-lint is not in the pass set — it will fail.
+	CommandRunner = stubRunner(
+		"docker info",
+		"gh --version",
+		"gh auth",
+		"python3 --version",
+	)
+	EnvLookup = func(key string) string {
+		if key == "ANTHROPIC_API_KEY" {
+			return "sk-test"
+		}
+		return ""
+	}
+
+	var buf bytes.Buffer
+	checks := Checks("", "golangci-lint run ./...")
+	passed := Run(&buf, checks)
+
+	if passed {
+		t.Error("expected Run to return false when golangci-lint is missing")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[FAIL] golangci-lint installed") {
+		t.Errorf("expected golangci-lint FAIL in output:\n%s", out)
+	}
+	if !strings.Contains(out, "brew install golangci-lint") {
+		t.Errorf("expected brew install hint in fix message:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Closes #327

## Implementation Notes

### Approach
Extended `doctor.Checks()` with a second `lintCommand string` parameter. When the value contains `"golangci-lint"`, a new check is appended that runs `golangci-lint --version` via the existing `CommandRunner` testability seam. The cmd layer loads config best-effort (same pattern as runtime detection) to extract `LintCommand` and pass it through.

### Key Decisions
- Added `lintCommand` as a plain `string` parameter rather than passing `*config.Config` into the domain layer — this respects the architecture rule that domain must not depend on foundation/infrastructure (config lives in foundation).
- Best-effort config load in `cmd/doctor.go` mirrors the existing best-effort runtime detection pattern; a missing or invalid `godark.yaml` silently results in no golangci-lint check rather than a hard error.
- The check is appended after the Python 3 check so all existing check ordering is preserved.

### Known Limitations
None.

### Architecture
- **domain** (`internal/doctor/`): `Checks()` signature updated to accept `lintCommand string`; no new imports.
- **cmd** (`internal/cmd/doctor.go`): imports `internal/config` (already a valid dependency for the cmd layer) to load lint command; passes it to `doctor.Checks()`.
- No other layers touched.