### PR TITLE
feat: wire recon brief into implementer prompt

### DIFF
--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -56,6 +56,11 @@ type PromptData struct {
 	// this to branch off origin/<BaseBranch> and pass --base <BaseBranch> to
 	// gh pr create.
 	BaseBranch string
+	// ReconBrief holds the output from the recon agent. When non-empty it is
+	// injected into the implementer prompt as pre-implementation context.
+	// Not set by newPromptData() — set by the caller after running the recon
+	// agent.
+	ReconBrief string
 }
 
 // loadPromptFile reads a prompt from the config path if set, otherwise from

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -948,3 +948,59 @@ func TestSpecGeneratorPrompt_BaseBranchEmpty_NeverCommitToMain(t *testing.T) {
 		t.Error("spec_generator prompt should contain 'Never commit directly to main' when BaseBranch is empty")
 	}
 }
+
+func TestImplementerPrompt_WithReconBrief_IncludesBrief(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	brief := "## Relevant files\n- internal/config/config.go: Prompts struct at line 206"
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		BuildCommand:   "make build",
+		TestCommand:    "make test",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "test-issue",
+		ReconBrief:     brief,
+	}
+	rendered, err := RenderPrompt(p.Implementer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if !strings.Contains(rendered, brief) {
+		t.Error("implementer prompt should contain the recon brief when ReconBrief is set")
+	}
+	if !strings.Contains(rendered, "recon brief") {
+		t.Error("implementer prompt should contain 'recon brief' heading when ReconBrief is set")
+	}
+}
+
+func TestImplementerPrompt_WithoutReconBrief_OmitsReconSection(t *testing.T) {
+	p, err := LoadPrompts(&config.Config{})
+	if err != nil {
+		t.Fatalf("LoadPrompts() error = %v", err)
+	}
+	data := PromptData{
+		IssueNumber:    1,
+		IssueTitle:     "Test Issue",
+		Repo:           "owner/repo",
+		BuildCommand:   "make build",
+		TestCommand:    "make test",
+		ProtectedPaths: "CLAUDE.md",
+		ScenarioDir:    "tests/scenarios/",
+		ReviewDir:      "tests/review/",
+		Slug:           "test-issue",
+		ReconBrief:     "",
+	}
+	rendered, err := RenderPrompt(p.Implementer, data)
+	if err != nil {
+		t.Fatalf("RenderPrompt() error = %v", err)
+	}
+	if strings.Contains(rendered, "recon brief") {
+		t.Error("implementer prompt should not contain 'recon brief' when ReconBrief is empty")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -743,6 +743,38 @@ prompts:
 	}
 }
 
+func TestReconPromptPathFromYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+prompts:
+  recon: "custom/recon.txt"
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Prompts.Recon != "custom/recon.txt" {
+		t.Errorf("Prompts.Recon = %q, want %q", cfg.Prompts.Recon, "custom/recon.txt")
+	}
+}
+
+func TestReconPromptPathDefaultEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Prompts.Recon != "" {
+		t.Errorf("Prompts.Recon = %q, want empty string", cfg.Prompts.Recon)
+	}
+}
+
 func TestDeniedCommandsDefaults(t *testing.T) {
 	dir := t.TempDir()
 	path := writeYAML(t, dir, `

--- a/prompts/implementer.txt
+++ b/prompts/implementer.txt
@@ -1,5 +1,15 @@
 Read CLAUDE.md completely before doing anything else.
 Then implement GitHub issue #{{.IssueNumber}} in the {{.Repo}} repository.
+{{- if .ReconBrief}}
+
+## Pre-implementation context (recon brief)
+
+The following is a summary of relevant files, signatures, and architectural
+notes gathered by the recon agent before implementation. Use it as context
+when reading code and planning your approach.
+
+{{.ReconBrief}}
+{{- end}}
 
 Issue title: {{.IssueTitle}}
 Issue body:


### PR DESCRIPTION
## Summary

- Add `ReconBrief string` field to `PromptData` struct in `internal/agent/prompt.go` so the recon agent's output can be passed to the implementer
- Add `{{if .ReconBrief}}` conditional block to `prompts/implementer.txt` that injects the brief as pre-implementation context when present
- Add config and prompt tests: `prompts.recon` field parsed from YAML, default empty, implementer renders with/without `ReconBrief`

## Test plan

- [x] `TestReconPromptPathFromYAML` — `prompts.recon: "custom/recon.txt"` is reflected in parsed config
- [x] `TestReconPromptPathDefaultEmpty` — absent `prompts.recon` yields empty `Prompts.Recon`
- [x] `TestImplementerPrompt_WithReconBrief_IncludesBrief` — rendered implementer contains brief text when `ReconBrief` is set
- [x] `TestImplementerPrompt_WithoutReconBrief_OmitsReconSection` — rendered implementer does not contain recon section when `ReconBrief` is empty
- [x] All existing tests pass (`go test ./internal/config/... ./internal/agent/...`)

## Implementation Notes

### Approach
Added `ReconBrief` as a plain `string` field on `PromptData`, not set by any constructor — the caller (`ProcessIssue`) assigns it after running the recon agent. The `implementer.txt` template guards the block with `{{if .ReconBrief}}` so existing behavior is unchanged when the field is empty.

### Key Decisions
- `ReconBrief` is on `PromptData` (the template data), not `Prompts` (the loaded template text). This matches the issue spec: the brief is runtime output, not a template file.
- The `Recon` field in `config.Prompts` and the load logic in `LoadPrompts()` were already added by #367; this PR only adds the wiring for the brief output.
- The conditional block in `implementer.txt` uses `{{- if .ReconBrief}}` trim markers to avoid extra blank lines when the section is absent.

### Known Limitations
- `ReconBrief` is not yet assigned by `ProcessIssue` — that wiring belongs to a future issue in the recon workflow.

### Architecture
- `internal/config/` (foundation layer): added `Recon string` field test coverage only; field itself was added by #367.
- `internal/agent/` (orchestration layer): `PromptData` extended with `ReconBrief`; no new imports or dependencies.
- `prompts/implementer.txt` (content layer): template updated with conditional block; no runtime dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #368