### PR TITLE
refactor: extract handleNonBlockingResult helper in loop.go

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -91,35 +91,20 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	if prompts.SpecGenerator != "" && !HasScenarioSpec(cfg.ScenarioDir, issue.Number) {
 		logger.Info("no scenario spec found, generating", "issue_number", issue.Number)
 		specResult, err := GenerateSpec(ctx, issue, cfg, prompts, authEnv, logger)
-		if err != nil {
-			logger.Warn("spec generation failed, continuing without spec", "error", err)
-			if hook != nil {
-				step := rundata.StepResult{Error: err.Error()}
-				if writeErr := hook.WriteSpecGeneratorResult(issue.Number, step); writeErr != nil {
-					logger.Warn("failed to write spec generator result", "error", writeErr)
-				}
+		var specWriteHook func(rundata.StepResult) error
+		if hook != nil {
+			specWriteHook = func(step rundata.StepResult) error {
+				return hook.WriteSpecGeneratorResult(issue.Number, step)
 			}
-		} else if specResult.TimedOut {
-			logger.Warn("spec generation timed out, continuing without spec")
-			if hook != nil {
-				step := ResultToStep(specResult)
-				step.Error = "timed out"
-				if writeErr := hook.WriteSpecGeneratorResult(issue.Number, step); writeErr != nil {
-					logger.Warn("failed to write spec generator result", "error", writeErr)
-				}
-			}
-		} else {
+		}
+		specText := handleNonBlockingResult(specResult, err, "spec-generator", logger, specWriteHook)
+		if specText != "" {
 			// The spec was committed to the remote branch inside the container.
 			// The file isn't on the host, but the reviewer container will see it
 			// when it checks out the PR branch. After merge and pull, the spec
 			// lands on main permanently.
 			specGenerated = true
 			logger.Info("spec generated on remote branch", "branch", branch)
-			if hook != nil {
-				if writeErr := hook.WriteSpecGeneratorResult(issue.Number, ResultToStep(specResult)); writeErr != nil {
-					logger.Warn("failed to write spec generator result", "error", writeErr)
-				}
-			}
 		}
 	}
 
@@ -134,31 +119,13 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	reconBrief := ""
 	if prompts.Recon != "" {
 		reconResult, reconErr := Recon(ctx, issue, cfg, prompts, authEnv, logger)
-		if reconErr != nil {
-			logger.Warn("recon agent failed, continuing without brief", "error", reconErr)
-			if hook != nil {
-				step := rundata.StepResult{Error: reconErr.Error()}
-				if writeErr := hook.WriteReconResult(issue.Number, step); writeErr != nil {
-					logger.Warn("failed to write recon result", "error", writeErr)
-				}
-			}
-		} else if reconResult.TimedOut {
-			logger.Warn("recon agent timed out, continuing without brief")
-			if hook != nil {
-				step := ResultToStep(reconResult)
-				step.Error = "timed out"
-				if writeErr := hook.WriteReconResult(issue.Number, step); writeErr != nil {
-					logger.Warn("failed to write recon result", "error", writeErr)
-				}
-			}
-		} else {
-			reconBrief = reconResult.ResultText
-			if hook != nil {
-				if writeErr := hook.WriteReconResult(issue.Number, ResultToStep(reconResult)); writeErr != nil {
-					logger.Warn("failed to write recon result", "error", writeErr)
-				}
+		var reconWriteHook func(rundata.StepResult) error
+		if hook != nil {
+			reconWriteHook = func(step rundata.StepResult) error {
+				return hook.WriteReconResult(issue.Number, step)
 			}
 		}
+		reconBrief = handleNonBlockingResult(reconResult, reconErr, "recon agent", logger, reconWriteHook)
 	}
 
 	implResult, err := Implement(ctx, issue, cfg, prompts, authEnv, logger, reconBrief)
@@ -888,6 +855,47 @@ func runVerifyPhase(
 		}
 	}
 	return nil
+}
+
+// handleNonBlockingResult handles the 3-way error/timeout/success dispatch
+// common to non-blocking agent steps (spec-gen, recon). It logs warnings for
+// failure and timeout, calls writeHook in all three cases (if non-nil), and
+// returns the agent's ResultText on success or empty string otherwise.
+// result may be nil when err is non-nil.
+func handleNonBlockingResult(
+	result *Result,
+	err error,
+	agentName string,
+	logger *slog.Logger,
+	writeHook func(rundata.StepResult) error,
+) (resultText string) {
+	if err != nil {
+		logger.Warn(agentName+" failed, continuing", "error", err)
+		if writeHook != nil {
+			step := rundata.StepResult{Error: err.Error()}
+			if writeErr := writeHook(step); writeErr != nil {
+				logger.Warn("failed to write "+agentName+" result", "error", writeErr)
+			}
+		}
+		return ""
+	}
+	if result.TimedOut {
+		logger.Warn(agentName + " timed out, continuing")
+		if writeHook != nil {
+			step := ResultToStep(result)
+			step.Error = "timed out"
+			if writeErr := writeHook(step); writeErr != nil {
+				logger.Warn("failed to write "+agentName+" result", "error", writeErr)
+			}
+		}
+		return ""
+	}
+	if writeHook != nil {
+		if writeErr := writeHook(ResultToStep(result)); writeErr != nil {
+			logger.Warn("failed to write "+agentName+" result", "error", writeErr)
+		}
+	}
+	return result.ResultText
 }
 
 // checkDriftAndClose checks for protected path modifications and closes the

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -4333,3 +4333,108 @@ func TestProcessIssue_AllResumeWithMaxResumeRetriesHigherThanMaxRetries(t *testi
 		t.Errorf("assembleHandoffContext called %d time(s) with MaxResumeRetries=10, expected all-resume mode (0 calls)", handoffCalled)
 	}
 }
+
+func TestHandleNonBlockingResult_Error(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := bufferLogger(&logBuf)
+
+	var hookStep rundata.StepResult
+	hookCalled := false
+	writeHook := func(step rundata.StepResult) error {
+		hookStep = step
+		hookCalled = true
+		return nil
+	}
+
+	result := handleNonBlockingResult(nil, fmt.Errorf("something went wrong"), "test-agent", logger, writeHook)
+
+	if result != "" {
+		t.Errorf("expected empty string on error, got %q", result)
+	}
+	if !hookCalled {
+		t.Error("expected writeHook to be called on error")
+	}
+	if hookStep.Error != "something went wrong" {
+		t.Errorf("hookStep.Error = %q, want %q", hookStep.Error, "something went wrong")
+	}
+	if !strings.Contains(logBuf.String(), "test-agent failed, continuing") {
+		t.Errorf("expected warning log for failure, got: %s", logBuf.String())
+	}
+}
+
+func TestHandleNonBlockingResult_Timeout(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := bufferLogger(&logBuf)
+
+	var hookStep rundata.StepResult
+	hookCalled := false
+	writeHook := func(step rundata.StepResult) error {
+		hookStep = step
+		hookCalled = true
+		return nil
+	}
+
+	r := &Result{TimedOut: true, ResultText: "ignored"}
+	result := handleNonBlockingResult(r, nil, "test-agent", logger, writeHook)
+
+	if result != "" {
+		t.Errorf("expected empty string on timeout, got %q", result)
+	}
+	if !hookCalled {
+		t.Error("expected writeHook to be called on timeout")
+	}
+	if hookStep.Error != "timed out" {
+		t.Errorf("hookStep.Error = %q, want %q", hookStep.Error, "timed out")
+	}
+	if !strings.Contains(logBuf.String(), "test-agent timed out, continuing") {
+		t.Errorf("expected timeout warning log, got: %s", logBuf.String())
+	}
+}
+
+func TestHandleNonBlockingResult_Success(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := bufferLogger(&logBuf)
+
+	var hookStep rundata.StepResult
+	hookCalled := false
+	writeHook := func(step rundata.StepResult) error {
+		hookStep = step
+		hookCalled = true
+		return nil
+	}
+
+	r := &Result{ResultText: "the brief", TimedOut: false}
+	result := handleNonBlockingResult(r, nil, "test-agent", logger, writeHook)
+
+	if result != "the brief" {
+		t.Errorf("expected result text %q, got %q", "the brief", result)
+	}
+	if !hookCalled {
+		t.Error("expected writeHook to be called on success")
+	}
+	if hookStep.Error != "" {
+		t.Errorf("hookStep.Error should be empty on success, got %q", hookStep.Error)
+	}
+}
+
+func TestHandleNonBlockingResult_NilHook(t *testing.T) {
+	logger := slog.Default()
+
+	// Should not panic with nil writeHook in any case.
+	result := handleNonBlockingResult(nil, fmt.Errorf("oops"), "test-agent", logger, nil)
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+
+	r := &Result{TimedOut: true}
+	result = handleNonBlockingResult(r, nil, "test-agent", logger, nil)
+	if result != "" {
+		t.Errorf("expected empty string, got %q", result)
+	}
+
+	r2 := &Result{ResultText: "ok"}
+	result = handleNonBlockingResult(r2, nil, "test-agent", logger, nil)
+	if result != "ok" {
+		t.Errorf("expected %q, got %q", "ok", result)
+	}
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicated error/timeout/success 3-way dispatch from the spec-gen and recon blocks in `loop.go` into a single unexported `handleNonBlockingResult` helper
- Reduces ~45 lines of duplicated boilerplate to ~10 lines at each call site
- Adds 4 unit tests covering error, timeout, success, and nil-hook cases

## Implementation Notes

### Approach
Introduced `handleNonBlockingResult(result *Result, err error, agentName string, logger *slog.Logger, writeHook func(rundata.StepResult) error) (resultText string)` in `loop.go`. Callers construct a `writeHook` lambda that closes over the hook interface and issue number, passing `nil` when `hook == nil`. The helper handles the `writeHook != nil` guard internally.

### Key Decisions
- `writeHook` is `func(rundata.StepResult) error` (not the `RunDataHook` interface) so the helper stays unaware of which hook method or issue number to use — callers close over those details.
- Passed `"recon agent"` (not `"recon"`) to preserve the existing log message `"recon agent timed out, continuing"` that an existing test asserts on.
- The spec-gen success-path `logger.Info("spec generated on remote branch", ...)` is kept at the call site since it references the local `branch` variable and is not part of the 3-way dispatch.
- `specGenerated` is derived from a non-empty return value: `specText != ""`.

### Known Limitations
- The verify phase pattern (inside `runVerifyPhase`) is intentionally left unchanged per the issue scope.

### Architecture
Only `internal/agent/` (orchestration layer) was touched. The helper references `*Result` and `ResultToStep` (orchestration), `*slog.Logger` (foundation), and `rundata.StepResult` (domain) — all permitted dependencies for this layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #393