### PR TITLE
feat(init): add format_command and lint_command to scaffolded godark.yaml

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/phs/dark-factory/internal/detect"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/harness/templates"
 	"github.com/phs/dark-factory/internal/label"
@@ -14,7 +15,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultConfig = `# godark.yaml — Configuration for godark
+// buildDefaultConfig constructs the default godark.yaml config string.
+// formatExample and lintExample are the example values shown in the commented-out
+// format_command and lint_command fields. Pass empty strings for generic examples.
+func buildDefaultConfig(formatExample, lintExample string) string {
+	if formatExample == "" {
+		formatExample = `""`
+	}
+	if lintExample == "" {
+		lintExample = `""`
+	}
+	return `# godark.yaml — Configuration for godark
 repo: ""              # GitHub repository (owner/repo)
 
 # Merge behavior — two-tier config:
@@ -30,6 +41,12 @@ auto_merge:
   feature: none
   rollup: none
 
+# Build, test, format, and lint commands (all optional)
+# build_command: "go build ./..."  # run before the verify step
+# test_command: "go test ./..."    # run by the verify step
+# format_command: ` + formatExample + `  # run during verify step
+# lint_command: ` + lintExample + `  # run during verify step
+
 # Paths (defaults shown — override to customize)
 # roadmap_path: docs/ROADMAP.md
 # planning_dir: docs/planning/
@@ -44,6 +61,7 @@ prompts:
 # Agent timeout (Go duration format: "30m", "1h", etc.)
 # agent_timeout: "30m"
 `
+}
 
 var initCmd = &cobra.Command{
 	Use:   "init",
@@ -131,12 +149,25 @@ func writeDefaultConfig(cmd *cobra.Command) error {
 		return nil
 	}
 
-	if err := os.WriteFile(configPath, []byte(defaultConfig), 0o644); err != nil {
+	formatEx, lintEx := commandExamplesForDir(".")
+	content := buildDefaultConfig(formatEx, lintEx)
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("writing %s: %w", configPath, err)
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", configPath)
 	return nil
+}
+
+// commandExamplesForDir returns format_command and lint_command example strings
+// for the config template. When a Go project is detected in dir, Go-specific
+// tool suggestions are returned; otherwise empty strings produce generic placeholders.
+func commandExamplesForDir(dir string) (formatExample, lintExample string) {
+	dp, err := detect.DetectRuntime(dir)
+	if err != nil || dp.Runtime.Name != "go" {
+		return "", ""
+	}
+	return `"gofmt -l -d ."`, `"golangci-lint run ./..."`
 }
 
 // writeHarnessDocs scaffolds harness documentation files into the current

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -335,3 +335,88 @@ func TestInitGuidanceWithoutResetFlag(t *testing.T) {
 		t.Error("expected CLAUDE.md guidance hint in output when --reset-claude-md not used")
 	}
 }
+
+func TestInitConfigIncludesFormatCommand(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	runInit(t)
+
+	data, err := os.ReadFile("godark.yaml")
+	if err != nil {
+		t.Fatalf("godark.yaml not created: %v", err)
+	}
+
+	if !strings.Contains(string(data), "format_command") {
+		t.Error("godark.yaml missing format_command field")
+	}
+}
+
+func TestInitConfigIncludesLintCommand(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	runInit(t)
+
+	data, err := os.ReadFile("godark.yaml")
+	if err != nil {
+		t.Fatalf("godark.yaml not created: %v", err)
+	}
+
+	if !strings.Contains(string(data), "lint_command") {
+		t.Error("godark.yaml missing lint_command field")
+	}
+}
+
+func TestInitGoProjectSuggestsGolangciLint(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// Simulate a Go project by writing a minimal go.mod.
+	if err := os.WriteFile("go.mod", []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	runInit(t)
+
+	data, err := os.ReadFile("godark.yaml")
+	if err != nil {
+		t.Fatalf("godark.yaml not created: %v", err)
+	}
+
+	if !strings.Contains(string(data), "golangci-lint run ./...") {
+		t.Error("godark.yaml should suggest golangci-lint for Go projects")
+	}
+	if !strings.Contains(string(data), "gofmt -l -d .") {
+		t.Error("godark.yaml should suggest gofmt for Go projects")
+	}
+}
+
+func TestInitNonGoProjectUsesGenericExamples(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// No go.mod — non-Go project uses generic (empty-string) examples.
+	runInit(t)
+
+	data, err := os.ReadFile("godark.yaml")
+	if err != nil {
+		t.Fatalf("godark.yaml not created: %v", err)
+	}
+
+	content := string(data)
+	if strings.Contains(content, "golangci-lint") {
+		t.Error("non-Go project should not suggest golangci-lint")
+	}
+	if strings.Contains(content, "gofmt") {
+		t.Error("non-Go project should not suggest gofmt")
+	}
+}

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -124,7 +124,8 @@ func runNew(cmd *cobra.Command, projectName, repo string) error {
 // writeNewProjectConfig writes godark.yaml into the current directory, with the
 // repo field pre-populated if repo is non-empty.
 func writeNewProjectConfig(cmd *cobra.Command, repo string) error {
-	config := defaultConfig
+	// New projects have no go.mod yet, so use generic (empty) command examples.
+	config := buildDefaultConfig("", "")
 	if repo != "" {
 		safe := strings.ReplaceAll(repo, `"`, `\"`)
 		config = strings.Replace(config, `repo: ""`, fmt.Sprintf(`repo: "%s"`, safe), 1)


### PR DESCRIPTION
## Summary

- Add `format_command` and `lint_command` as commented-out examples to the `godark init`-generated `godark.yaml`, grouped with `build_command` and `test_command`
- For Go projects (detected by presence of `go.mod`), suggest `gofmt -l -d .` and `golangci-lint run ./...` as examples; non-Go projects get generic empty-string placeholders
- `godark new` also uses the updated template (with generic examples, since no runtime exists yet in a new project)
- Four new tests: `TestInitConfigIncludesFormatCommand`, `TestInitConfigIncludesLintCommand`, `TestInitGoProjectSuggestsGolangciLint`, `TestInitNonGoProjectUsesGenericExamples`

Closes #328

## Implementation Notes

### Approach
Replaced the `const defaultConfig` string with a `buildDefaultConfig(formatExample, lintExample string) string` function. `writeDefaultConfig` calls `commandExamplesForDir(".")` which delegates to `detect.DetectRuntime` — if Go is detected, Go-specific tool suggestions are injected; otherwise empty strings produce `""` placeholders. `writeNewProjectConfig` in `new.go` now calls `buildDefaultConfig("", "")` directly since new projects have no runtime to detect.

### Key Decisions
- Used `detect.DetectRuntime` (existing domain layer) rather than duplicating the `go.mod` detection logic inline in `cmd`.
- `godark new` always gets generic examples — the project is brand-new, so no `go.mod` exists. If the user later adds Go and runs `godark init`, they'd see the skipped-already-exists message. This is the correct UX since `new` starts from scratch.
- `format_command` example is also made Go-specific (`gofmt -l -d .`) when Go is detected; the issue only mandates Go-specific `lint_command` but consistent treatment improves discoverability.

### Known Limitations
- Only Go gets runtime-specific suggestions. Other runtimes (Node, Rust, Elixir, Python, Flutter) receive empty-string placeholders. Future issues could add per-runtime linter suggestions as `detect.DetectedProject` is extended.

### Architecture
Only the `cmd` layer was touched. The new `commandExamplesForDir` helper calls `detect.DetectRuntime` from the `domain` layer — permitted since `cmd` may depend on all other layers. No new inter-package dependencies are introduced beyond the existing `detect` import already present in `internal/cmd/implement.go`.