### PR TITLE
feat(config): set MaxResumeRetries default to 2 and add tests

### DIFF
--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -4146,3 +4146,190 @@ func TestExtractSection_ReturnsEmptyWhenHeadingAbsent(t *testing.T) {
 		t.Errorf("expected empty string when heading absent, got: %s", result)
 	}
 }
+
+// handoffTrackingGuard returns a GuardRunner stub that handles the common calls
+// needed by ProcessIssue tests and tracks calls to assembleHandoffContext.
+// handoffCallCount, if non-nil, is incremented whenever the
+// "gh pr view --json body,comments" call (from assembleHandoffContext) is made.
+func handoffTrackingGuard(handoffCallCount *int) func(string, ...string) ([]byte, error) {
+	return func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "body,comments") {
+			if handoffCallCount != nil {
+				*handoffCallCount++
+			}
+			return []byte(`{"body": "", "comments": []}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	}
+}
+
+func TestProcessIssue_ResumeOnAttempt0WithMaxResumeRetries2(t *testing.T) {
+	// With MaxResumeRetries: 2, attempt 0 (first retry) uses session resumption.
+	// assembleHandoffContext should NOT be called.
+	cfg := loopConfig()
+	cfg.MaxRetries = 2
+	cfg.MaxResumeRetries = 2
+
+	var handoffCallCount int
+	// Agent outputs: implementer, quality(APPROVED), reviewer(CHANGES), retry, reviewer(APPROVED)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output",
+		"REVIEW_RESULT=APPROVED",
+	}, handoffTrackingGuard(&handoffCallCount))
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if handoffCallCount != 0 {
+		t.Errorf("assembleHandoffContext called %d time(s) on attempt 0 with MaxResumeRetries=2, expected resume mode (0 calls)", handoffCallCount)
+	}
+}
+
+func TestProcessIssue_FreshOnAttempt2WithMaxResumeRetries2(t *testing.T) {
+	// With MaxResumeRetries: 2, attempt 2 (third retry) uses fresh agent with handoff.
+	// assembleHandoffContext SHOULD be called on the third retry (attempt index 2).
+	cfg := loopConfig()
+	cfg.MaxRetries = 3
+	cfg.MaxResumeRetries = 2
+
+	var handoffCallCount int
+	// Agent outputs: implementer, quality(APPROVED), review(CHANGES)×3, retry×3, review(APPROVED)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output 1",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output 2",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output 3",
+		"REVIEW_RESULT=APPROVED",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "body,comments") {
+			handoffCallCount++
+			return []byte(`{"body": "", "comments": []}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	// Attempt 0 and 1 resume (< 2), attempt 2 is fresh (>= 2). So handoff called once.
+	if handoffCallCount != 1 {
+		t.Errorf("handoff assembled %d time(s), want 1 (only on attempt 2)", handoffCallCount)
+	}
+}
+
+func TestProcessIssue_AllFreshWithMaxResumeRetries0(t *testing.T) {
+	// With MaxResumeRetries: 0, every retry uses fresh mode.
+	// assembleHandoffContext should be called on each retry attempt.
+	cfg := loopConfig()
+	cfg.MaxRetries = 2
+	cfg.MaxResumeRetries = 0
+
+	var handoffCallCount int
+	// Agent outputs: implementer, quality(APPROVED), review(CHANGES)×2, retry×2, review(APPROVED)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output 1",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output 2",
+		"REVIEW_RESULT=APPROVED",
+	}, func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "body,comments") {
+			handoffCallCount++
+			return []byte(`{"body": "", "comments": []}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json number") {
+			return []byte(`{"number": 10}`), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") && strings.Contains(joined, "--json body") {
+			return []byte(`{"body": "Closes #5"}`), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	})
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	// Both retries (attempt 0 and 1) should use fresh mode with MaxResumeRetries=0.
+	if handoffCallCount != 2 {
+		t.Errorf("handoff assembled %d time(s), want 2 (all retries fresh)", handoffCallCount)
+	}
+}
+
+func TestProcessIssue_AllResumeWithMaxResumeRetriesHigherThanMaxRetries(t *testing.T) {
+	// With MaxResumeRetries: 10 and MaxRetries: 3, all retry attempts use session resumption.
+	// assembleHandoffContext should never be called.
+	cfg := loopConfig()
+	cfg.MaxRetries = 3
+	cfg.MaxResumeRetries = 10
+
+	var handoffCalled int
+	// Agent outputs: implementer, quality(APPROVED), review(CHANGES)×3, retry×3, review(APPROVED)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output 1",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output 2",
+		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"retry output 3",
+		"REVIEW_RESULT=APPROVED",
+	}, handoffTrackingGuard(&handoffCalled))
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "implemented" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "implemented", outcome.Err)
+	}
+	if handoffCalled != 0 {
+		t.Errorf("assembleHandoffContext called %d time(s) with MaxResumeRetries=10, expected all-resume mode (0 calls)", handoffCalled)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,8 +129,8 @@ type Config struct {
 	// MaxResumeRetries controls when retry agents switch from resuming their
 	// prior session to starting a fresh session with structured handoff context.
 	// On attempt N where N >= MaxResumeRetries, a fresh session is started.
-	// Must be strictly less than MaxRetries for the feature to activate under
-	// default configuration. Default: 1.
+	// A value of 0 means all retries use fresh mode. A value >= MaxRetries
+	// means all retries use session resumption. Default: 2.
 	MaxResumeRetries int `yaml:"max_resume_retries"`
 
 	AgentTimeout  string            `yaml:"agent_timeout"`
@@ -287,7 +287,7 @@ func Load(path string, flags CLIFlags) (*Config, error) {
 func defaults() *Config {
 	return &Config{
 		MaxRetries:       3,
-		MaxResumeRetries: 1,
+		MaxResumeRetries: 2,
 		AutoMerge:      AutoMerge{Feature: "none", Rollup: "none"},
 		RoadmapPath:    "docs/ROADMAP.md",
 		ProtectedPaths: []string{"godark.yaml"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1771,3 +1771,32 @@ claude_flags: ["-v"]
 		t.Errorf("unexpected error loading config with legacy claude_flags: %v", err)
 	}
 }
+
+func TestMaxResumeRetriesDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `repo: owner/repo`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxResumeRetries != 2 {
+		t.Errorf("MaxResumeRetries = %d, want 2", cfg.MaxResumeRetries)
+	}
+}
+
+func TestMaxResumeRetriesOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+max_resume_retries: 0
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxResumeRetries != 0 {
+		t.Errorf("MaxResumeRetries = %d, want 0", cfg.MaxResumeRetries)
+	}
+}


### PR DESCRIPTION
## Summary

- Corrects `MaxResumeRetries` default value from 1 to 2 in `config.defaults()`
- Updates the field comment to document the `0` (all-fresh) and `>= MaxRetries` (all-resume) boundary semantics
- Adds config tests: default value of 2, and YAML override to 0
- Adds four loop tests covering all acceptance criteria scenarios

Closes #372

## Implementation Notes

### Approach
Issue #371 added the `MaxResumeRetries` field, wired the `qAttempt >= cfg.MaxResumeRetries` and `attempt >= cfg.MaxResumeRetries` checks in both retry loops, and implemented `assembleHandoffContext`. This PR corrects the default (1 → 2) and adds the test coverage specified in the issue.

The loop tests observe whether `assembleHandoffContext` was invoked by detecting the `gh pr view --json body,comments` GuardRunner call it makes, which is distinct from the other `gh pr view` calls in the loop.

### Key Decisions
- Named the new test helper `handoffTrackingGuard` to avoid collision with the existing `standardLoopGuard` helper (which takes no parameters).
- Tests use a counter (`int`) rather than a boolean to assert the exact number of handoff assemblies, making boundary conditions explicit.

### Known Limitations
None. All acceptance criteria test cases are covered.

### Architecture
Only the `foundation` layer (`internal/config/`) and `orchestration` layer (`internal/agent/`) are touched. No new dependencies introduced. The change is purely a default value correction and test addition.

## Test plan
- [x] `TestMaxResumeRetriesDefault` — new config has `MaxResumeRetries` of 2
- [x] `TestMaxResumeRetriesOverride` — setting `max_resume_retries: 0` in YAML is reflected
- [x] `TestProcessIssue_ResumeOnAttempt0WithMaxResumeRetries2` — attempt 0 uses session resumption
- [x] `TestProcessIssue_FreshOnAttempt2WithMaxResumeRetries2` — attempt 2 uses fresh agent
- [x] `TestProcessIssue_AllFreshWithMaxResumeRetries0` — all retries use fresh mode
- [x] `TestProcessIssue_AllResumeWithMaxResumeRetriesHigherThanMaxRetries` — all retries use resume mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)