### PR TITLE
refactor: extract unified ParseVerdict (#390)

### DIFF
--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -114,21 +114,7 @@ func ClosePR(repo string, prNum int, reason string) error {
 // ParseReviewResult scans the agent stdout for a REVIEW_RESULT line and
 // returns "APPROVED", "CHANGES_REQUESTED", or "" if not found.
 func ParseReviewResult(stdout string) string {
-	upper := strings.ToUpper(stdout)
-	for _, line := range strings.Split(upper, "\n") {
-		line = strings.TrimSpace(line)
-		// Accept both "REVIEW_RESULT=APPROVED" and "REVIEW RESULT: APPROVED" etc.
-		if strings.Contains(line, "APPROVED") && strings.Contains(line, "REVIEW") && strings.Contains(line, "RESULT") {
-			if strings.Contains(line, "CHANGES") {
-				return "CHANGES_REQUESTED"
-			}
-			return "APPROVED"
-		}
-		if strings.Contains(line, "CHANGES_REQUESTED") && strings.Contains(line, "REVIEW") {
-			return "CHANGES_REQUESTED"
-		}
-	}
-	return ""
+	return ParseVerdict(stdout, "REVIEW")
 }
 
 // HasScenarioSpec returns true if any .md file in scenarioDir (including

--- a/internal/agent/guardrails_test.go
+++ b/internal/agent/guardrails_test.go
@@ -8,30 +8,6 @@ import (
 	"testing"
 )
 
-func TestParseReviewResult_Approved(t *testing.T) {
-	stdout := "some output\nREVIEW_RESULT=APPROVED\nmore output"
-	got := ParseReviewResult(stdout)
-	if got != "APPROVED" {
-		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
-	}
-}
-
-func TestParseReviewResult_ChangesRequested(t *testing.T) {
-	stdout := "output\nREVIEW_RESULT=CHANGES_REQUESTED\n"
-	got := ParseReviewResult(stdout)
-	if got != "CHANGES_REQUESTED" {
-		t.Errorf("ParseReviewResult() = %q, want %q", got, "CHANGES_REQUESTED")
-	}
-}
-
-func TestParseReviewResult_NotFound(t *testing.T) {
-	stdout := "just some random output\nno result here"
-	got := ParseReviewResult(stdout)
-	if got != "" {
-		t.Errorf("ParseReviewResult() = %q, want empty", got)
-	}
-}
-
 func TestFindPR_ReturnsPRNumber(t *testing.T) {
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return []byte(`{"number": 42}`), nil
@@ -284,46 +260,6 @@ func TestClosePR_ReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "closing PR #10") {
 		t.Errorf("error = %v, want 'closing PR #10'", err)
-	}
-}
-
-func TestParseReviewResult_FirstMatchWins(t *testing.T) {
-	stdout := "REVIEW_RESULT=APPROVED\nREVIEW_RESULT=CHANGES_REQUESTED\n"
-	got := ParseReviewResult(stdout)
-	if got != "APPROVED" {
-		t.Errorf("ParseReviewResult() = %q, want %q (first match should win)", got, "APPROVED")
-	}
-}
-
-func TestParseReviewResult_WhitespaceHandling(t *testing.T) {
-	stdout := "  REVIEW_RESULT=APPROVED  \n"
-	got := ParseReviewResult(stdout)
-	if got != "APPROVED" {
-		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
-	}
-}
-
-func TestParseReviewResult_ColonFormat(t *testing.T) {
-	stdout := "REVIEW RESULT: APPROVED\n"
-	got := ParseReviewResult(stdout)
-	if got != "APPROVED" {
-		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
-	}
-}
-
-func TestParseReviewResult_ColonFormatChanges(t *testing.T) {
-	stdout := "REVIEW RESULT: CHANGES_REQUESTED\n"
-	got := ParseReviewResult(stdout)
-	if got != "CHANGES_REQUESTED" {
-		t.Errorf("ParseReviewResult() = %q, want %q", got, "CHANGES_REQUESTED")
-	}
-}
-
-func TestParseReviewResult_CaseInsensitive(t *testing.T) {
-	stdout := "Review Result: Approved\n"
-	got := ParseReviewResult(stdout)
-	if got != "APPROVED" {
-		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
 	}
 }
 

--- a/internal/agent/quality_reviewer.go
+++ b/internal/agent/quality_reviewer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
@@ -79,18 +78,5 @@ func strictnessDirective(cycle, maxAttempts int, decay bool) string {
 // ParseQualityResult scans agent output for a QUALITY_RESULT line and
 // returns "APPROVED", "CHANGES_REQUESTED", or "" if not found.
 func ParseQualityResult(stdout string) string {
-	upper := strings.ToUpper(stdout)
-	for _, line := range strings.Split(upper, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.Contains(line, "APPROVED") && strings.Contains(line, "QUALITY") && strings.Contains(line, "RESULT") {
-			if strings.Contains(line, "CHANGES") {
-				return "CHANGES_REQUESTED"
-			}
-			return "APPROVED"
-		}
-		if strings.Contains(line, "CHANGES_REQUESTED") && strings.Contains(line, "QUALITY") {
-			return "CHANGES_REQUESTED"
-		}
-	}
-	return ""
+	return ParseVerdict(stdout, "QUALITY")
 }

--- a/internal/agent/quality_reviewer_test.go
+++ b/internal/agent/quality_reviewer_test.go
@@ -70,27 +70,6 @@ func TestQualityReview_StructuredVerdict(t *testing.T) {
 	}
 }
 
-func TestParseQualityResult_Approved(t *testing.T) {
-	got := ParseQualityResult("some output\nQUALITY_RESULT=APPROVED\nmore output")
-	if got != "APPROVED" {
-		t.Errorf("ParseQualityResult() = %q, want %q", got, "APPROVED")
-	}
-}
-
-func TestParseQualityResult_ChangesRequested(t *testing.T) {
-	got := ParseQualityResult("QUALITY_RESULT=CHANGES_REQUESTED\n")
-	if got != "CHANGES_REQUESTED" {
-		t.Errorf("ParseQualityResult() = %q, want %q", got, "CHANGES_REQUESTED")
-	}
-}
-
-func TestParseQualityResult_NoMatch(t *testing.T) {
-	got := ParseQualityResult("no sentinel here")
-	if got != "" {
-		t.Errorf("ParseQualityResult() = %q, want %q", got, "")
-	}
-}
-
 // --- strictnessDirective unit tests ---
 
 func TestStrictnessDirective_Cycle0NoDirective(t *testing.T) {

--- a/internal/agent/verdict.go
+++ b/internal/agent/verdict.go
@@ -1,0 +1,24 @@
+package agent
+
+import "strings"
+
+// ParseVerdict scans agent stdout for a result line matching the given keyword
+// (e.g. "REVIEW" or "QUALITY") and returns "APPROVED", "CHANGES_REQUESTED",
+// or "" if no sentinel is found. Matching is case-insensitive; first match wins.
+func ParseVerdict(stdout, keyword string) string {
+	upper := strings.ToUpper(stdout)
+	kw := strings.ToUpper(keyword)
+	for _, line := range strings.Split(upper, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "APPROVED") && strings.Contains(line, kw) && strings.Contains(line, "RESULT") {
+			if strings.Contains(line, "CHANGES") {
+				return "CHANGES_REQUESTED"
+			}
+			return "APPROVED"
+		}
+		if strings.Contains(line, "CHANGES_REQUESTED") && strings.Contains(line, kw) {
+			return "CHANGES_REQUESTED"
+		}
+	}
+	return ""
+}

--- a/internal/agent/verdict_test.go
+++ b/internal/agent/verdict_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import "testing"
+
+// --- ParseReviewResult verdict tests ---
+
+func TestParseReviewResult_Approved(t *testing.T) {
+	stdout := "some output\nREVIEW_RESULT=APPROVED\nmore output"
+	got := ParseReviewResult(stdout)
+	if got != "APPROVED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
+	}
+}
+
+func TestParseReviewResult_ChangesRequested(t *testing.T) {
+	stdout := "output\nREVIEW_RESULT=CHANGES_REQUESTED\n"
+	got := ParseReviewResult(stdout)
+	if got != "CHANGES_REQUESTED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "CHANGES_REQUESTED")
+	}
+}
+
+func TestParseReviewResult_NotFound(t *testing.T) {
+	stdout := "just some random output\nno result here"
+	got := ParseReviewResult(stdout)
+	if got != "" {
+		t.Errorf("ParseReviewResult() = %q, want empty", got)
+	}
+}
+
+func TestParseReviewResult_FirstMatchWins(t *testing.T) {
+	stdout := "REVIEW_RESULT=APPROVED\nREVIEW_RESULT=CHANGES_REQUESTED\n"
+	got := ParseReviewResult(stdout)
+	if got != "APPROVED" {
+		t.Errorf("ParseReviewResult() = %q, want %q (first match should win)", got, "APPROVED")
+	}
+}
+
+func TestParseReviewResult_WhitespaceHandling(t *testing.T) {
+	stdout := "  REVIEW_RESULT=APPROVED  \n"
+	got := ParseReviewResult(stdout)
+	if got != "APPROVED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
+	}
+}
+
+func TestParseReviewResult_ColonFormat(t *testing.T) {
+	stdout := "REVIEW RESULT: APPROVED\n"
+	got := ParseReviewResult(stdout)
+	if got != "APPROVED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
+	}
+}
+
+func TestParseReviewResult_ColonFormatChanges(t *testing.T) {
+	stdout := "REVIEW RESULT: CHANGES_REQUESTED\n"
+	got := ParseReviewResult(stdout)
+	if got != "CHANGES_REQUESTED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "CHANGES_REQUESTED")
+	}
+}
+
+func TestParseReviewResult_CaseInsensitive(t *testing.T) {
+	stdout := "Review Result: Approved\n"
+	got := ParseReviewResult(stdout)
+	if got != "APPROVED" {
+		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
+	}
+}
+
+// --- ParseQualityResult verdict tests ---
+
+func TestParseQualityResult_Approved(t *testing.T) {
+	got := ParseQualityResult("some output\nQUALITY_RESULT=APPROVED\nmore output")
+	if got != "APPROVED" {
+		t.Errorf("ParseQualityResult() = %q, want %q", got, "APPROVED")
+	}
+}
+
+func TestParseQualityResult_ChangesRequested(t *testing.T) {
+	got := ParseQualityResult("QUALITY_RESULT=CHANGES_REQUESTED\n")
+	if got != "CHANGES_REQUESTED" {
+		t.Errorf("ParseQualityResult() = %q, want %q", got, "CHANGES_REQUESTED")
+	}
+}
+
+func TestParseQualityResult_NoMatch(t *testing.T) {
+	got := ParseQualityResult("no sentinel here")
+	if got != "" {
+		t.Errorf("ParseQualityResult() = %q, want %q", got, "")
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces `ParseVerdict(stdout, keyword string) string` in `internal/agent/verdict.go` — the shared line-scanning logic parameterized by keyword
- `ParseReviewResult` and `ParseQualityResult` become one-line wrappers delegating to `ParseVerdict`
- Removes unused `"strings"` import from `quality_reviewer.go`
- Migrates all 11 verdict-specific tests to `verdict_test.go`; tests continue to call the wrapper functions

## Test plan

- [x] `go test ./internal/agent/...` passes with all 11 verdict tests plus full existing suite

## Implementation Notes

### Approach
Extracted the structurally-identical line-scanning bodies into a single `ParseVerdict(stdout, keyword string) string` function in a new `verdict.go` file. Both `ParseReviewResult("REVIEW")` and `ParseQualityResult("QUALITY")` delegate to it as thin wrappers, preserving backwards compatibility. All 11 existing verdict tests were moved verbatim into `verdict_test.go`.

### Key Decisions
- `keyword` is upper-cased inside `ParseVerdict` (via `strings.ToUpper`) so callers can pass either `"REVIEW"` or `"review"` — but we pass uppercase for clarity.
- The two code paths in the original functions (APPROVED-branch with inner CHANGES check, and CHANGES_REQUESTED-branch) are faithfully preserved.
- Tests continue to call the wrapper functions (`ParseReviewResult`, `ParseQualityResult`) rather than `ParseVerdict` directly — this exercises the delegation path and maintains the existing test intent.

### Known Limitations
None.

### Architecture
Only `internal/agent/` (orchestration layer) is touched. `verdict.go` imports only `"strings"` from the standard library — no new inter-package dependencies, no layer constraint issues.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)