### PR TITLE
feat: add internal/mdutil package with WalkMarkdownFiles

### DIFF
--- a/docs/architecture.json
+++ b/docs/architecture.json
@@ -45,7 +45,7 @@
     {
       "name": "foundation",
       "description": "Zero-dependency utilities importable by all layers. Configuration and logging.",
-      "paths": ["internal/config/", "internal/logging/", "internal/label/"],
+      "paths": ["internal/config/", "internal/logging/", "internal/label/", "internal/mdutil/"],
       "may_depend_on": [],
       "must_not_depend_on": ["cmd", "orchestration", "service", "domain", "infrastructure", "presentation", "content"]
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ content.
 
 ### foundation
 
-**Paths:** `internal/config/`, `internal/logging/`, `internal/label/`
+**Paths:** `internal/config/`, `internal/logging/`, `internal/label/`, `internal/mdutil/`
 
 **Purpose:** Zero-dependency utilities that any layer may import. Configuration
 loading and structured logging.

--- a/internal/mdutil/walk.go
+++ b/internal/mdutil/walk.go
@@ -1,0 +1,22 @@
+package mdutil
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// WalkMarkdownFiles walks dir recursively and calls fn for each .md file found.
+// Directories and non-.md files are skipped. Returns the first error from fn
+// or from the walk itself.
+func WalkMarkdownFiles(dir string, fn func(path string) error) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		return fn(path)
+	})
+}

--- a/internal/mdutil/walk_test.go
+++ b/internal/mdutil/walk_test.go
@@ -1,0 +1,86 @@
+package mdutil_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/mdutil"
+)
+
+func TestWalkMarkdownFiles_OnlyMarkdownFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.md"), "")
+	writeFile(t, filepath.Join(dir, "b.go"), "")
+	writeFile(t, filepath.Join(dir, "c.txt"), "")
+
+	var got []string
+	err := mdutil.WalkMarkdownFiles(dir, func(path string) error {
+		got = append(got, filepath.Base(path))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "a.md" {
+		t.Errorf("got %v, want [a.md]", got)
+	}
+}
+
+func TestWalkMarkdownFiles_SkipsSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(subdir, "nested.md"), "")
+
+	var got []string
+	err := mdutil.WalkMarkdownFiles(dir, func(path string) error {
+		got = append(got, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// fn should only be called with file paths, not directory paths
+	for _, p := range got {
+		info, statErr := os.Stat(p)
+		if statErr != nil {
+			t.Fatalf("stat %s: %v", p, statErr)
+		}
+		if info.IsDir() {
+			t.Errorf("fn was called with a directory path: %s", p)
+		}
+	}
+}
+
+func TestWalkMarkdownFiles_PropagatesFnError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.md"), "")
+
+	sentinel := errors.New("stop")
+	err := mdutil.WalkMarkdownFiles(dir, func(path string) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("got %v, want sentinel error", err)
+	}
+}
+
+func TestWalkMarkdownFiles_MissingDirectory(t *testing.T) {
+	err := mdutil.WalkMarkdownFiles("/nonexistent/path/does/not/exist", func(path string) error {
+		return nil
+	})
+	if err == nil {
+		t.Error("expected error for missing directory, got nil")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- Creates `internal/mdutil` foundation-layer package with `WalkMarkdownFiles(dir string, fn func(path string) error) error`
- Adds `internal/mdutil/` to the foundation layer `paths` in `docs/architecture.json` and `docs/architecture.md`
- Includes unit tests covering all 4 acceptance test cases

## Test plan

- [x] Walks only `.md` files — `.go` and `.txt` siblings are ignored
- [x] Directories are not passed to `fn`
- [x] Errors returned from `fn` are propagated
- [x] Missing directory returns an error

Closes #384

## Implementation Notes

### Approach
`WalkMarkdownFiles` is a thin wrapper around `filepath.WalkDir` that filters to `.md` files only and delegates to a caller-supplied `fn`. The implementation mirrors the shared pattern found across `internal/vet`, `internal/punchlist`, and `internal/agent` but does not refactor those call sites (out of scope per the issue).

### Key Decisions
- Used `io/fs.DirEntry` (not `filepath.DirEntry` which doesn't exist) as the callback parameter type, consistent with the `filepath.WalkDir` signature.
- Zero internal imports — only `io/fs`, `path/filepath`, and `strings` from stdlib, satisfying the foundation layer's zero-dependency constraint.

### Known Limitations
The three existing call sites (`internal/vet/scenarios.go`, `internal/punchlist/punchlist.go`, `internal/agent/guardrails.go`) are not yet migrated to use this utility; that is deferred to future cleanup issues.

### Architecture
Touches only the **foundation** layer (new package `internal/mdutil/`) and its two documentation files. No higher-layer packages were modified. The new package has no internal dependencies, consistent with all other foundation packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)