### PR TITLE
feat: pre-merge rebase check and conflict recovery (#381)

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -478,6 +478,29 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				return outcome
 			}
 
+			// Step 5.45: Pre-merge rebase check. Verifies the PR is still
+			// mergeable after approval; if not, attempts automatic rebase or
+			// triggers a conflict-fix cycle.
+			if needsHR, rebaseErr := runPreMergeRebasePhase(
+				ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles,
+			); rebaseErr != nil {
+				outcome.Status = "failed"
+				outcome.Err = rebaseErr
+				return outcome
+			} else if needsHR {
+				if err := LabelPR(cfg.Repo, prNum, "needs-human-review"); err != nil {
+					logger.Warn("failed to label PR", "error", err)
+				}
+				applyLifecycleLabel(label.AwaitingHumanReview)
+				comment := fmt.Sprintf("PR has unresolvable conflicts after %d rebase attempt(s). Labeling for human review.", cfg.MaxRebaseAttempts)
+				if _, err := GuardRunner("gh", "pr", "comment", fmt.Sprintf("%d", prNum), "--repo", cfg.Repo, "--body", comment); err != nil {
+					logger.Warn("failed to comment on PR", "error", err)
+				}
+				outcome.Status = "needs-human-review"
+				outcome.Retries = attempt
+				return outcome
+			}
+
 			// Step 5.5: Wait for CI checks if configured.
 			if cfg.WaitForChecks != nil {
 				ciTimeout, _ := time.ParseDuration(cfg.WaitForChecks.Timeout) // already validated by config.Load
@@ -1177,4 +1200,106 @@ func logAndRecordFlags(flags []quality.Flag, logger *slog.Logger, issueNum int) 
 		rdFlags[i] = rundata.Flag{Code: f.Code, Message: f.Message}
 	}
 	return rdFlags
+}
+
+// runPreMergeRebasePhase checks whether the PR has conflicts before merging.
+// If the PR is CONFLICTING, it attempts to resolve them via automatic rebase
+// (gh pr update-branch) or by invoking the implementer in a conflict-fix cycle.
+// After any successful rebase, the verify pipeline is re-run since branch
+// content has changed. The cycle repeats up to cfg.MaxRebaseAttempts times.
+//
+// Returns (true, nil) when all attempts are exhausted and the caller should
+// label the PR for human review. Returns (false, nil) when the PR is ready to
+// merge. Returns (false, err) on hard errors (agent failure, context cancel,
+// drift detection).
+//
+// If cfg.MaxRebaseAttempts is 0 the function is a no-op and returns (false, nil).
+func runPreMergeRebasePhase(
+	ctx context.Context,
+	issue github.Issue,
+	prNum int,
+	branch string,
+	baseSHA string,
+	cfg *config.Config,
+	prompts *Prompts,
+	authEnv map[string]string,
+	logger *slog.Logger,
+	hook RunDataHook,
+	sessionID *string,
+	fixCycles *int,
+) (needsHumanReview bool, err error) {
+	if cfg.MaxRebaseAttempts <= 0 {
+		return false, nil
+	}
+
+	for attempt := 0; attempt < cfg.MaxRebaseAttempts; attempt++ {
+		mergeable, checkErr := github.CheckMergeable(cfg.Repo, prNum)
+		if checkErr != nil {
+			// Best-effort: log and proceed; the merge call will fail naturally
+			// if the PR is actually conflicting.
+			logger.Warn("failed to check mergeable status, proceeding to merge",
+				"pr_number", prNum, "error", checkErr)
+			return false, nil
+		}
+
+		if mergeable != "CONFLICTING" {
+			// MERGEABLE or UNKNOWN — proceed with merge.
+			return false, nil
+		}
+
+		logger.Info("PR is conflicting, attempting automatic rebase",
+			"pr_number", prNum,
+			"attempt", attempt+1,
+			"max_attempts", cfg.MaxRebaseAttempts,
+		)
+
+		updateErr := github.UpdateBranch(cfg.Repo, prNum)
+		if updateErr != nil {
+			// Automatic rebase failed — invoke the implementer in a fix cycle
+			// so it can resolve the conflicts manually.
+			logger.Info("automatic rebase failed, invoking conflict fix cycle",
+				"pr_number", prNum,
+				"attempt", attempt+1,
+				"error", updateErr,
+			)
+			conflictInfo := fmt.Sprintf(
+				"PR #%d has merge conflicts with the base branch that could not be automatically resolved.\n\nError: %v\n\nPlease resolve the merge conflicts, push the changes, and ensure the branch is up to date with the base branch.",
+				prNum, updateErr,
+			)
+			retryResult, retryErr := Retry(ctx, issue, prNum, *sessionID, conflictInfo, "", cfg, prompts, authEnv, logger)
+			if retryErr != nil {
+				return false, fmt.Errorf("conflict fix agent: %w", retryErr)
+			}
+			if retryResult.TimedOut {
+				return false, fmt.Errorf("conflict fix agent timed out")
+			}
+			*sessionID = retryResult.SessionID
+
+			if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
+				return false, driftErr
+			}
+		}
+
+		// Re-run verify since the branch content has changed (either by
+		// automatic rebase or by the implementer's conflict fix).
+		if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, sessionID, fixCycles); verifyErr != nil {
+			return false, fmt.Errorf("verify after rebase attempt %d: %w", attempt+1, verifyErr)
+		}
+	}
+
+	// All attempts used; check one final time.
+	mergeable, checkErr := github.CheckMergeable(cfg.Repo, prNum)
+	if checkErr != nil {
+		logger.Warn("failed to check mergeable status after rebase attempts, proceeding",
+			"pr_number", prNum, "error", checkErr)
+		return false, nil
+	}
+	if mergeable == "CONFLICTING" {
+		logger.Warn("PR still conflicting after all rebase attempts, labeling for human review",
+			"pr_number", prNum,
+			"max_attempts", cfg.MaxRebaseAttempts,
+		)
+		return true, nil
+	}
+	return false, nil
 }

--- a/internal/agent/rebase_test.go
+++ b/internal/agent/rebase_test.go
@@ -1,0 +1,372 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/phs/dark-factory/internal/github"
+)
+
+// rebaseTestConfig returns a config suitable for runPreMergeRebasePhase tests.
+// No verify commands are configured so the verify phase is a no-op.
+func rebaseTestConfig() *config.Config {
+	return &config.Config{
+		Repo:              "owner/repo",
+		NoSandbox:         true,
+		AgentTimeout:      "10m",
+		ProtectedPaths:    []string{"CLAUDE.md"},
+		ScenarioDir:       "tests/scenarios/",
+		ReviewDir:         "tests/review/",
+		MaxRebaseAttempts: 1,
+	}
+}
+
+// standardRebaseGuard returns a GuardRunner stub that satisfies the minimum
+// responses needed for runPreMergeRebasePhase: drift diff and any other calls.
+func standardRebaseGuard() func(string, ...string) ([]byte, error) {
+	return func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			return []byte("src/main.go\n"), nil
+		}
+		return []byte(""), nil
+	}
+}
+
+func TestRunPreMergeRebasePhase_Disabled(t *testing.T) {
+	cfg := rebaseTestConfig()
+	cfg.MaxRebaseAttempts = 0
+
+	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
+		// Should not be called when MaxRebaseAttempts=0.
+		return []byte(""), nil
+	})
+
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	called := false
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		called = true
+		return []byte(""), nil
+	}
+
+	sid := "sess"
+	fc := 0
+	needsHR, err := runPreMergeRebasePhase(
+		context.Background(), testIssue(), 42, "42-test", "abc123",
+		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needsHR {
+		t.Error("expected needsHumanReview=false when MaxRebaseAttempts=0")
+	}
+	if called {
+		t.Error("expected github.CommandRunner not to be called when MaxRebaseAttempts=0")
+	}
+}
+
+func TestRunPreMergeRebasePhase_Mergeable(t *testing.T) {
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "--json mergeable") {
+			return []byte(`{"mergeable":"MERGEABLE"}`), nil
+		}
+		return []byte(""), nil
+	}
+
+	stubGuardRunner(t, standardRebaseGuard())
+
+	cfg := rebaseTestConfig()
+	sid := "sess"
+	fc := 0
+	needsHR, err := runPreMergeRebasePhase(
+		context.Background(), testIssue(), 42, "42-test", "abc123",
+		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needsHR {
+		t.Error("expected needsHumanReview=false for MERGEABLE PR")
+	}
+}
+
+func TestRunPreMergeRebasePhase_Unknown(t *testing.T) {
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "--json mergeable") {
+			return []byte(`{"mergeable":"UNKNOWN"}`), nil
+		}
+		return []byte(""), nil
+	}
+
+	stubGuardRunner(t, standardRebaseGuard())
+
+	cfg := rebaseTestConfig()
+	sid := "sess"
+	fc := 0
+	needsHR, err := runPreMergeRebasePhase(
+		context.Background(), testIssue(), 42, "42-test", "abc123",
+		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needsHR {
+		t.Error("expected needsHumanReview=false for UNKNOWN mergeable status")
+	}
+}
+
+func TestRunPreMergeRebasePhase_CheckMergeableError(t *testing.T) {
+	// CheckMergeable failing is best-effort: should log warning and proceed (false, nil).
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("gh: network error")
+	}
+
+	stubGuardRunner(t, standardRebaseGuard())
+
+	cfg := rebaseTestConfig()
+	sid := "sess"
+	fc := 0
+	needsHR, err := runPreMergeRebasePhase(
+		context.Background(), testIssue(), 42, "42-test", "abc123",
+		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needsHR {
+		t.Error("expected needsHumanReview=false on CheckMergeable error (best-effort)")
+	}
+}
+
+func TestRunPreMergeRebasePhase_ConflictingAutoRebaseSuccess(t *testing.T) {
+	// PR is CONFLICTING. UpdateBranch succeeds. Final check returns MERGEABLE.
+	checkCallCount := 0
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "--json mergeable") {
+			checkCallCount++
+			if checkCallCount == 1 {
+				return []byte(`{"mergeable":"CONFLICTING"}`), nil
+			}
+			// Final check after rebase: return MERGEABLE.
+			return []byte(`{"mergeable":"MERGEABLE"}`), nil
+		}
+		if strings.Contains(joined, "update-branch") {
+			return []byte(""), nil // update-branch succeeds
+		}
+		return []byte(""), nil
+	}
+
+	stubGuardRunner(t, standardRebaseGuard())
+
+	cfg := rebaseTestConfig()
+	cfg.MaxRebaseAttempts = 1
+	sid := "sess"
+	fc := 0
+	needsHR, err := runPreMergeRebasePhase(
+		context.Background(), testIssue(), 42, "42-test", "abc123",
+		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needsHR {
+		t.Errorf("expected needsHumanReview=false after successful auto-rebase")
+	}
+	if checkCallCount < 2 {
+		t.Errorf("expected at least 2 CheckMergeable calls, got %d", checkCallCount)
+	}
+}
+
+func TestRunPreMergeRebasePhase_ConflictingUpdateBranchFails_ImplementerFixes(t *testing.T) {
+	// PR is CONFLICTING. UpdateBranch fails. Retry agent runs. Final check MERGEABLE.
+	checkCallCount := 0
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "--json mergeable") {
+			checkCallCount++
+			if checkCallCount == 1 {
+				return []byte(`{"mergeable":"CONFLICTING"}`), nil
+			}
+			return []byte(`{"mergeable":"MERGEABLE"}`), nil
+		}
+		if strings.Contains(joined, "update-branch") {
+			return nil, fmt.Errorf("exit status 1: conflicts") // update-branch fails
+		}
+		return []byte(""), nil
+	}
+
+	retryCallCount := 0
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		retryCallCount++
+		out := wrapRunnerJSON("conflict fix output")
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	stubGuardRunner(t, standardRebaseGuard())
+
+	cfg := rebaseTestConfig()
+	cfg.MaxRebaseAttempts = 1
+	sid := "sess"
+	fc := 0
+	needsHR, err := runPreMergeRebasePhase(
+		context.Background(), testIssue(), 42, "42-test", "abc123",
+		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if needsHR {
+		t.Errorf("expected needsHumanReview=false after implementer fixes conflicts")
+	}
+	if retryCallCount == 0 {
+		t.Errorf("expected Retry agent to be called on update-branch failure, got 0 calls")
+	}
+}
+
+func TestRunPreMergeRebasePhase_ExhaustsAttempts_NeedsHumanReview(t *testing.T) {
+	// PR remains CONFLICTING after all rebase attempts.
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "--json mergeable") {
+			return []byte(`{"mergeable":"CONFLICTING"}`), nil
+		}
+		if strings.Contains(joined, "update-branch") {
+			return nil, fmt.Errorf("exit status 1: conflicts")
+		}
+		return []byte(""), nil
+	}
+
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		out := wrapRunnerJSON("conflict fix attempted but conflicts remain")
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	stubGuardRunner(t, standardRebaseGuard())
+
+	cfg := rebaseTestConfig()
+	cfg.MaxRebaseAttempts = 1
+	sid := "sess"
+	fc := 0
+	needsHR, err := runPreMergeRebasePhase(
+		context.Background(), testIssue(), 42, "42-test", "abc123",
+		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !needsHR {
+		t.Errorf("expected needsHumanReview=true when all rebase attempts exhausted")
+	}
+}
+
+func TestRunPreMergeRebasePhase_MultipleAttempts(t *testing.T) {
+	// With MaxRebaseAttempts=2, should try twice before marking needs-human-review.
+	checkCallCount := 0
+	retryCallCount := 0
+
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if strings.Contains(joined, "--json mergeable") {
+			checkCallCount++
+			return []byte(`{"mergeable":"CONFLICTING"}`), nil
+		}
+		if strings.Contains(joined, "update-branch") {
+			return nil, fmt.Errorf("exit status 1: conflicts")
+		}
+		return []byte(""), nil
+	}
+
+	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		retryCallCount++
+		out := wrapRunnerJSON("conflict fix output")
+		return []byte(out), []byte(""), 0, nil
+	})
+
+	stubGuardRunner(t, standardRebaseGuard())
+
+	cfg := rebaseTestConfig()
+	cfg.MaxRebaseAttempts = 2
+	sid := "sess"
+	fc := 0
+	needsHR, err := runPreMergeRebasePhase(
+		context.Background(), testIssue(), 42, "42-test", "abc123",
+		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !needsHR {
+		t.Error("expected needsHumanReview=true after exhausting 2 attempts")
+	}
+	// 2 loop checks + 1 final check = 3 total.
+	if checkCallCount != 3 {
+		t.Errorf("expected 3 CheckMergeable calls (2 loop + 1 final), got %d", checkCallCount)
+	}
+	if retryCallCount != 2 {
+		t.Errorf("expected 2 Retry calls (one per attempt), got %d", retryCallCount)
+	}
+}
+
+// TestProcessIssue_PreMergeRebase_LabelsNeedsHumanReview tests the full
+// ProcessIssue flow when the pre-merge rebase phase exhausts attempts.
+func TestProcessIssue_PreMergeRebase_LabelsNeedsHumanReview(t *testing.T) {
+	// github.CommandRunner handles CheckMergeable (CONFLICTING) and UpdateBranch (fails),
+	// plus AddIssueLabel for the needs-human-review label.
+	var addedLabels []string
+	origGH := github.CommandRunner
+	t.Cleanup(func() { github.CommandRunner = origGH })
+	github.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		for i, a := range args {
+			if a == "--add-label" && i+1 < len(args) {
+				addedLabels = append(addedLabels, args[i+1])
+			}
+		}
+		if strings.Contains(joined, "--json mergeable") {
+			return []byte(`{"mergeable":"CONFLICTING"}`), nil
+		}
+		if strings.Contains(joined, "update-branch") {
+			return nil, fmt.Errorf("exit status 1: conflicts")
+		}
+		return []byte(""), nil
+	}
+
+	// Agent calls: implementer, quality_reviewer (APPROVED), reviewer (APPROVED), conflict fix
+	setupLoopTest(t, []string{
+		"implementer output",
+		"QUALITY_RESULT=APPROVED",
+		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"conflict fix output",
+	}, standardLoopGuard())
+
+	cfg := loopConfig()
+	cfg.MaxRebaseAttempts = 1
+
+	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
+
+	if outcome.Status != "needs-human-review" {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, "needs-human-review", outcome.Err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,6 +132,12 @@ type Config struct {
 	// A value of 0 means all retries use fresh mode. A value >= MaxRetries
 	// means all retries use session resumption. Default: 2.
 	MaxResumeRetries int `yaml:"max_resume_retries"`
+	// MaxRebaseAttempts controls how many automatic rebase/conflict-fix cycles
+	// are attempted before a conflicting PR is labeled needs-human-review.
+	// Each cycle tries gh pr update-branch first; if that fails it invokes the
+	// implementer to resolve conflicts. A value of 0 disables the pre-merge
+	// rebase check entirely. Default: 1.
+	MaxRebaseAttempts int `yaml:"max_rebase_attempts"`
 
 	AgentTimeout  string            `yaml:"agent_timeout"`
 	FormatCommand string            `yaml:"format_command"`
@@ -286,8 +292,9 @@ func Load(path string, flags CLIFlags) (*Config, error) {
 
 func defaults() *Config {
 	return &Config{
-		MaxRetries:       3,
-		MaxResumeRetries: 2,
+		MaxRetries:        3,
+		MaxResumeRetries:  2,
+		MaxRebaseAttempts: 1,
 		AutoMerge:      AutoMerge{Feature: "none", Rollup: "none"},
 		RoadmapPath:    "docs/ROADMAP.md",
 		ProtectedPaths: []string{"godark.yaml"},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1800,3 +1800,50 @@ max_resume_retries: 0
 		t.Errorf("MaxResumeRetries = %d, want 0", cfg.MaxResumeRetries)
 	}
 }
+
+func TestMaxRebaseAttemptsDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxRebaseAttempts != 1 {
+		t.Errorf("MaxRebaseAttempts = %d, want 1", cfg.MaxRebaseAttempts)
+	}
+}
+
+func TestMaxRebaseAttemptsOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+max_rebase_attempts: 3
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxRebaseAttempts != 3 {
+		t.Errorf("MaxRebaseAttempts = %d, want 3", cfg.MaxRebaseAttempts)
+	}
+}
+
+func TestMaxRebaseAttemptsZeroDisables(t *testing.T) {
+	dir := t.TempDir()
+	path := writeYAML(t, dir, `
+repo: owner/repo
+max_rebase_attempts: 0
+`)
+
+	cfg, err := Load(path, CLIFlags{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MaxRebaseAttempts != 0 {
+		t.Errorf("MaxRebaseAttempts = %d, want 0", cfg.MaxRebaseAttempts)
+	}
+}

--- a/internal/github/mergeable.go
+++ b/internal/github/mergeable.go
@@ -1,0 +1,43 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// CheckMergeable returns the mergeable status of a pull request.
+// Possible return values are "MERGEABLE", "CONFLICTING", and "UNKNOWN".
+// Returns an error if the GitHub API call fails or the output cannot be parsed.
+func CheckMergeable(repo string, prNum int) (string, error) {
+	out, err := CommandRunner("gh", "pr", "view",
+		fmt.Sprintf("%d", prNum),
+		"--repo", repo,
+		"--json", "mergeable",
+	)
+	if err != nil {
+		return "", fmt.Errorf("gh pr view --json mergeable: %w", err)
+	}
+
+	var result struct {
+		Mergeable string `json:"mergeable"`
+	}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", fmt.Errorf("parsing mergeable status: %w", err)
+	}
+
+	return result.Mergeable, nil
+}
+
+// UpdateBranch updates a PR branch by rebasing it onto the base branch via
+// GitHub's built-in rebase mechanism. Returns an error if the update fails
+// (e.g. the PR has unresolvable conflicts).
+func UpdateBranch(repo string, prNum int) error {
+	_, err := CommandRunner("gh", "pr", "update-branch",
+		fmt.Sprintf("%d", prNum),
+		"--repo", repo,
+	)
+	if err != nil {
+		return fmt.Errorf("gh pr update-branch #%d: %w", prNum, err)
+	}
+	return nil
+}

--- a/internal/github/mergeable_test.go
+++ b/internal/github/mergeable_test.go
@@ -1,0 +1,165 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestCheckMergeable_Mergeable(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(`{"mergeable":"MERGEABLE"}`), nil
+	}
+
+	status, err := CheckMergeable("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "MERGEABLE" {
+		t.Errorf("got %q, want %q", status, "MERGEABLE")
+	}
+}
+
+func TestCheckMergeable_Conflicting(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(`{"mergeable":"CONFLICTING"}`), nil
+	}
+
+	status, err := CheckMergeable("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "CONFLICTING" {
+		t.Errorf("got %q, want %q", status, "CONFLICTING")
+	}
+}
+
+func TestCheckMergeable_Unknown(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(`{"mergeable":"UNKNOWN"}`), nil
+	}
+
+	status, err := CheckMergeable("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != "UNKNOWN" {
+		t.Errorf("got %q, want %q", status, "UNKNOWN")
+	}
+}
+
+func TestCheckMergeable_CLIError(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 1")
+	}
+
+	_, err := CheckMergeable("owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestCheckMergeable_MalformedJSON(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(`not valid json`), nil
+	}
+
+	_, err := CheckMergeable("owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestCheckMergeable_PassesCorrectArgs(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	var capturedArgs []string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		capturedArgs = append([]string{name}, args...)
+		return []byte(`{"mergeable":"MERGEABLE"}`), nil
+	}
+
+	_, err := CheckMergeable("owner/repo", 99)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"gh", "pr", "view", "99", "--repo", "owner/repo", "--json", "mergeable"}
+	if len(capturedArgs) != len(want) {
+		t.Fatalf("args length: got %d, want %d\ngot: %v", len(capturedArgs), len(want), capturedArgs)
+	}
+	for i, w := range want {
+		if capturedArgs[i] != w {
+			t.Errorf("arg[%d]: got %q, want %q", i, capturedArgs[i], w)
+		}
+	}
+}
+
+func TestUpdateBranch_Success(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	err := UpdateBranch("owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateBranch_CLIError(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("exit status 1")
+	}
+
+	err := UpdateBranch("owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestUpdateBranch_PassesCorrectArgs(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	var capturedArgs []string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		capturedArgs = append([]string{name}, args...)
+		return []byte(""), nil
+	}
+
+	err := UpdateBranch("owner/repo", 77)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"gh", "pr", "update-branch", "77", "--repo", "owner/repo"}
+	if len(capturedArgs) != len(want) {
+		t.Fatalf("args length: got %d, want %d\ngot: %v", len(capturedArgs), len(want), capturedArgs)
+	}
+	for i, w := range want {
+		if capturedArgs[i] != w {
+			t.Errorf("arg[%d]: got %q, want %q", i, capturedArgs[i], w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CheckMergeable()` and `UpdateBranch()` wrappers in `internal/github/` to query PR mergeable status and trigger GitHub's built-in rebase
- Add `runPreMergeRebasePhase()` in `internal/agent/loop.go` — called after approval but before `WaitForChecks`/merge; automatically resolves conflicts or triggers an implementer fix cycle
- Add `MaxRebaseAttempts` config field (default 1) to `internal/config/config.go`

## Test plan

- [ ] `go test ./internal/github/... -run TestCheckMergeable` — 6 tests for the new `CheckMergeable` wrapper
- [ ] `go test ./internal/github/... -run TestUpdateBranch` — 3 tests for the new `UpdateBranch` wrapper
- [ ] `go test ./internal/agent/... -run TestRunPreMergeRebasePhase` — 8 unit tests covering disabled, MERGEABLE, UNKNOWN, error (best-effort), auto-rebase success, auto-rebase fail + implementer fix, exhausted attempts, multiple attempts
- [ ] `go test ./internal/agent/... -run TestProcessIssue_PreMergeRebase` — integration test verifying `needs-human-review` outcome when rebase is exhausted
- [ ] `go test ./internal/config/... -run TestMaxRebaseAttempts` — 3 tests for default, override, and zero (disabled)

Closes #381

## Implementation Notes

### Approach
The pre-merge rebase check (`runPreMergeRebasePhase`) is inserted as Step 5.45, after the `shouldMerge` decision but before `WaitForChecks`. This avoids running CI twice: we resolve conflicts first, then hand off to the existing CI wait + merge sequence.

### Key Decisions
- `CheckMergeable` / `UpdateBranch` placed in `internal/github/` (infrastructure layer) — they are thin `gh` CLI wrappers following the same pattern as `FetchPRCommentBodies`.
- Conflict details are passed to `Retry` as `reviewFeedback` — this reuses the existing implementer-retry prompt without any template changes.
- Best-effort on `CheckMergeable` errors: if the API call fails, a warning is logged and the merge proceeds normally (the merge call will fail loudly if the PR is actually conflicting).
- `MaxRebaseAttempts = 0` fully disables the rebase check (opt-out path).

### Known Limitations
- `gh pr update-branch` performs a merge-commit update, not a true rebase. If GitHub's API evolves to support true rebases, the function name still makes sense.
- No re-review after rebase (by design per the issue spec): only the verify pipeline is re-run.

### Architecture
- **foundation** (`internal/config`): added `MaxRebaseAttempts` field
- **infrastructure** (`internal/github`): added `mergeable.go` with two new CLI wrappers
- **orchestration** (`internal/agent`): modified `loop.go` to call the new phase; orchestration layer depends on infrastructure — compliant with the layer graph

🤖 Generated with [Claude Code](https://claude.com/claude-code)