### PR TITLE
feat: create internal/exec package with CommandRunnerFunc

### DIFF
--- a/docs/architecture.json
+++ b/docs/architecture.json
@@ -45,7 +45,7 @@
     {
       "name": "foundation",
       "description": "Zero-dependency utilities importable by all layers. Configuration and logging.",
-      "paths": ["internal/config/", "internal/logging/", "internal/label/", "internal/mdutil/"],
+      "paths": ["internal/config/", "internal/logging/", "internal/label/", "internal/mdutil/", "internal/exec/"],
       "may_depend_on": [],
       "must_not_depend_on": ["cmd", "orchestration", "service", "domain", "infrastructure", "presentation", "content"]
     },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,10 +100,10 @@ content.
 
 ### foundation
 
-**Paths:** `internal/config/`, `internal/logging/`, `internal/label/`, `internal/mdutil/`
+**Paths:** `internal/config/`, `internal/logging/`, `internal/label/`, `internal/mdutil/`, `internal/exec/`
 
 **Purpose:** Zero-dependency utilities that any layer may import. Configuration
-loading and structured logging.
+loading, structured logging, and command execution.
 
 **May depend on:** (none).
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -1,0 +1,14 @@
+package exec
+
+import osexec "os/exec"
+
+// CommandRunnerFunc is the shared function type for package-level command
+// runner variables. It executes a named command with the given arguments and
+// returns the combined output.
+type CommandRunnerFunc func(name string, args ...string) ([]byte, error)
+
+// Default is a CommandRunnerFunc that runs the named command and returns its
+// combined stdout and stderr output.
+var Default CommandRunnerFunc = func(name string, args ...string) ([]byte, error) {
+	return osexec.Command(name, args...).CombinedOutput()
+}

--- a/internal/exec/exec_test.go
+++ b/internal/exec/exec_test.go
@@ -1,0 +1,29 @@
+package exec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultRunsCommand(t *testing.T) {
+	out, err := Default("echo", "hello")
+	if err != nil {
+		t.Fatalf("Default: unexpected error: %v", err)
+	}
+	if !strings.Contains(string(out), "hello") {
+		t.Errorf("Default: got %q, want output containing %q", string(out), "hello")
+	}
+}
+
+func TestCommandRunnerFuncAssignable(t *testing.T) {
+	var runner CommandRunnerFunc = func(name string, args ...string) ([]byte, error) {
+		return []byte("fake"), nil
+	}
+	out, err := runner("anything")
+	if err != nil {
+		t.Fatalf("runner: unexpected error: %v", err)
+	}
+	if string(out) != "fake" {
+		t.Errorf("runner: got %q, want %q", string(out), "fake")
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `internal/exec` as a new foundation-layer package
- Defines `CommandRunnerFunc` as a named function type (`func(name string, args ...string) ([]byte, error)`)
- Provides `Default` as a ready-to-use `CommandRunnerFunc` backed by `os/exec.Command(...).CombinedOutput()`
- Updates `docs/architecture.json` and `docs/architecture.md` to register `internal/exec/` in the foundation layer

## Test plan

- [x] `TestDefaultRunsCommand` — verifies `exec.Default("echo", "hello")` returns output containing "hello"
- [x] `TestCommandRunnerFuncAssignable` — verifies a function literal is assignable to `CommandRunnerFunc`
- [x] `go test ./internal/exec/...` passes

## Implementation Notes

### Approach
Created a minimal `internal/exec` package with a single file that defines the shared `CommandRunnerFunc` type and a `Default` variable. Used `import osexec "os/exec"` as the issue specified to avoid a package-name collision with the package itself. No callers are migrated; that's handled by subsequent issues.

### Key Decisions
- Used `CombinedOutput()` for `Default`, consistent with the majority (5 of 7) existing `CommandRunner` usages in the codebase. The one outlier (`internal/github/issues.go` using `.Output()`) is noted in the recon brief and will be addressed in the follow-on migration issue.
- The package is pure stdlib — no internal imports — satisfying the foundation layer's `may_depend_on: []` constraint.

### Known Limitations
- No callers updated; `CommandRunner` variables in `config`, `punchlist`, `orchestrator`, `sandbox`, and `github` still have inline type declarations. Migration is out of scope for this issue.
- The context-bearing variants (`doctor.CommandRunner` and `sandbox/container.go CommandRunnerWithContext`) are also out of scope per the issue.

### Architecture
Only the **foundation** layer is touched. `internal/exec/` has no internal imports, satisfying the foundation constraint of `may_depend_on: []`. All layers that hold `CommandRunner` variables (domain, orchestration, infrastructure) are already permitted to depend on foundation, so the follow-on migration issues will introduce no new dependency violations.

Closes #385