### PR TITLE
feat: add recon agent prompt template and role (#367)

### DIFF
--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -21,6 +21,7 @@ type Prompts struct {
 	SpecGenerator    string
 	Punchlist        string
 	VerifyFix        string
+	Recon            string
 }
 
 // PromptData contains the values substituted into prompt templates.
@@ -129,6 +130,14 @@ func LoadPrompts(cfg *config.Config) (*Prompts, error) {
 		p.VerifyFix = ""
 	} else {
 		p.VerifyFix = vf
+	}
+
+	// Recon is optional — load from config or embedded default.
+	recon, err := loadPromptFile(cfg.Prompts.Recon, "recon.txt")
+	if err != nil {
+		p.Recon = ""
+	} else {
+		p.Recon = recon
 	}
 
 	return p, nil

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -383,6 +383,40 @@ func TestPromptTemplateVarsPreserved(t *testing.T) {
 	}
 }
 
+func TestLoadPrompts_ReconLoadedFromEmbedded(t *testing.T) {
+	cfg := &config.Config{}
+
+	p, err := LoadPrompts(cfg)
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	if p.Recon == "" {
+		t.Error("Recon should be loaded from embedded default")
+	}
+}
+
+func TestReconPrompt_RendersWithIssueTitleAndBody(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber: 42,
+		IssueTitle:  "Add recon agent",
+		IssueBody:   "The recon agent explores the codebase before implementation.",
+	}
+	rendered, err := RenderPrompt(p.Recon, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, "Add recon agent") {
+		t.Error("recon prompt should contain the issue title")
+	}
+	if !strings.Contains(rendered, "The recon agent explores the codebase before implementation.") {
+		t.Error("recon prompt should contain the issue body")
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/agent/runner/agent_runner.py
+++ b/internal/agent/runner/agent_runner.py
@@ -58,6 +58,10 @@ _ROLE_PERMISSIONS: dict[str, dict] = {
         "allowed_tools": ["Read", "Glob", "Grep"],
         "disallowed_tools": ["Write", "Edit", "Bash"],
     },
+    "recon": {
+        "allowed_tools": ["Read", "Glob", "Grep"],
+        "disallowed_tools": ["Write", "Edit", "Bash"],
+    },
 }
 
 

--- a/internal/agent/runner/embed_test.go
+++ b/internal/agent/runner/embed_test.go
@@ -75,6 +75,53 @@ func TestAgentRunnerPyReviewerDisallowsWrite(t *testing.T) {
 	}
 }
 
+// TestAgentRunnerPyReconRolePermissions verifies that the recon role
+// configuration in agent_runner.py allows Read, Glob, Grep and hard-denies
+// Write, Edit, Bash via disallowed_tools.
+func TestAgentRunnerPyReconRolePermissions(t *testing.T) {
+	content, err := runner.FS.ReadFile("agent_runner.py")
+	if err != nil {
+		t.Fatalf("ReadFile(agent_runner.py): %v", err)
+	}
+	s := string(content)
+
+	reconIdx := strings.Index(s, `"recon"`)
+	if reconIdx < 0 {
+		t.Fatal("recon role not found in agent_runner.py")
+	}
+
+	// Find the recon section up to the next role entry (closing brace of dict).
+	reconSection := s[reconIdx:]
+	// The next top-level key after "recon" would be another quoted role name or the closing '}'.
+	// We look for the pattern `},` or `}` followed by a newline and `}` to bound the section.
+	// A simple approach: find the next `},` after the opening of the recon entry.
+	nextEntryIdx := strings.Index(reconSection[1:], `},`)
+	if nextEntryIdx < 0 {
+		// Last entry in dict — bound by `}`
+		nextEntryIdx = strings.Index(reconSection[1:], `}`)
+	}
+	if nextEntryIdx >= 0 {
+		reconSection = reconSection[:nextEntryIdx+2]
+	}
+
+	// Verify allowed tools.
+	for _, tool := range []string{`"Read"`, `"Glob"`, `"Grep"`} {
+		if !strings.Contains(reconSection, tool) {
+			t.Errorf("recon allowed_tools does not include %s", tool)
+		}
+	}
+
+	// Verify disallowed tools.
+	if !strings.Contains(reconSection, "disallowed_tools") {
+		t.Error("recon role does not define disallowed_tools")
+	}
+	for _, tool := range []string{`"Write"`, `"Edit"`, `"Bash"`} {
+		if !strings.Contains(reconSection, tool) {
+			t.Errorf("recon disallowed_tools does not include %s", tool)
+		}
+	}
+}
+
 // TestAgentRunnerPyUnknownRoleExits verifies that agent_runner.py contains
 // logic to exit with a non-zero code when GODARK_ROLE is not a known role.
 func TestAgentRunnerPyUnknownRoleExits(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,6 +212,7 @@ type Prompts struct {
 	SpecGenerator    string `yaml:"spec_generator"`
 	Punchlist        string `yaml:"punchlist"`
 	VerifyFix        string `yaml:"verify_fix"`
+	Recon            string `yaml:"recon"`
 }
 
 // CLIFlags holds flag values passed on the command line.

--- a/prompts/recon.txt
+++ b/prompts/recon.txt
@@ -1,0 +1,28 @@
+You are a codebase reconnaissance agent. Your job is to explore the repository
+and produce a free-form analysis that will be handed directly to the implementer
+as context before they begin work on the issue below.
+
+## Issue #{{.IssueNumber}}: {{.IssueTitle}}
+
+### Issue Description
+{{.IssueBody}}
+
+## Your task
+
+Read the issue description carefully, then explore the codebase to answer:
+
+- Which files will need to change? List them with their current paths.
+- What are the relevant function signatures, type definitions, and interfaces
+  the issue would touch? Quote the current signatures verbatim.
+- What packages are involved, and which architecture layers do they belong to?
+  Cross-reference docs/architecture.json to confirm layer membership and
+  allowed dependencies.
+- What infrastructure or utilities from prior issues are already available that
+  the implementer can reuse?
+- Does anything in the current codebase differ from what the issue description
+  assumes — missing types, renamed functions, already-completed work, or
+  constraint conflicts?
+
+Write your findings naturally. There is no required output format — the
+implementer will read your full response as context. Be specific: quote code,
+name files with line numbers, and flag anything surprising.


### PR DESCRIPTION
## Summary

- Add `prompts/recon.txt` — minimal codebase exploration prompt for the recon agent
- Add `recon` role to `_ROLE_PERMISSIONS` in `agent_runner.py` (read-only: Read, Glob, Grep)
- Extend `config.Prompts` and `agent.Prompts` structs with `Recon` field
- Tests for role permissions and prompt rendering

Closes #367

## Implementation Notes

### Approach
Added the `recon` role following the exact pattern of the existing `punchlist` role — strictly read-only with `allowed_tools: [Read, Glob, Grep]` and `disallowed_tools: [Write, Edit, Bash]`. The prompt template is intentionally minimal: it tells the agent what to investigate (issue requirements, relevant files/signatures, architecture layer membership, available infrastructure, discrepancies) without prescribing an output format, so the raw natural-language output can be passed directly to the implementer.

### Key Decisions
- The prompt uses `{{.IssueNumber}}`, `{{.IssueTitle}}`, and `{{.IssueBody}}` from `PromptData` — all standard fields already present in the struct, so no new fields were needed.
- Recon is treated as an optional prompt (like punchlist, verify_fix) — a missing embedded file yields an empty string rather than an error, keeping `LoadPrompts` non-fatal for optional prompts.
- No Go-side orchestration code was added (no recon agent runner/launcher) since the issue scope is limited to the prompt template and role definition.

### Known Limitations
- No orchestration integration yet — the recon prompt and role are wired up but there is no call site in the orchestrator that invokes the recon agent. That integration is expected in a follow-on issue.

### Architecture
- `prompts/recon.txt` — `content` layer (static embedded template, no runtime dependencies)
- `internal/config/config.go` — `foundation` layer (`Prompts.Recon` field addition)
- `internal/agent/prompt.go` — `orchestration` layer (loads and exposes the recon prompt)
- `internal/agent/runner/agent_runner.py` — `infrastructure` layer (role permissions)

All dependency rules respected: no upward layer references introduced.