### PR TITLE
feat(dashboard): surface auto_merge config in run detail view

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -104,7 +104,7 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 
 		// Create RunDataWriter first to get the run directory for the log file.
 		var hook agent.RunDataHook
-		writer, writerErr := rundata.New(cfg.Repo, "", issueNums, cfg.BaseBranch)
+		writer, writerErr := rundata.New(cfg.Repo, "", issueNums, cfg.BaseBranch, rundata.AutoMerge{Feature: cfg.AutoMerge.Feature, Rollup: cfg.AutoMerge.Rollup})
 		var logDir string
 		if writerErr != nil {
 			// Fall back to a private temp directory so each run is isolated.

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -201,7 +201,7 @@ func handleChangesRequested(ctx context.Context, cfg *config.Config, prompts *ag
 	feedback := buildFeedback(review.Body, watchFetchReviewCommentsFn, cfg.Repo, pr.Number, review.ID, logger)
 
 	// Create a run data writer for this watch-initiated fix cycle.
-	writer, writerErr := watchNewWriterFn(cfg.Repo, "", []int{issueNum}, cfg.BaseBranch)
+	writer, writerErr := watchNewWriterFn(cfg.Repo, "", []int{issueNum}, cfg.BaseBranch, rundata.AutoMerge{Feature: cfg.AutoMerge.Feature, Rollup: cfg.AutoMerge.Rollup})
 	if writerErr != nil {
 		logger.Warn("failed to create run data writer", "err", writerErr)
 	}

--- a/internal/cmd/watch_test.go
+++ b/internal/cmd/watch_test.go
@@ -43,7 +43,7 @@ func stubWatchSeams(t *testing.T) {
 		return &agent.Result{SessionID: "sess-stub"}, nil
 	}
 	watchFindSessionIDFn = func(_ string, _ int) (string, error) { return "", nil }
-	watchNewWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string) (*rundata.Writer, error) {
+	watchNewWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string, _ rundata.AutoMerge) (*rundata.Writer, error) {
 		return nil, nil
 	}
 	watchFetchReviewCommentsFn = func(_ string, _ int, _ int) ([]string, error) { return nil, nil }
@@ -319,7 +319,7 @@ func TestHandleChangesRequested_FeedbackFed(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string, _ rundata.AutoMerge) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn
@@ -365,7 +365,7 @@ func TestHandleChangesRequested_SessionResumed(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string, _ rundata.AutoMerge) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn
@@ -410,7 +410,7 @@ func TestHandleChangesRequested_LabelsSwapped(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string, _ rundata.AutoMerge) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn
@@ -485,7 +485,7 @@ func TestHandleChangesRequested_NoSessionID(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string, _ rundata.AutoMerge) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn
@@ -531,10 +531,10 @@ func TestHandleChangesRequested_RunDataWritten(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string) (*rundata.Writer, error) {
+	watchNewWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string, am rundata.AutoMerge) (*rundata.Writer, error) {
 		writerCreated = true
 		// Use a custom base dir to verify the call actually happened.
-		w, err := rundata.NewWithBase(base, repo, milestone, issueNumbers, baseBranch)
+		w, err := rundata.NewWithBase(base, repo, milestone, issueNumbers, baseBranch, am)
 		return w, err
 	}
 	defer func() { watchNewWriterFn = origNewWriter }()
@@ -591,7 +591,7 @@ func TestHandleChangesRequested_MultipleCommentsConcatenated(t *testing.T) {
 	defer func() { watchFindSessionIDFn = origFindSession }()
 
 	origNewWriter := watchNewWriterFn
-	watchNewWriterFn = func(_, _ string, _ []int, _ string) (*rundata.Writer, error) { return nil, nil }
+	watchNewWriterFn = func(_, _ string, _ []int, _ string, _ rundata.AutoMerge) (*rundata.Writer, error) { return nil, nil }
 	defer func() { watchNewWriterFn = origNewWriter }()
 
 	origFetchComments := watchFetchReviewCommentsFn

--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -1430,6 +1430,78 @@ func TestServer_RunDetail_BaseBranch_Hidden_When_Empty(t *testing.T) {
 	}
 }
 
+func TestServer_RunDetail_AutoMerge_Shown(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	am := &rundata.AutoMerge{Feature: "low_risk", Rollup: "auto"}
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+		AutoMerge:    am,
+	})
+
+	writeIssueFiles(t, runDir, 1,
+		rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+		rundata.StepResult{Output: "ok", DurationSeconds: 5},
+		rundata.StepResult{},
+		rundata.StepResult{},
+	)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts, nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "low_risk") {
+		t.Errorf("body missing auto_merge.feature value; got: %q", truncate(body, 500))
+	}
+	if !strings.Contains(body, "rollup=auto") {
+		t.Errorf("body missing auto_merge.rollup value; got: %q", truncate(body, 500))
+	}
+}
+
+func TestServer_RunDetail_AutoMerge_Hidden_When_Absent(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+		// AutoMerge intentionally absent — simulates older run data.
+	})
+
+	writeIssueFiles(t, runDir, 1,
+		rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+		rundata.StepResult{Output: "ok", DurationSeconds: 5},
+		rundata.StepResult{},
+		rundata.StepResult{},
+	)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts, nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "Auto-merge") {
+		t.Errorf("body should not contain 'Auto-merge' when AutoMerge is absent; got: %q", truncate(body, 500))
+	}
+}
+
 // --- Verify check summary tests ---
 
 func writeVerifyResult(t *testing.T, issueDir string, vr rundata.VerifyStepResult) {

--- a/internal/dashboard/templates/run-detail.html
+++ b/internal/dashboard/templates/run-detail.html
@@ -70,7 +70,7 @@
     <main class="main">
       <div class="page-header animate-in">
         <h1 class="page-header__title">{{.Meta.Repo}}</h1>
-        <p class="page-header__subtitle">{{.Meta.Milestone}} &middot; {{.Timestamp}}{{if .Meta.BaseBranch}} &middot; Base branch: {{.Meta.BaseBranch}}{{end}}</p>
+        <p class="page-header__subtitle">{{.Meta.Milestone}} &middot; {{.Timestamp}}{{if .Meta.BaseBranch}} &middot; Base branch: {{.Meta.BaseBranch}}{{end}}{{if .Meta.AutoMerge}} &middot; Auto-merge: feature={{.Meta.AutoMerge.Feature}}, rollup={{.Meta.AutoMerge.Rollup}}{{end}}</p>
       </div>
 
       {{if and .Meta.Summary .Meta.Summary.AbortReason}}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -90,7 +90,7 @@ func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone
 	if !dryRun {
 		issueNums := issueNumbers(issues)
 		var writerErr error
-		writer, writerErr = newRunDataWriterFn(cfg.Repo, milestone, issueNums, cfg.BaseBranch)
+		writer, writerErr = newRunDataWriterFn(cfg.Repo, milestone, issueNums, cfg.BaseBranch, rundata.AutoMerge{Feature: cfg.AutoMerge.Feature, Rollup: cfg.AutoMerge.Rollup})
 		if writerErr != nil {
 			logger.Warn("failed to create run data writer, run data will not be recorded", "error", writerErr)
 		} else if runLogger, logErr := logging.NewLogger(writer.Dir()); logErr == nil {
@@ -586,8 +586,8 @@ func dialogueOutcome(e dialogue.Entry) string {
 }
 
 // newRunDataWriterFn creates a new RunDataWriter. Replaceable for testing.
-var newRunDataWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string) (*rundata.Writer, error) {
-	return rundata.New(repo, milestone, issueNumbers, baseBranch)
+var newRunDataWriterFn = func(repo, milestone string, issueNumbers []int, baseBranch string, autoMerge rundata.AutoMerge) (*rundata.Writer, error) {
+	return rundata.New(repo, milestone, issueNumbers, baseBranch, autoMerge)
 }
 
 // createRollupPRFn creates a rollup PR and returns its number and URL.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -246,7 +246,7 @@ func TestAllBlocked(t *testing.T) {
 	// Run creates a RunDataWriter when dryRun=false; disable it for this test.
 	origWriter := newRunDataWriterFn
 	t.Cleanup(func() { newRunDataWriterFn = origWriter })
-	newRunDataWriterFn = func(repo, milestone string, issueNums []int, baseBranch string) (*rundata.Writer, error) {
+	newRunDataWriterFn = func(repo, milestone string, issueNums []int, baseBranch string, autoMerge rundata.AutoMerge) (*rundata.Writer, error) {
 		return nil, fmt.Errorf("disabled in test")
 	}
 
@@ -589,7 +589,7 @@ func TestProcessIssues_FinalizeRunCalled(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	writer, err := rundata.New("owner/repo", "test-milestone", []int{10, 11}, "")
+	writer, err := rundata.New("owner/repo", "test-milestone", []int{10, 11}, "", rundata.AutoMerge{})
 	if err != nil {
 		t.Fatalf("rundata.New: %v", err)
 	}
@@ -714,7 +714,7 @@ func TestProcessIssues_WritesDialogue(t *testing.T) {
 
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
-	writer, err := rundata.New("owner/repo", "test-milestone", []int{5}, "")
+	writer, err := rundata.New("owner/repo", "test-milestone", []int{5}, "", rundata.AutoMerge{})
 	if err != nil {
 		t.Fatalf("rundata.New: %v", err)
 	}

--- a/internal/rundata/reader_test.go
+++ b/internal/rundata/reader_test.go
@@ -490,7 +490,7 @@ func TestReadDialogueMissingFile(t *testing.T) {
 func TestReadDialogueRoundTrip(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("HOME", base)
-	w, err := New("owner/repo", "Phase 7", []int{5}, "")
+	w, err := New("owner/repo", "Phase 7", []int{5}, "", AutoMerge{})
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -9,11 +9,22 @@ import (
 	"time"
 )
 
+// AutoMerge holds the auto-merge strategy settings recorded at run start.
+type AutoMerge struct {
+	// Feature controls merging of the feature branch into the base branch.
+	// Valid values: "none", "low_risk", "all".
+	Feature string `json:"feature"`
+	// Rollup controls what happens to the base branch → default branch after
+	// a run completes. Valid values: "none", "manual", "auto".
+	Rollup string `json:"rollup"`
+}
+
 // RunMeta is the structure persisted to run.json.
 type RunMeta struct {
 	Repo         string      `json:"repo"`
 	Milestone    string      `json:"milestone"`
 	BaseBranch   string      `json:"base_branch,omitempty"`
+	AutoMerge    *AutoMerge  `json:"auto_merge,omitempty"`
 	IssueNumbers []int       `json:"issue_numbers"`
 	IssueDeps    []IssueDep  `json:"issue_deps,omitempty"`
 	StartedAt    time.Time   `json:"started_at"`
@@ -84,17 +95,17 @@ type Writer struct {
 // directory under ~/.godark/runs/<owner>/<repo>/<YYYYMMDD-HHMMSS>/ and writes
 // an initial run.json. Repo must be in "owner/name" format; components
 // containing ".." or path separators are rejected.
-func New(repo, milestone string, issueNumbers []int, baseBranch string) (*Writer, error) {
+func New(repo, milestone string, issueNumbers []int, baseBranch string, autoMerge AutoMerge) (*Writer, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, fmt.Errorf("getting home dir: %w", err)
 	}
-	return NewWithBase(filepath.Join(home, ".godark", "runs"), repo, milestone, issueNumbers, baseBranch)
+	return NewWithBase(filepath.Join(home, ".godark", "runs"), repo, milestone, issueNumbers, baseBranch, autoMerge)
 }
 
 // NewWithBase creates a new Writer using a custom base directory instead of
 // the default ~/.godark/runs/. Intended for testing.
-func NewWithBase(baseDir, repo, milestone string, issueNumbers []int, baseBranch string) (*Writer, error) {
+func NewWithBase(baseDir, repo, milestone string, issueNumbers []int, baseBranch string, autoMerge AutoMerge) (*Writer, error) {
 	owner, repoName, err := validateRepo(repo)
 	if err != nil {
 		return nil, err
@@ -115,10 +126,16 @@ func NewWithBase(baseDir, repo, milestone string, issueNumbers []int, baseBranch
 		startedAt: now,
 	}
 
+	var autoMergePtr *AutoMerge
+	if autoMerge.Feature != "" || autoMerge.Rollup != "" {
+		cp := autoMerge
+		autoMergePtr = &cp
+	}
 	meta := RunMeta{
 		Repo:         repo,
 		Milestone:    milestone,
 		BaseBranch:   baseBranch,
+		AutoMerge:    autoMergePtr,
 		IssueNumbers: issueNumbers,
 		StartedAt:    now,
 	}

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -14,7 +14,7 @@ import (
 func newWithBase(t *testing.T, base, repo, milestone string, issueNumbers []int) (*Writer, error) {
 	t.Helper()
 	t.Setenv("HOME", base)
-	return New(repo, milestone, issueNumbers, "")
+	return New(repo, milestone, issueNumbers, "", AutoMerge{})
 }
 
 func TestRunDirectoryCreated(t *testing.T) {
@@ -773,7 +773,7 @@ func TestPathTraversalRejected(t *testing.T) {
 	for _, repo := range cases {
 		base := t.TempDir()
 		t.Setenv("HOME", base)
-		_, err := New(repo, "Phase 7", []int{1}, "")
+		_, err := New(repo, "Phase 7", []int{1}, "", AutoMerge{})
 		if err == nil {
 			t.Errorf("New(%q) should return error for path traversal, got nil", repo)
 		}
@@ -819,7 +819,7 @@ func TestWriteRiskAssessmentCreatesFile(t *testing.T) {
 func TestBaseBranchWrittenToRunJSON(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("HOME", base)
-	w, err := New("owner/repo", "Phase 7", []int{1}, "feature/foo")
+	w, err := New("owner/repo", "Phase 7", []int{1}, "feature/foo", AutoMerge{})
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}
@@ -842,7 +842,7 @@ func TestBaseBranchWrittenToRunJSON(t *testing.T) {
 func TestBaseBranchOmittedWhenEmpty(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("HOME", base)
-	w, err := New("owner/repo", "Phase 7", []int{1}, "")
+	w, err := New("owner/repo", "Phase 7", []int{1}, "", AutoMerge{})
 	if err != nil {
 		t.Fatalf("New() error: %v", err)
 	}
@@ -858,6 +858,71 @@ func TestBaseBranchOmittedWhenEmpty(t *testing.T) {
 	}
 	if _, ok := raw["base_branch"]; ok {
 		t.Error("base_branch key should be omitted from JSON when empty")
+	}
+}
+
+func TestAutoMergeWrittenToRunJSON(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("HOME", base)
+	w, err := New("owner/repo", "Phase 7", []int{1}, "", AutoMerge{Feature: "low_risk", Rollup: "auto"})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(w.Dir(), "run.json"))
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+
+	var meta RunMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("parsing run.json: %v", err)
+	}
+
+	if meta.AutoMerge == nil {
+		t.Fatal("AutoMerge should be set in run.json")
+	}
+	if meta.AutoMerge.Feature != "low_risk" {
+		t.Errorf("AutoMerge.Feature = %q, want %q", meta.AutoMerge.Feature, "low_risk")
+	}
+	if meta.AutoMerge.Rollup != "auto" {
+		t.Errorf("AutoMerge.Rollup = %q, want %q", meta.AutoMerge.Rollup, "auto")
+	}
+}
+
+func TestAutoMergeOmittedWhenEmpty(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("HOME", base)
+	w, err := New("owner/repo", "Phase 7", []int{1}, "", AutoMerge{})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(w.Dir(), "run.json"))
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+	if _, ok := raw["auto_merge"]; ok {
+		t.Error("auto_merge key should be omitted from JSON when AutoMerge is empty")
+	}
+}
+
+func TestAutoMergeMissingInOldDataDeserializesCleanly(t *testing.T) {
+	// Simulate old run.json without auto_merge field.
+	oldJSON := []byte(`{"repo":"owner/repo","milestone":"Phase 7","issue_numbers":[1],"started_at":"2024-01-01T00:00:00Z"}`)
+
+	var meta RunMeta
+	if err := json.Unmarshal(oldJSON, &meta); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+
+	if meta.AutoMerge != nil {
+		t.Errorf("AutoMerge = %+v, want nil for old data without auto_merge", meta.AutoMerge)
 	}
 }
 


### PR DESCRIPTION
Closes #338

## Summary
- Adds `AutoMerge` struct to `rundata.RunMeta` and persists it in `run.json` at run creation time
- Propagates `cfg.AutoMerge` from the orchestrator and `implement`/`watch` commands into `rundata.New()`
- Displays `auto_merge.feature` and `auto_merge.rollup` in the run detail page subtitle, alongside base branch
- Older runs without the `auto_merge` field in `run.json` render cleanly (field is `omitempty`, pointer stays nil)

## Test plan
- [ ] `TestAutoMergeWrittenToRunJSON` — confirms values are persisted in `run.json`
- [ ] `TestAutoMergeOmittedWhenEmpty` — confirms `auto_merge` key is omitted when both values are empty
- [ ] `TestAutoMergeMissingInOldDataDeserializesCleanly` — confirms old `run.json` without the field deserializes to nil without error
- [ ] `TestServer_RunDetail_AutoMerge_Shown` — confirms feature and rollup values appear in the rendered page
- [ ] `TestServer_RunDetail_AutoMerge_Hidden_When_Absent` — confirms no "Auto-merge" text appears for older runs
- [ ] Full `go test ./...` — all 27 packages pass

## Implementation Notes

### Approach
Added an `AutoMerge` struct directly in the `rundata` package (domain layer) to keep the domain model self-contained. The struct is stored as a pointer in `RunMeta` with `json:"auto_merge,omitempty"` so that: (a) older run.json files without the field deserialize to `nil`, and (b) runs where both values happen to be empty don't write a spurious `auto_merge` key.

The template uses `{{if .Meta.AutoMerge}}` to guard display, so older runs render without any errors or "n/a" noise.

### Key Decisions
- **Pointer vs value in RunMeta**: Used `*AutoMerge` so `omitempty` works on a struct field. A zero-value struct would not be omitted by `encoding/json`; a nil pointer is.
- **Own struct vs importing config.AutoMerge**: Defined `rundata.AutoMerge` rather than importing `config.AutoMerge`. Both are in layers that allow the dependency (domain can import foundation), but keeping `rundata` free of the `config` import is cleaner.
- **Template placement**: Appended to the existing subtitle line alongside base branch — consistent with how `BaseBranch` is already displayed.

### Known Limitations
None. All acceptance criteria are met.

### Architecture
- **`rundata`** (domain layer): new `AutoMerge` struct + field on `RunMeta`; updated `New`/`NewWithBase` signatures — no new external deps
- **`orchestrator`** (orchestration layer): passes `cfg.AutoMerge` → `rundata.AutoMerge` at run creation
- **`cmd`** (cmd layer): same propagation in `implement` and `watch` commands
- **`dashboard`** (presentation layer): template reads `Meta.AutoMerge` already present on `RunMeta` — no new handler code needed, no new imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)