### PR TITLE
docs: update docs and schemas for structured auto_merge config

### DIFF
--- a/.claude/godark.md
+++ b/.claude/godark.md
@@ -46,7 +46,8 @@ step fails, the verify-fix agent attempts to correct the issue automatically.
 |-------|---------|---------|
 | `max_retries` | Review/fix cycles before escalating to human | `3` |
 | `agent_timeout` | Max wall-clock time per agent run | `30m` |
-| `auto_merge` | Merge strategy after approval: `none`, `low_risk`, `all` | `none` |
+| `auto_merge.feature` | Merge strategy for feature PRs after approval: `none`, `low_risk`, `all` | `none` |
+| `auto_merge.rollup` | Rollup PR handling after a run completes: `none`, `manual`, `auto` | `none` |
 | `no_sandbox` | Run agents on host instead of Docker | `false` |
 
 ### Paths and constraints
@@ -90,7 +91,19 @@ step fails, the verify-fix agent attempts to correct the issue automatically.
 | `wait_for_checks.timeout` | Max time to wait for CI checks to complete |
 | `wait_for_checks.required` | List of CI check names that must pass before merge |
 
-### Risk thresholds (for `auto_merge: low_risk`)
+### Rollup modes (`auto_merge.rollup`)
+
+When godark runs against a non-default base branch, a rollup PR merges the base
+branch into main after all feature PRs are done. The `rollup` field controls
+what godark does with that rollup PR:
+
+| Mode | Feature PRs → base branch | Base branch → main |
+|---|---|---|
+| `none` | godark merges | human does everything (inspects branch, opens PR manually) |
+| `manual` | godark merges | godark opens PR, human reviews and merges |
+| `auto` | godark merges | godark opens PR and merges |
+
+### Risk thresholds (for `auto_merge.feature: low_risk`)
 
 | Field | Purpose | Default |
 |-------|---------|---------|

--- a/.claude/skills/godark-configure-project/godark-config-schema.json
+++ b/.claude/skills/godark-configure-project/godark-config-schema.json
@@ -92,9 +92,22 @@
       "description": "Run agents on host instead of in Docker"
     },
     "auto_merge": {
-      "type": "string",
-      "enum": ["none", "low_risk", "all"],
-      "default": "none"
+      "type": "object",
+      "description": "Merge behavior for feature PRs and rollup PRs",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "enum": ["none", "low_risk", "all"],
+          "description": "Merge strategy for feature PRs after approval",
+          "default": "none"
+        },
+        "rollup": {
+          "type": "string",
+          "enum": ["none", "manual", "auto"],
+          "description": "Rollup PR handling after a run completes: none (human does everything), manual (godark opens PR, human merges), auto (godark opens and merges)",
+          "default": "none"
+        }
+      }
     },
     "quality_strictness_decay": {
       "type": "boolean",

--- a/README.md
+++ b/README.md
@@ -510,7 +510,9 @@ repo: owner/repo
 max_retries: 3            # review/fix cycles before escalating (default 3)
 agent_timeout: "30m"      # max wall-clock time per agent run
 no_sandbox: false         # run agents on host instead of Docker
-auto_merge: "none"        # merge strategy: none, low_risk, all
+auto_merge:
+  feature: "none"         # feature PR merge strategy: none, low_risk, all
+  rollup: "none"          # rollup PR handling: none, manual, auto
 quality_strictness_decay: true  # use diminishing strictness on quality review retries
 auth_preference: ""       # force "oauth" or "api_key" (auto-detected if empty)
 
@@ -578,6 +580,17 @@ verify:
 wait_for_checks:
   timeout: "10m"           # max time to wait for checks to complete
   required: []             # check names that must pass before merge
+
+# Rollup PR behavior (when base_branch differs from main)
+# none   — godark merges feature PRs; human opens and merges the rollup PR
+# manual — godark merges feature PRs and opens the rollup PR; human merges it
+# auto   — godark merges feature PRs, opens the rollup PR, and merges it
+
+# | Mode   | Feature PRs → base branch | Base branch → main                    |
+# |--------|---------------------------|---------------------------------------|
+# | none   | godark merges             | human inspects branch, opens PR, merges|
+# | manual | godark merges             | godark opens PR, human reviews/merges |
+# | auto   | godark merges             | godark opens PR and merges             |
 
 # Risk thresholds for low_risk auto-merge
 risk_thresholds:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -810,6 +810,11 @@ a parent feature branch, then submit the parent for human review.
   of hardcoded `origin main`
 - Track base branch in run data for audit trail
 - Surface base branch name in the status dashboard on run detail pages
+- Two-tier merge model via structured `auto_merge` config: `auto_merge.feature`
+  controls how feature PRs are merged into the base branch (`none`, `low_risk`,
+  `all`); `auto_merge.rollup` controls what godark does with the rollup PR that
+  merges the base branch into main (`none` = human handles everything, `manual` =
+  godark opens the PR and human merges, `auto` = godark opens and merges)
 
 **Issues**: #311-#316
 

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -17,11 +17,18 @@ import (
 const defaultConfig = `# godark.yaml — Configuration for godark
 repo: ""              # GitHub repository (owner/repo)
 
-# Merge strategy after both reviewers approve:
-#   none     — label PR awaiting-human-review (default, safest)
-#   low_risk — auto-merge small/safe PRs, label others for human review
-#   all      — auto-merge everything
-auto_merge: none
+# Merge behavior — two-tier config:
+#   feature: controls how feature PRs are merged after both reviewers approve
+#     none     — label PR awaiting-human-review (default, safest)
+#     low_risk — auto-merge small/safe PRs, label others for human review
+#     all      — auto-merge everything
+#   rollup: controls rollup PR behavior (only relevant when base_branch ≠ main)
+#     none   — godark stops after feature PRs; human opens and merges rollup PR
+#     manual — godark opens rollup PR; human reviews and merges
+#     auto   — godark opens and merges rollup PR
+auto_merge:
+  feature: none
+  rollup: none
 
 # Paths (defaults shown — override to customize)
 # roadmap_path: docs/ROADMAP.md

--- a/internal/harness/templates/godark.md
+++ b/internal/harness/templates/godark.md
@@ -46,7 +46,8 @@ step fails, the verify-fix agent attempts to correct the issue automatically.
 |-------|---------|---------|
 | `max_retries` | Review/fix cycles before escalating to human | `3` |
 | `agent_timeout` | Max wall-clock time per agent run | `30m` |
-| `auto_merge` | Merge strategy after approval: `none`, `low_risk`, `all` | `none` |
+| `auto_merge.feature` | Merge strategy for feature PRs after approval: `none`, `low_risk`, `all` | `none` |
+| `auto_merge.rollup` | Rollup PR handling after a run completes: `none`, `manual`, `auto` | `none` |
 | `no_sandbox` | Run agents on host instead of Docker | `false` |
 
 ### Paths and constraints
@@ -90,7 +91,19 @@ step fails, the verify-fix agent attempts to correct the issue automatically.
 | `wait_for_checks.timeout` | Max time to wait for CI checks to complete |
 | `wait_for_checks.required` | List of CI check names that must pass before merge |
 
-### Risk thresholds (for `auto_merge: low_risk`)
+### Rollup modes (`auto_merge.rollup`)
+
+When godark runs against a non-default base branch, a rollup PR merges the base
+branch into main after all feature PRs are done. The `rollup` field controls
+what godark does with that rollup PR:
+
+| Mode | Feature PRs → base branch | Base branch → main |
+|---|---|---|
+| `none` | godark merges | human does everything (inspects branch, opens PR manually) |
+| `manual` | godark merges | godark opens PR, human reviews and merges |
+| `auto` | godark merges | godark opens PR and merges |
+
+### Risk thresholds (for `auto_merge.feature: low_risk`)
 
 | Field | Purpose | Default |
 |-------|---------|---------|

--- a/internal/skills/godark-configure-project/godark-config-schema.json
+++ b/internal/skills/godark-configure-project/godark-config-schema.json
@@ -92,9 +92,22 @@
       "description": "Run agents on host instead of in Docker"
     },
     "auto_merge": {
-      "type": "string",
-      "enum": ["none", "low_risk", "all"],
-      "default": "none"
+      "type": "object",
+      "description": "Merge behavior for feature PRs and rollup PRs",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "enum": ["none", "low_risk", "all"],
+          "description": "Merge strategy for feature PRs after approval",
+          "default": "none"
+        },
+        "rollup": {
+          "type": "string",
+          "enum": ["none", "manual", "auto"],
+          "description": "Rollup PR handling after a run completes: none (human does everything), manual (godark opens PR, human merges), auto (godark opens and merges)",
+          "default": "none"
+        }
+      }
     },
     "quality_strictness_decay": {
       "type": "boolean",


### PR DESCRIPTION
## Summary

- Replace flat `auto_merge: "string"` with `auto_merge.feature` / `auto_merge.rollup` struct in all docs, schemas, and the default config template
- Add rollup modes table explaining `none`, `manual`, `auto` behavior in both `godark.md` files and README
- Update JSON schemas (both copies) to validate the object form with `feature` (enum: none/low_risk/all) and `rollup` (enum: none/manual/auto) fields
- Add Phase 17 note to ROADMAP.md about the two-tier merge model

## Test plan

- [ ] Verify `.claude/godark.md` shows `auto_merge.feature` and `auto_merge.rollup` rows in the Agent behavior table
- [ ] Verify `internal/harness/templates/godark.md` matches `.claude/godark.md` (same changes)
- [ ] Verify `README.md` config YAML uses `auto_merge: { feature: ..., rollup: ... }` format and includes the rollup modes table
- [ ] Verify both JSON schemas accept `{ "auto_merge": { "feature": "all", "rollup": "none" } }` as valid
- [ ] Verify `godark.yaml` still has the new struct format (unchanged)
- [ ] Verify `docs/ROADMAP.md` Phase 17 section includes the two-tier merge model note
- [ ] Verify `internal/cmd/init.go` default config template uses the new struct format

## Implementation Notes

### Approach
Pure documentation and schema update — no Go runtime code changes. Updated all locations that reference the `auto_merge` config field to use the new `feature`/`rollup` struct format introduced in the previous implementation PR.

### Key Decisions
- Also updated `internal/cmd/init.go`'s `defaultConfig` constant (not listed in the issue but contains the old flat format) so `godark init` generates correct config for new projects.
- Added the rollup modes explanation as a dedicated subsection in both `godark.md` files (not just in the Agent behavior table) since the three-mode distinction warrants more context than a table row provides.

### Known Limitations
- Historical references to `auto_merge: none/low_risk/all` remain in `docs/planning/`, `docs/phase-overviews/`, and `tests/scenarios/` (protected paths). These are historical records of previous phase designs and are intentionally left unchanged.

### Architecture
Only `content` and `cmd` layers were touched:
- `internal/harness/templates/godark.md` — content layer (no runtime deps)
- `internal/skills/godark-configure-project/godark-config-schema.json` — content layer
- `internal/cmd/init.go` — cmd layer (default config constant only, no logic change)
- All other files are project-level docs/config with no layer classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #336