### PR TITLE
feat: persist recon result to run data and surface in dashboard (#370)

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -125,10 +125,28 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		reconResult, reconErr := Recon(ctx, issue, cfg, prompts, authEnv, logger)
 		if reconErr != nil {
 			logger.Warn("recon agent failed, continuing without brief", "error", reconErr)
+			if hook != nil {
+				step := rundata.StepResult{Error: reconErr.Error()}
+				if writeErr := hook.WriteReconResult(issue.Number, step); writeErr != nil {
+					logger.Warn("failed to write recon result", "error", writeErr)
+				}
+			}
 		} else if reconResult.TimedOut {
 			logger.Warn("recon agent timed out, continuing without brief")
+			if hook != nil {
+				step := ResultToStep(reconResult)
+				step.Error = "timed out"
+				if writeErr := hook.WriteReconResult(issue.Number, step); writeErr != nil {
+					logger.Warn("failed to write recon result", "error", writeErr)
+				}
+			}
 		} else {
 			reconBrief = reconResult.ResultText
+			if hook != nil {
+				if writeErr := hook.WriteReconResult(issue.Number, ResultToStep(reconResult)); writeErr != nil {
+					logger.Warn("failed to write recon result", "error", writeErr)
+				}
+			}
 		}
 	}
 

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -930,6 +930,7 @@ func TestProcessIssue_SkipsQualityReviewWhenNoPrompt(t *testing.T) {
 
 // testRunDataHook is a simple RunDataHook implementation for unit tests.
 type testRunDataHook struct {
+	reconCalls                 int
 	specGeneratorCalls         int
 	implementCalls             int
 	reviewKinds                []string
@@ -942,6 +943,10 @@ type testRunDataHook struct {
 	riskAssessments            []rundata.RiskAssessment
 }
 
+func (h *testRunDataHook) WriteReconResult(_ int, _ rundata.StepResult) error {
+	h.reconCalls++
+	return nil
+}
 func (h *testRunDataHook) WriteSpecGeneratorResult(_ int, _ rundata.StepResult) error {
 	h.specGeneratorCalls++
 	return nil

--- a/internal/agent/runhook.go
+++ b/internal/agent/runhook.go
@@ -6,6 +6,7 @@ import "github.com/phs/dark-factory/internal/rundata"
 // these methods after each agent step. Callers should check for nil before
 // passing; individual methods are not required to be nil-safe themselves.
 type RunDataHook interface {
+	WriteReconResult(issueNumber int, step rundata.StepResult) error
 	WriteSpecGeneratorResult(issueNumber int, step rundata.StepResult) error
 	WriteImplementResult(issueNumber int, step rundata.StepResult) error
 	WriteReviewResult(issueNumber int, kind string, step rundata.StepResult) error

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -506,7 +506,7 @@ func (s *Server) handleReviewChain(w http.ResponseWriter, r *http.Request) {
 // issueToRowView converts an IssueDetail to the view model for the run detail table.
 func issueToRowView(issue rundata.IssueDetail, owner, repo, timestamp string) IssueRowView {
 	flagCount := len(issue.Implement.Flags) + len(issue.QualityReview.Flags) + len(issue.FunctionalReview.Flags)
-	totalCost := issue.Implement.CostUSD + issue.QualityReview.CostUSD + issue.FunctionalReview.CostUSD
+	totalCost := issue.Recon.CostUSD + issue.Implement.CostUSD + issue.QualityReview.CostUSD + issue.FunctionalReview.CostUSD
 	for _, retry := range issue.Retries {
 		flagCount += len(retry.Retry.Flags) + len(retry.QualityReview.Flags) + len(retry.FunctionalReview.Flags)
 		totalCost += retry.Retry.CostUSD + retry.QualityReview.CostUSD + retry.FunctionalReview.CostUSD
@@ -575,6 +575,9 @@ func buildTimeline(issue rundata.IssueDetail) []TimelineStepView {
 
 	if hasStepData(issue.SpecGenerator) {
 		steps = append(steps, stepToView("Spec Generator", issue.SpecGenerator))
+	}
+	if hasStepData(issue.Recon) {
+		steps = append(steps, stepToView("Recon", issue.Recon))
 	}
 	if hasStepData(issue.Implement) {
 		steps = append(steps, stepToView("Implement", issue.Implement))

--- a/internal/dashboard/handlers_review_chain_test.go
+++ b/internal/dashboard/handlers_review_chain_test.go
@@ -3,12 +3,104 @@ package dashboard_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/phs/dark-factory/internal/rundata"
 )
+
+// writeReconFile creates a recon.json under the issue directory.
+func writeReconFile(t *testing.T, issueDir string, step rundata.StepResult) {
+	t.Helper()
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	writeJSON(t, filepath.Join(issueDir, "recon.json"), step)
+}
+
+func TestServer_ReviewChain_WithReconStep(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{8},
+		StartedAt:    now,
+	})
+
+	writeIssueFiles(t, runDir, 8,
+		rundata.Outcome{IssueNumber: 8, Status: "implemented", PRNumber: 42},
+		rundata.StepResult{Output: "impl done", DurationSeconds: 60},
+		rundata.StepResult{},
+		rundata.StepResult{Output: "review done REVIEW_RESULT=APPROVED", DurationSeconds: 15},
+	)
+	issueDir := filepath.Join(runDir, "issues", "8")
+	writeReconFile(t, issueDir, rundata.StepResult{
+		Output:          "Recon brief: the codebase uses X pattern",
+		CostUSD:         0.0025,
+		DurationSeconds: 18.5,
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/8/review-chain", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 500))
+	}
+	body := rr.Body.String()
+
+	if !strings.Contains(body, "Recon") {
+		t.Error("body missing Recon step")
+	}
+	if !strings.Contains(body, "Implement") {
+		t.Error("body missing Implement step")
+	}
+}
+
+func TestServer_ReviewChain_WithoutReconStep(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{9},
+		StartedAt:    now,
+	})
+
+	writeIssueFiles(t, runDir, 9,
+		rundata.Outcome{IssueNumber: 9, Status: "implemented"},
+		rundata.StepResult{Output: "impl done REVIEW_RESULT=APPROVED", DurationSeconds: 30},
+		rundata.StepResult{},
+		rundata.StepResult{},
+	)
+	// No recon.json written — simulates a pre-Phase-18 run.
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/9/review-chain", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 500))
+	}
+	body := rr.Body.String()
+
+	if strings.Contains(body, ">Recon<") {
+		t.Error("body should not contain Recon step when no recon data exists")
+	}
+	if !strings.Contains(body, "Implement") {
+		t.Error("body missing Implement step")
+	}
+}
 
 func TestServer_ReviewChain_WithSteps(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/rundata/reader.go
+++ b/internal/rundata/reader.go
@@ -26,6 +26,7 @@ type IssueDetail struct {
 	Outcome          Outcome
 	LiveStatus       IssueStatus // from status.json; empty Status if not present
 	BlockedBy        []int       // open (not-yet-completed) dependencies; derived by LoadRun
+	Recon            StepResult
 	SpecGenerator    StepResult
 	Implement        StepResult
 	QualityReview    StepResult
@@ -270,6 +271,7 @@ func (r *Reader) readRunMeta(runDir string) (RunMeta, bool) {
 func (r *Reader) loadIssueDetail(issueDir string, issueNum int) IssueDetail {
 	return IssueDetail{
 		IssueNumber:      issueNum,
+		Recon:            r.readStep(filepath.Join(issueDir, "recon.json")),
 		SpecGenerator:    r.readStep(filepath.Join(issueDir, "spec-generator.json")),
 		Implement:        r.readStep(filepath.Join(issueDir, "implement.json")),
 		QualityReview:    r.readStep(filepath.Join(issueDir, "quality-review.json")),

--- a/internal/rundata/reader_test.go
+++ b/internal/rundata/reader_test.go
@@ -989,3 +989,75 @@ func TestLoadRun_NoDepsNoBlockedBy(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadRun_ReconJSONLoaded(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:         "owner/repo",
+		IssueNumbers: []int{10},
+		StartedAt:    time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "10")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	recon := StepResult{Output: "recon brief", SessionID: "s1", CostUSD: 0.005, DurationSeconds: 20}
+	if err := writeJSON(filepath.Join(issueDir, "recon.json"), recon); err != nil {
+		t.Fatalf("writing recon.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+	got := detail.Issues[0].Recon
+	if got.Output != "recon brief" {
+		t.Errorf("Recon.Output = %q, want %q", got.Output, "recon brief")
+	}
+	if got.SessionID != "s1" {
+		t.Errorf("Recon.SessionID = %q, want %q", got.SessionID, "s1")
+	}
+	if got.CostUSD != 0.005 {
+		t.Errorf("Recon.CostUSD = %v, want 0.005", got.CostUSD)
+	}
+}
+
+func TestLoadRun_MissingReconJSONNoError(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120001", RunMeta{
+		Repo:         "owner/repo",
+		IssueNumbers: []int{11},
+		StartedAt:    time.Now().UTC(),
+	})
+
+	issueDir := filepath.Join(runDir, "issues", "11")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	// Write outcome but no recon.json — simulates a pre-Phase-18 run.
+	outcome := Outcome{IssueNumber: 11, Status: "implemented"}
+	if err := writeJSON(filepath.Join(issueDir, "outcome.json"), outcome); err != nil {
+		t.Fatalf("writing outcome.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120001")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+	recon := detail.Issues[0].Recon
+	// Recon should be zero value — no output, no cost, no duration.
+	if recon.Output != "" || recon.CostUSD != 0 || recon.DurationSeconds != 0 {
+		t.Errorf("Recon should be zero value for old run data, got: %+v", recon)
+	}
+}

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -151,6 +151,13 @@ func (w *Writer) Dir() string {
 	return w.dir
 }
 
+// WriteReconResult writes the recon step result for the given issue.
+// Path: issues/<issueNum>/recon.json
+func (w *Writer) WriteReconResult(issueNum int, step StepResult) error {
+	path := filepath.Join(w.dir, "issues", fmt.Sprintf("%d", issueNum), "recon.json")
+	return writeJSONMkdirs(path, step)
+}
+
 // WriteSpecGeneratorResult writes the spec generator step result for the given issue.
 // Path: issues/<issueNum>/spec-generator.json
 func (w *Writer) WriteSpecGeneratorResult(issueNum int, step StepResult) error {

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -135,6 +135,48 @@ func TestRunJSONFinalized(t *testing.T) {
 	}
 }
 
+func TestReconResultWritten(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := StepResult{
+		Output:          "recon brief text",
+		SessionID:       "sess-abc",
+		CostUSD:         0.0012,
+		DurationSeconds: 15.0,
+	}
+	if err := w.WriteReconResult(42, step); err != nil {
+		t.Fatalf("WriteReconResult() error: %v", err)
+	}
+
+	path := filepath.Join(w.Dir(), "issues", "42", "recon.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file at %s, got: %v", path, err)
+	}
+
+	var written StepResult
+	if err := json.Unmarshal(data, &written); err != nil {
+		t.Fatalf("parsing recon.json: %v", err)
+	}
+
+	if written.Output != "recon brief text" {
+		t.Errorf("Output = %q, want %q", written.Output, "recon brief text")
+	}
+	if written.SessionID != "sess-abc" {
+		t.Errorf("SessionID = %q, want %q", written.SessionID, "sess-abc")
+	}
+	if written.CostUSD != 0.0012 {
+		t.Errorf("CostUSD = %v, want 0.0012", written.CostUSD)
+	}
+	if written.DurationSeconds != 15.0 {
+		t.Errorf("DurationSeconds = %v, want 15.0", written.DurationSeconds)
+	}
+}
+
 func TestSpecGeneratorWritten(t *testing.T) {
 	base := t.TempDir()
 	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})


### PR DESCRIPTION
## Summary

- Adds `WriteReconResult` to the `RunDataHook` interface and implements it in `rundata.Writer` (writes `recon.json` alongside other step files)
- Calls `hook.WriteReconResult()` in `loop.go` after the recon agent on all paths (error, timeout, success)
- Surfaces the recon step in the dashboard issue-detail timeline (before Implement), including cost and duration; backwards compatible when `recon.json` is absent

## Test plan

- [x] `TestReconResultWritten` — verifies `recon.json` is created with correct fields
- [x] `TestLoadRun_ReconJSONLoaded` — verifies reader correctly loads `recon.json`
- [x] `TestLoadRun_MissingReconJSONNoError` — verifies old run data without `recon.json` loads without error (zero value)
- [x] `TestServer_ReviewChain_WithReconStep` — verifies the Recon step appears in the timeline when `recon.json` exists
- [x] `TestServer_ReviewChain_WithoutReconStep` — verifies no Recon step appears for pre-Phase-18 runs
- [x] All existing tests continue to pass

## Implementation Notes

### Approach
Follows the exact same pattern as `WriteSpecGeneratorResult`: a simple `writeJSONMkdirs` call to `issues/<issueNum>/recon.json`. The `IssueDetail` struct gets a new `Recon StepResult` field populated by `loadIssueDetail` using the existing `readStep` helper (which already handles missing files gracefully).

### Key Decisions
- Recon step is positioned before Implement in the timeline (matching the execution order).
- Recon cost is included in the issue row total cost alongside implement/review costs.
- The `Output` field of `StepResult` carries the brief text (the recon agent's `ResultText`), consistent with all other steps.

### Known Limitations
- The dashboard template (`issue-detail.html`) itself does not need changes — the Recon step flows through the existing `review-chain-steps` template which already renders duration, cost, output, and tool trace.

### Architecture
- `internal/agent/runhook.go` (orchestration layer) — interface addition
- `internal/agent/loop.go` (orchestration layer) — call site
- `internal/rundata/writer.go` and `reader.go` (domain layer) — persistence
- `internal/dashboard/handlers.go` (presentation layer) — timeline rendering

All dependency arrows flow downward: orchestration → domain, presentation → domain. No new cross-layer imports introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #370