### PR TITLE
refactor: single-source scenario spec format in SKILL.md

### DIFF
--- a/internal/skills/godark-create-scenarios/SKILL.md
+++ b/internal/skills/godark-create-scenarios/SKILL.md
@@ -49,21 +49,12 @@ Generate scenario spec files for all issues in a phase, or for a single issue.
 
 ## Format
 
-```markdown
-# Scenario: <descriptive title>
+The canonical scenario spec format is defined in `prompts/spec_generator.txt`.
+Follow that file exactly when generating specs.
 
-Relates to: Issue #<issue-number>
-
-## Setup
-- Description of test fixture state needed for these cases
-
-## Cases
-
-### <case name>
-Description of what to do.
-- Expected outcome 1
-- Expected outcome 2
-```
+The structure is: `# Scenario:` header, `Relates to: Issue #N` line, `## Setup`
+section with fixture prerequisites, and `## Cases` section with one or more
+`### <Case name>` subsections each containing a description and outcome bullets.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Removes the duplicate inline format block from `internal/skills/godark-create-scenarios/SKILL.md`
- Replaces it with a prose note referencing `prompts/spec_generator.txt` as the authoritative format source
- Keeps a brief structural summary so the skill file remains self-contained without reproducing the full spec

## Test plan
- [ ] `SKILL.md` no longer contains the duplicate fenced format block
- [ ] `SKILL.md` references `prompts/spec_generator.txt`
- [ ] `prompts/spec_generator.txt` is unchanged
- [ ] Existing tests in `internal/cmd/init_test.go` (`TestInitWritesSkillFiles`, `TestInitIdempotent`) still pass — they only check for frontmatter and file existence, not the `## Format` body

## Implementation Notes

### Approach
Replaced the `## Format` fenced code block (lines 50–66 of the original file) with two short prose paragraphs: one directing readers to `prompts/spec_generator.txt` as the canonical source, and one summarising the key structural elements so the skill remains usable without consulting the prompt file.

### Key Decisions
- Kept the summary as inline code spans rather than a full fenced block to avoid re-introducing an almost-duplicate example.
- The `## Rules` section (enforcement rules beyond the bare format) was left entirely unchanged — it is not duplicated in `spec_generator.txt` and adds value.

### Known Limitations
None. This is a pure content-layer markdown edit with no runtime or test impact.

### Architecture
Only the `content` layer is touched (`internal/skills/` path per `docs/architecture.json`). No Go code, no imports, no inter-layer dependencies changed.

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)