### PR TITLE
feat(dashboard): surface verify check names in timeline summary

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -80,18 +80,25 @@ type IssueDetailData struct {
 	FailureAnalysis *rundata.FailureAnalysis
 }
 
+// CheckSummaryView is the view model for one check within a verify step summary.
+type CheckSummaryView struct {
+	Name   string
+	Passed bool
+}
+
 // TimelineStepView is the view model for one step in the issue timeline.
 type TimelineStepView struct {
-	Name         string
-	MarkerClass  string // "success", "danger", "warning", "info", "neutral"
-	Duration     string // formatted duration, e.g. "42s" or "—"
-	Cost         string // formatted cost, e.g. "$0.0042" or "—"
-	Verdict      string // "Passed", "Failed", "Flagged", "Error", "—"
-	VerdictClass string // badge class suffix
-	Flags        []rundata.Flag
-	HasOutput    bool
-	Output       string
-	ToolTrace    []string // tool calls recorded during this step
+	Name           string
+	MarkerClass    string // "success", "danger", "warning", "info", "neutral"
+	Duration       string // formatted duration, e.g. "42s" or "—"
+	Cost           string // formatted cost, e.g. "$0.0042" or "—"
+	Verdict        string // "Passed", "Failed", "Flagged", "Error", "—"
+	VerdictClass   string // badge class suffix
+	Flags          []rundata.Flag
+	HasOutput      bool
+	Output         string
+	ToolTrace      []string           // tool calls recorded during this step
+	CheckSummaries []CheckSummaryView // per-check results for verify steps; nil for other steps
 }
 
 // IndexData is the data passed to the index template.
@@ -665,7 +672,16 @@ func verifyToTimelineView(vr rundata.VerifyStepResult) TimelineStepView {
 		verdict = "Failed"
 	}
 
-	// Build output from check results.
+	// Build per-check summaries for the timeline header.
+	var checkSummaries []CheckSummaryView
+	for _, c := range vr.Checks {
+		checkSummaries = append(checkSummaries, CheckSummaryView{
+			Name:   c.Name,
+			Passed: c.Passed,
+		})
+	}
+
+	// Build output from check results for the expandable detail.
 	var sb strings.Builder
 	for _, c := range vr.Checks {
 		status := "PASS"
@@ -685,14 +701,15 @@ func verifyToTimelineView(vr rundata.VerifyStepResult) TimelineStepView {
 	output := sb.String()
 
 	return TimelineStepView{
-		Name:         name,
-		MarkerClass:  markerClass,
-		Duration:     "—",
-		Cost:         "—",
-		Verdict:      verdict,
-		VerdictClass: verdictClass,
-		HasOutput:    output != "",
-		Output:       output,
+		Name:           name,
+		MarkerClass:    markerClass,
+		Duration:       "—",
+		Cost:           "—",
+		Verdict:        verdict,
+		VerdictClass:   verdictClass,
+		HasOutput:      output != "",
+		Output:         output,
+		CheckSummaries: checkSummaries,
 	}
 }
 

--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -2,6 +2,7 @@ package dashboard_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1426,5 +1427,209 @@ func TestServer_RunDetail_BaseBranch_Hidden_When_Empty(t *testing.T) {
 	body := rr.Body.String()
 	if strings.Contains(body, "Base branch") {
 		t.Errorf("body should not contain 'Base branch' when BaseBranch is empty; got: %q", truncate(body, 500))
+	}
+}
+
+// --- Verify check summary tests ---
+
+func writeVerifyResult(t *testing.T, issueDir string, vr rundata.VerifyStepResult) {
+	t.Helper()
+	path := filepath.Join(issueDir, fmt.Sprintf("verify-%d.json", vr.Attempt))
+	writeJSON(t, path, vr)
+}
+
+func TestServer_IssueDetail_VerifyCheckSummaries_AllPassed(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		IssueNumbers: []int{50},
+		StartedAt:    now,
+	})
+	issueDir := buildIssueDir(t, runDir, 50)
+	writeVerifyResult(t, issueDir, rundata.VerifyStepResult{
+		Attempt:   0,
+		AllPassed: true,
+		Checks: []rundata.CheckResult{
+			{Name: "build", Passed: true, ExitCode: 0},
+			{Name: "lint", Passed: true, ExitCode: 0},
+			{Name: "test", Passed: true, ExitCode: 0},
+		},
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/50", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+
+	// Check names should appear in the summary.
+	for _, name := range []string{"build", "lint", "test"} {
+		if !strings.Contains(body, name) {
+			t.Errorf("body missing check name %q; got: %q", name, truncate(body, 500))
+		}
+	}
+
+	// All checks passed — verify-check--pass class should appear, not verify-check--fail.
+	if !strings.Contains(body, "verify-check--pass") {
+		t.Errorf("body missing verify-check--pass class for passed checks")
+	}
+	if strings.Contains(body, "verify-check--fail") {
+		t.Errorf("body should not contain verify-check--fail when all checks pass")
+	}
+}
+
+func TestServer_IssueDetail_VerifyCheckSummaries_SomeFailed(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		IssueNumbers: []int{51},
+		StartedAt:    now,
+	})
+	issueDir := buildIssueDir(t, runDir, 51)
+	writeVerifyResult(t, issueDir, rundata.VerifyStepResult{
+		Attempt:   0,
+		AllPassed: false,
+		Checks: []rundata.CheckResult{
+			{Name: "format", Passed: true, ExitCode: 0},
+			{Name: "build", Passed: true, ExitCode: 0},
+			{Name: "lint", Passed: false, ExitCode: 1, Output: "lint error output"},
+			{Name: "test", Passed: false, ExitCode: 2, Output: "test failure output"},
+		},
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/51", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+
+	// All check names should appear in the summary.
+	for _, name := range []string{"format", "build", "lint", "test"} {
+		if !strings.Contains(body, name) {
+			t.Errorf("body missing check name %q", name)
+		}
+	}
+
+	// Both pass and fail classes should appear.
+	if !strings.Contains(body, "verify-check--pass") {
+		t.Errorf("body missing verify-check--pass class for passed checks")
+	}
+	if !strings.Contains(body, "verify-check--fail") {
+		t.Errorf("body missing verify-check--fail class for failed checks")
+	}
+
+	// The overall verdict should be Failed.
+	if !strings.Contains(body, "Failed") {
+		t.Errorf("body missing 'Failed' verdict for verify step with failing checks")
+	}
+
+	// Expanded detail should include output for failed checks.
+	if !strings.Contains(body, "lint error output") {
+		t.Errorf("body missing lint error output in expanded detail")
+	}
+	if !strings.Contains(body, "test failure output") {
+		t.Errorf("body missing test failure output in expanded detail")
+	}
+}
+
+func TestServer_IssueDetail_VerifyCheckSummaries_FixAttempt(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		IssueNumbers: []int{52},
+		StartedAt:    now,
+	})
+	issueDir := buildIssueDir(t, runDir, 52)
+
+	// Initial verify: failed.
+	writeVerifyResult(t, issueDir, rundata.VerifyStepResult{
+		Attempt:   0,
+		AllPassed: false,
+		Checks: []rundata.CheckResult{
+			{Name: "build", Passed: false, ExitCode: 1, Output: "compile error"},
+		},
+	})
+	// Fix attempt: passed.
+	writeVerifyResult(t, issueDir, rundata.VerifyStepResult{
+		Attempt:      1,
+		AllPassed:    true,
+		FixAttempted: true,
+		Checks: []rundata.CheckResult{
+			{Name: "build", Passed: true, ExitCode: 0},
+		},
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/52", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+
+	// Both verify steps should be visible.
+	if !strings.Contains(body, "Verify (fix attempt 1)") {
+		t.Errorf("body missing fix-attempt label; got: %q", truncate(body, 500))
+	}
+
+	// The initial failed step should show the build check as failed.
+	if !strings.Contains(body, "verify-check--fail") {
+		t.Errorf("body missing verify-check--fail for initial failing verify step")
+	}
+}
+
+func TestServer_IssueDetail_VerifyCheckSummaries_NoChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		IssueNumbers: []int{53},
+		StartedAt:    now,
+	})
+	issueDir := buildIssueDir(t, runDir, 53)
+	writeVerifyResult(t, issueDir, rundata.VerifyStepResult{
+		Attempt:   0,
+		AllPassed: true,
+		Checks:    nil,
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/53", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+
+	// No check summary pills when no checks are recorded.
+	if strings.Contains(body, "verify-check") {
+		t.Errorf("body should not contain verify-check class when no checks are recorded")
+	}
+	// Verdict should still be Passed.
+	if !strings.Contains(body, "Passed") {
+		t.Errorf("body missing 'Passed' verdict")
 	}
 }

--- a/internal/dashboard/static/style.css
+++ b/internal/dashboard/static/style.css
@@ -604,6 +604,35 @@ a:hover {
   pointer-events: none;
 }
 
+/* --- Verify Check Summaries --- */
+.verify-checks {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.verify-check {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-family: monospace;
+  font-weight: 500;
+}
+
+.verify-check--pass {
+  background: var(--status-success-muted);
+  color: var(--status-success);
+}
+
+.verify-check--fail {
+  background: var(--status-danger-muted);
+  color: var(--status-danger);
+  font-weight: 700;
+}
+
 /* --- Cards --- */
 .card {
   background: var(--bg-surface-1);

--- a/internal/dashboard/templates/issue-detail.html
+++ b/internal/dashboard/templates/issue-detail.html
@@ -236,6 +236,13 @@
       <div class="timeline__header">
         <span class="timeline__title">{{.Name}}</span>
         <div class="flex gap-2 items-center">
+          {{if .CheckSummaries}}
+          <span class="verify-checks">
+            {{range .CheckSummaries}}
+            <span class="verify-check {{if .Passed}}verify-check--pass{{else}}verify-check--fail{{end}}">{{.Name}}</span>
+            {{end}}
+          </span>
+          {{end}}
           {{if .Flags}}
           <div class="quality-flags">
             {{range .Flags}}


### PR DESCRIPTION
## Summary

- Add `CheckSummaryView` struct and `CheckSummaries []CheckSummaryView` field to `TimelineStepView`
- Populate `CheckSummaries` in `verifyToTimelineView` from the per-check results in `VerifyStepResult`
- Render each check as a colored pill in the timeline header (green for pass, bold red for fail)
- Add CSS classes `.verify-check`, `.verify-check--pass`, `.verify-check--fail` to `style.css`
- Add 4 test cases covering: all-pass, some-fail, fix-attempt sequence, and no-checks edge case

## Test plan

- [ ] `TestServer_IssueDetail_VerifyCheckSummaries_AllPassed` — all check pills show pass styling
- [ ] `TestServer_IssueDetail_VerifyCheckSummaries_SomeFailed` — failed check pills distinct from passed; full output still in expanded detail
- [ ] `TestServer_IssueDetail_VerifyCheckSummaries_FixAttempt` — initial failing + fix-attempt verify steps both show check names
- [ ] `TestServer_IssueDetail_VerifyCheckSummaries_NoChecks` — no pills when no checks recorded; verdict still shown

## Implementation Notes

### Approach
Added a `CheckSummaryView` struct (name + passed bool) to the presentation layer and a `CheckSummaries` slice field on `TimelineStepView`. `verifyToTimelineView` populates it from `vr.Checks`. The template renders the pills immediately before the verdict badge in the timeline header row.

### Key Decisions
- Pills are placed in the header summary line (as required by the issue), not only in the expanded detail.
- Failed checks use `font-weight: 700` (bold) and danger color to be visually distinct.
- The expanded output section is unchanged — it continues to show full output for failed checks.
- `CheckSummaries` is nil for non-verify steps, so the template block is a no-op for all other timeline entries.

### Known Limitations
- No changes were needed to the `verifyToTimelineView` signature or the `rundata` package; all changes are in the `presentation` layer only.

### Architecture
Only the `presentation` layer (`internal/dashboard/`) was touched:
- `handlers.go` — new struct + field + populated in `verifyToTimelineView`
- `templates/issue-detail.html` — render `CheckSummaries` in the timeline header
- `static/style.css` — new CSS classes for the pill styling

No new cross-layer dependencies introduced. The `rundata` package (domain) was already an allowed dependency for this layer.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)