### PR TITLE
feat: define FeatureMergeStrategy and RollupMergeStrategy typed enums

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -416,10 +416,10 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			// config value is empty or unrecognized.
 			shouldMerge := false
 			switch cfg.AutoMerge.Feature {
-			case "all":
+			case config.MergeAll:
 				logger.Info("PR approved, will merge (auto_merge.feature=all)", "pr_number", prNum)
 				shouldMerge = true
-			case "low_risk":
+			case config.MergeLowRisk:
 				additions, deletions, fileCount, statsErr := github.FetchPRStats(cfg.Repo, prNum)
 				if statsErr != nil {
 					logger.Warn("failed to fetch PR stats for risk classification, labeling for human review",

--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -108,7 +108,7 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 
 		// Create RunDataWriter first to get the run directory for the log file.
 		var hook agent.RunDataHook
-		writer, writerErr := rundata.New(cfg.Repo, "", issueNums, cfg.BaseBranch, rundata.AutoMerge{Feature: cfg.AutoMerge.Feature, Rollup: cfg.AutoMerge.Rollup})
+		writer, writerErr := rundata.New(cfg.Repo, "", issueNums, cfg.BaseBranch, rundata.AutoMerge{Feature: string(cfg.AutoMerge.Feature), Rollup: string(cfg.AutoMerge.Rollup)})
 		var logDir string
 		if writerErr != nil {
 			// Fall back to a private temp directory so each run is isolated.

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -201,7 +201,7 @@ func handleChangesRequested(ctx context.Context, cfg *config.Config, prompts *ag
 	feedback := buildFeedback(review.Body, watchFetchReviewCommentsFn, cfg.Repo, pr.Number, review.ID, logger)
 
 	// Create a run data writer for this watch-initiated fix cycle.
-	writer, writerErr := watchNewWriterFn(cfg.Repo, "", []int{issueNum}, cfg.BaseBranch, rundata.AutoMerge{Feature: cfg.AutoMerge.Feature, Rollup: cfg.AutoMerge.Rollup})
+	writer, writerErr := watchNewWriterFn(cfg.Repo, "", []int{issueNum}, cfg.BaseBranch, rundata.AutoMerge{Feature: string(cfg.AutoMerge.Feature), Rollup: string(cfg.AutoMerge.Rollup)})
 	if writerErr != nil {
 		logger.Warn("failed to create run data writer", "err", writerErr)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,15 +111,59 @@ type RiskThresholds struct {
 	MaxFiles int `yaml:"max_files"`
 }
 
+// FeatureMergeStrategy controls whether and how the feature branch is merged
+// into the base branch after a successful review cycle.
+type FeatureMergeStrategy string
+
+const (
+	// MergeNone disables automatic feature-branch merging.
+	MergeNone FeatureMergeStrategy = "none"
+	// MergeLowRisk merges automatically only when the risk classifier deems
+	// the PR low-risk.
+	MergeLowRisk FeatureMergeStrategy = "low_risk"
+	// MergeAll merges automatically regardless of risk.
+	MergeAll FeatureMergeStrategy = "all"
+)
+
+// Valid reports whether s is a recognized FeatureMergeStrategy value.
+func (s FeatureMergeStrategy) Valid() bool {
+	switch s {
+	case MergeNone, MergeLowRisk, MergeAll:
+		return true
+	}
+	return false
+}
+
+// RollupMergeStrategy controls what happens to the base branch after a run
+// completes (base branch → default branch rollup PR).
+type RollupMergeStrategy string
+
+const (
+	// RollupNone disables rollup PR creation.
+	RollupNone RollupMergeStrategy = "none"
+	// RollupManual creates a rollup PR but leaves it open for human review.
+	RollupManual RollupMergeStrategy = "manual"
+	// RollupAuto creates and immediately merges the rollup PR.
+	RollupAuto RollupMergeStrategy = "auto"
+)
+
+// Valid reports whether s is a recognized RollupMergeStrategy value.
+func (s RollupMergeStrategy) Valid() bool {
+	switch s {
+	case RollupNone, RollupManual, RollupAuto:
+		return true
+	}
+	return false
+}
+
 // AutoMerge holds independent merge-strategy controls for the two merge
 // points introduced by configurable base branches.
 type AutoMerge struct {
 	// Feature controls merging of the feature branch into the base branch.
-	// Valid values: "none", "low_risk", "all".
-	Feature string `yaml:"feature"`
+	Feature FeatureMergeStrategy `yaml:"feature"`
 	// Rollup controls what happens to the base branch → default branch after
-	// a run completes. Valid values: "none", "manual", "auto".
-	Rollup string `yaml:"rollup"`
+	// a run completes.
+	Rollup RollupMergeStrategy `yaml:"rollup"`
 }
 
 // Config holds all configuration for a godark run.
@@ -295,7 +339,7 @@ func defaults() *Config {
 		MaxRetries:        3,
 		MaxResumeRetries:  2,
 		MaxRebaseAttempts: 1,
-		AutoMerge:      AutoMerge{Feature: "none", Rollup: "none"},
+		AutoMerge:      AutoMerge{Feature: MergeNone, Rollup: RollupNone},
 		RoadmapPath:    "docs/ROADMAP.md",
 		ProtectedPaths: []string{"godark.yaml"},
 		DeniedCommands: []string{
@@ -331,10 +375,10 @@ func applyFlags(cfg *Config, flags CLIFlags) {
 		cfg.NoSandbox = *flags.NoSandbox
 	}
 	if flags.AutoMergeFeature != nil {
-		cfg.AutoMerge.Feature = *flags.AutoMergeFeature
+		cfg.AutoMerge.Feature = FeatureMergeStrategy(*flags.AutoMergeFeature)
 	}
 	if flags.AutoMergeRollup != nil {
-		cfg.AutoMerge.Rollup = *flags.AutoMergeRollup
+		cfg.AutoMerge.Rollup = RollupMergeStrategy(*flags.AutoMergeRollup)
 	}
 	if flags.BaseBranch != nil {
 		cfg.BaseBranch = *flags.BaseBranch
@@ -354,16 +398,10 @@ func validate(cfg *Config) error {
 	default:
 		return fmt.Errorf("auth_preference must be \"oauth\" or \"api_key\", got %q", cfg.AuthPreference)
 	}
-	switch cfg.AutoMerge.Feature {
-	case "none", "low_risk", "all":
-		// valid
-	default:
+	if !cfg.AutoMerge.Feature.Valid() {
 		return fmt.Errorf("auto_merge.feature must be \"none\", \"low_risk\", or \"all\", got %q", cfg.AutoMerge.Feature)
 	}
-	switch cfg.AutoMerge.Rollup {
-	case "none", "manual", "auto":
-		// valid
-	default:
+	if !cfg.AutoMerge.Rollup.Valid() {
 		return fmt.Errorf("auto_merge.rollup must be \"none\", \"manual\", or \"auto\", got %q", cfg.AutoMerge.Rollup)
 	}
 	if err := validateModules(cfg.Modules); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -356,7 +356,7 @@ func TestAutoMergeFeatureValidValues(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error for auto_merge.feature=%q: %v", value, err)
 			}
-			if cfg.AutoMerge.Feature != value {
+			if cfg.AutoMerge.Feature != FeatureMergeStrategy(value) {
 				t.Errorf("AutoMerge.Feature = %q, want %q", cfg.AutoMerge.Feature, value)
 			}
 		})
@@ -372,7 +372,7 @@ func TestAutoMergeRollupValidValues(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error for auto_merge.rollup=%q: %v", value, err)
 			}
-			if cfg.AutoMerge.Rollup != value {
+			if cfg.AutoMerge.Rollup != RollupMergeStrategy(value) {
 				t.Errorf("AutoMerge.Rollup = %q, want %q", cfg.AutoMerge.Rollup, value)
 			}
 		})
@@ -434,6 +434,36 @@ auto_merge:
 	}
 	if cfg.AutoMerge.Rollup != "auto" {
 		t.Errorf("AutoMerge.Rollup = %q, want %q (flag should override)", cfg.AutoMerge.Rollup, "auto")
+	}
+}
+
+func TestFeatureMergeStrategyValid(t *testing.T) {
+	valid := []FeatureMergeStrategy{MergeNone, MergeLowRisk, MergeAll}
+	for _, s := range valid {
+		if !s.Valid() {
+			t.Errorf("FeatureMergeStrategy(%q).Valid() = false, want true", s)
+		}
+	}
+	if FeatureMergeStrategy("invalid").Valid() {
+		t.Errorf("FeatureMergeStrategy(\"invalid\").Valid() = true, want false")
+	}
+	if FeatureMergeStrategy("").Valid() {
+		t.Errorf("FeatureMergeStrategy(\"\").Valid() = true, want false")
+	}
+}
+
+func TestRollupMergeStrategyValid(t *testing.T) {
+	valid := []RollupMergeStrategy{RollupNone, RollupManual, RollupAuto}
+	for _, s := range valid {
+		if !s.Valid() {
+			t.Errorf("RollupMergeStrategy(%q).Valid() = false, want true", s)
+		}
+	}
+	if RollupMergeStrategy("invalid").Valid() {
+		t.Errorf("RollupMergeStrategy(\"invalid\").Valid() = true, want false")
+	}
+	if RollupMergeStrategy("").Valid() {
+		t.Errorf("RollupMergeStrategy(\"\").Valid() = true, want false")
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -90,7 +90,7 @@ func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone
 	if !dryRun {
 		issueNums := issueNumbers(issues)
 		var writerErr error
-		writer, writerErr = newRunDataWriterFn(cfg.Repo, milestone, issueNums, cfg.BaseBranch, rundata.AutoMerge{Feature: cfg.AutoMerge.Feature, Rollup: cfg.AutoMerge.Rollup})
+		writer, writerErr = newRunDataWriterFn(cfg.Repo, milestone, issueNums, cfg.BaseBranch, rundata.AutoMerge{Feature: string(cfg.AutoMerge.Feature), Rollup: string(cfg.AutoMerge.Rollup)})
 		if writerErr != nil {
 			logger.Warn("failed to create run data writer, run data will not be recorded", "error", writerErr)
 		} else if runLogger, logErr := logging.NewLogger(writer.Dir()); logErr == nil {
@@ -473,7 +473,7 @@ done:
 	var rollupPRNumber int
 	var rollupPRURL string
 	if stats.abortReason == "" &&
-		cfg.AutoMerge.Rollup != "none" &&
+		cfg.AutoMerge.Rollup != config.RollupNone &&
 		cfg.BaseBranch != "" && cfg.BaseBranch != defaultBranch &&
 		stats.implemented > 0 {
 		prNum, prURL, err := handleRollupPR(ctx, cfg, implementedIssues, defaultBranch, logger)
@@ -620,7 +620,7 @@ func handleRollupPR(ctx context.Context, cfg *config.Config, issues []github.Iss
 	logger.Info("rollup PR created", "pr_number", prNum, "pr_url", prURL)
 	fmt.Printf("Rollup PR #%d created: %s\n", prNum, prURL)
 
-	if cfg.AutoMerge.Rollup == "auto" {
+	if cfg.AutoMerge.Rollup == config.RollupAuto {
 		// Wait for CI checks before merging if configured.
 		if cfg.WaitForChecks != nil {
 			timeout, err := time.ParseDuration(cfg.WaitForChecks.Timeout)


### PR DESCRIPTION
## Summary

- Define `FeatureMergeStrategy` and `RollupMergeStrategy` named string types in `internal/config/config.go` with constants for all valid values and `Valid() bool` methods
- Replace inline validation string switches in `validate()` with `Valid()` calls
- Update `AutoMerge` struct fields, `defaults()`, and `applyFlags()` to use the typed fields
- Update `loop.go` merge decision switch and `orchestrator.go` rollup gate comparisons to use typed constants
- Add `string()` casts at `rundata.AutoMerge` construction sites (that type is a separate infrastructure struct that stays string-typed)
- Fix `config_test.go` loop-variable comparisons and add `Valid()` unit tests

Closes #387

## Implementation Notes

### Approach
Defined both types as `type X string` so YAML unmarshal works transparently (no custom marshal/unmarshal needed). Added `Valid()` methods that switch over the typed constants, replacing the two inline validation switches in `validate()`. All call sites in the orchestration and cmd layers were updated to use constants or explicit casts.

### Key Decisions
- `rundata.AutoMerge.Feature/Rollup` remain `string` — that struct is a data-recording type in the infrastructure layer and there is no reason to couple it to `config` types. The three construction sites cast with `string()`.
- `CLIFlags.AutoMergeFeature/Rollup` remain `*string` — they are raw CLI inputs that validation will reject if invalid. `applyFlags()` casts them to the typed field.
- No changes to `rundata` package itself to avoid introducing a dependency from `infrastructure` on `foundation` types beyond what already exists.

### Known Limitations
None. All acceptance criteria from the issue are met.

### Architecture
- `internal/config/` (foundation layer): new types and constants defined here, importable by all layers
- `internal/agent/` and `internal/orchestrator/` (orchestration layer): updated to use `config.MergeAll`, `config.MergeLowRisk`, `config.RollupNone`, `config.RollupAuto` constants — already depended on `config`
- `internal/cmd/` (cmd layer): string() casts at rundata construction sites
- No new cross-layer dependencies introduced