### PR TITLE
refactor: extract parseCLIFlags helper (closes #394)

### DIFF
--- a/internal/cmd/cmdutil.go
+++ b/internal/cmd/cmdutil.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/phs/dark-factory/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// parseCLIFlags reads the 7 flag-overridable fields from cmd and returns a
+// partially-populated CLIFlags. Only flags that were explicitly set by the
+// caller (Changed == true) are written; unset flags leave their pointer fields
+// nil. The Config field is not handled here — callers set it separately via
+// cmd.Flags().GetString("config").
+func parseCLIFlags(cmd *cobra.Command) config.CLIFlags {
+	var flags config.CLIFlags
+
+	if cmd.Flags().Changed("repo") {
+		v, _ := cmd.Flags().GetString("repo")
+		flags.Repo = &v
+	}
+	if cmd.Flags().Changed("max-retries") {
+		v, _ := cmd.Flags().GetInt("max-retries")
+		flags.MaxRetries = &v
+	}
+	if cmd.Flags().Changed("no-sandbox") {
+		v, _ := cmd.Flags().GetBool("no-sandbox")
+		flags.NoSandbox = &v
+	}
+	if cmd.Flags().Changed("auto-merge-feature") {
+		v, _ := cmd.Flags().GetString("auto-merge-feature")
+		flags.AutoMergeFeature = &v
+	}
+	if cmd.Flags().Changed("auto-merge-rollup") {
+		v, _ := cmd.Flags().GetString("auto-merge-rollup")
+		flags.AutoMergeRollup = &v
+	}
+	if cmd.Flags().Changed("base-branch") {
+		v, _ := cmd.Flags().GetString("base-branch")
+		flags.BaseBranch = &v
+	}
+	if cmd.Flags().Changed("default-branch") {
+		v, _ := cmd.Flags().GetString("default-branch")
+		flags.DefaultBranch = &v
+	}
+
+	return flags
+}

--- a/internal/cmd/cmdutil_test.go
+++ b/internal/cmd/cmdutil_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestCmd returns a cobra.Command with all 7 flags registered, mirroring
+// the flag definitions used by runCmd and implementCmd.
+func newTestCmd() *cobra.Command {
+	c := &cobra.Command{Use: "test"}
+	f := c.Flags()
+	f.String("repo", "", "")
+	f.Int("max-retries", 3, "")
+	f.Bool("no-sandbox", false, "")
+	f.String("auto-merge-feature", "none", "")
+	f.String("auto-merge-rollup", "none", "")
+	f.String("base-branch", "", "")
+	f.String("default-branch", "", "")
+	return c
+}
+
+func TestParseCLIFlags_NoFlagsChanged(t *testing.T) {
+	t.Helper()
+	cmd := newTestCmd()
+	flags := parseCLIFlags(cmd)
+
+	if flags.Repo != nil {
+		t.Errorf("Repo: want nil, got %v", flags.Repo)
+	}
+	if flags.MaxRetries != nil {
+		t.Errorf("MaxRetries: want nil, got %v", flags.MaxRetries)
+	}
+	if flags.NoSandbox != nil {
+		t.Errorf("NoSandbox: want nil, got %v", flags.NoSandbox)
+	}
+	if flags.AutoMergeFeature != nil {
+		t.Errorf("AutoMergeFeature: want nil, got %v", flags.AutoMergeFeature)
+	}
+	if flags.AutoMergeRollup != nil {
+		t.Errorf("AutoMergeRollup: want nil, got %v", flags.AutoMergeRollup)
+	}
+	if flags.BaseBranch != nil {
+		t.Errorf("BaseBranch: want nil, got %v", flags.BaseBranch)
+	}
+	if flags.DefaultBranch != nil {
+		t.Errorf("DefaultBranch: want nil, got %v", flags.DefaultBranch)
+	}
+	if flags.Config != "" {
+		t.Errorf("Config: want empty, got %q", flags.Config)
+	}
+}
+
+func TestParseCLIFlags_AllFlagsSet(t *testing.T) {
+	t.Helper()
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{
+		"--repo", "owner/repo",
+		"--max-retries", "5",
+		"--no-sandbox",
+		"--auto-merge-feature", "all",
+		"--auto-merge-rollup", "auto",
+		"--base-branch", "main",
+		"--default-branch", "main",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	flags := parseCLIFlags(cmd)
+
+	if flags.Repo == nil || *flags.Repo != "owner/repo" {
+		t.Errorf("Repo: want %q, got %v", "owner/repo", flags.Repo)
+	}
+	if flags.MaxRetries == nil || *flags.MaxRetries != 5 {
+		t.Errorf("MaxRetries: want 5, got %v", flags.MaxRetries)
+	}
+	if flags.NoSandbox == nil || !*flags.NoSandbox {
+		t.Errorf("NoSandbox: want true, got %v", flags.NoSandbox)
+	}
+	if flags.AutoMergeFeature == nil || *flags.AutoMergeFeature != "all" {
+		t.Errorf("AutoMergeFeature: want %q, got %v", "all", flags.AutoMergeFeature)
+	}
+	if flags.AutoMergeRollup == nil || *flags.AutoMergeRollup != "auto" {
+		t.Errorf("AutoMergeRollup: want %q, got %v", "auto", flags.AutoMergeRollup)
+	}
+	if flags.BaseBranch == nil || *flags.BaseBranch != "main" {
+		t.Errorf("BaseBranch: want %q, got %v", "main", flags.BaseBranch)
+	}
+	if flags.DefaultBranch == nil || *flags.DefaultBranch != "main" {
+		t.Errorf("DefaultBranch: want %q, got %v", "main", flags.DefaultBranch)
+	}
+}
+
+func TestParseCLIFlags_PartialFlags(t *testing.T) {
+	t.Helper()
+	cmd := newTestCmd()
+	if err := cmd.ParseFlags([]string{
+		"--repo", "owner/repo",
+		"--no-sandbox",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+
+	flags := parseCLIFlags(cmd)
+
+	if flags.Repo == nil || *flags.Repo != "owner/repo" {
+		t.Errorf("Repo: want %q, got %v", "owner/repo", flags.Repo)
+	}
+	if flags.NoSandbox == nil || !*flags.NoSandbox {
+		t.Errorf("NoSandbox: want true, got %v", flags.NoSandbox)
+	}
+	// Unset fields must remain nil.
+	if flags.MaxRetries != nil {
+		t.Errorf("MaxRetries: want nil, got %v", flags.MaxRetries)
+	}
+	if flags.AutoMergeFeature != nil {
+		t.Errorf("AutoMergeFeature: want nil, got %v", flags.AutoMergeFeature)
+	}
+	if flags.AutoMergeRollup != nil {
+		t.Errorf("AutoMergeRollup: want nil, got %v", flags.AutoMergeRollup)
+	}
+	if flags.BaseBranch != nil {
+		t.Errorf("BaseBranch: want nil, got %v", flags.BaseBranch)
+	}
+	if flags.DefaultBranch != nil {
+		t.Errorf("DefaultBranch: want nil, got %v", flags.DefaultBranch)
+	}
+}

--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -43,36 +43,8 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		force, _ := cmd.Flags().GetBool("force")
 
-		flags := config.CLIFlags{Config: configPath}
-
-		if cmd.Flags().Changed("repo") {
-			v, _ := cmd.Flags().GetString("repo")
-			flags.Repo = &v
-		}
-		if cmd.Flags().Changed("max-retries") {
-			v, _ := cmd.Flags().GetInt("max-retries")
-			flags.MaxRetries = &v
-		}
-		if cmd.Flags().Changed("no-sandbox") {
-			v, _ := cmd.Flags().GetBool("no-sandbox")
-			flags.NoSandbox = &v
-		}
-		if cmd.Flags().Changed("auto-merge-feature") {
-			v, _ := cmd.Flags().GetString("auto-merge-feature")
-			flags.AutoMergeFeature = &v
-		}
-		if cmd.Flags().Changed("auto-merge-rollup") {
-			v, _ := cmd.Flags().GetString("auto-merge-rollup")
-			flags.AutoMergeRollup = &v
-		}
-		if cmd.Flags().Changed("base-branch") {
-			v, _ := cmd.Flags().GetString("base-branch")
-			flags.BaseBranch = &v
-		}
-		if cmd.Flags().Changed("default-branch") {
-			v, _ := cmd.Flags().GetString("default-branch")
-			flags.DefaultBranch = &v
-		}
+		flags := parseCLIFlags(cmd)
+		flags.Config = configPath
 
 		cfg, err := config.Load(configPath, flags)
 		if err != nil {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -25,36 +25,8 @@ each unblocked issue through the implement → review → merge loop.`,
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		force, _ := cmd.Flags().GetBool("force")
 
-		flags := config.CLIFlags{Config: configPath}
-
-		if cmd.Flags().Changed("repo") {
-			v, _ := cmd.Flags().GetString("repo")
-			flags.Repo = &v
-		}
-		if cmd.Flags().Changed("max-retries") {
-			v, _ := cmd.Flags().GetInt("max-retries")
-			flags.MaxRetries = &v
-		}
-		if cmd.Flags().Changed("no-sandbox") {
-			v, _ := cmd.Flags().GetBool("no-sandbox")
-			flags.NoSandbox = &v
-		}
-		if cmd.Flags().Changed("auto-merge-feature") {
-			v, _ := cmd.Flags().GetString("auto-merge-feature")
-			flags.AutoMergeFeature = &v
-		}
-		if cmd.Flags().Changed("auto-merge-rollup") {
-			v, _ := cmd.Flags().GetString("auto-merge-rollup")
-			flags.AutoMergeRollup = &v
-		}
-		if cmd.Flags().Changed("base-branch") {
-			v, _ := cmd.Flags().GetString("base-branch")
-			flags.BaseBranch = &v
-		}
-		if cmd.Flags().Changed("default-branch") {
-			v, _ := cmd.Flags().GetString("default-branch")
-			flags.DefaultBranch = &v
-		}
+		flags := parseCLIFlags(cmd)
+		flags.Config = configPath
 
 		// Parse milestone/issue locally — these are per-run params, not config.
 		var milestone string


### PR DESCRIPTION
## Summary
- Extract the 28-line duplicated flag-parsing block from `run.go` and `implement.go` into a single `parseCLIFlags(cmd *cobra.Command) config.CLIFlags` helper in a new `internal/cmd/cmdutil.go`
- Replace both inline blocks with a one-liner `parseCLIFlags(cmd)` call; callers set `flags.Config` separately (the `config` flag is not in the 7-field list the helper handles)
- Add unit tests in `cmdutil_test.go` covering all-flags-set, no-flags-changed, and partial-flags cases

## Test plan
- [ ] `go test ./internal/cmd/...` passes (all existing + new tests)
- [ ] All 7 pointer fields populated correctly when flags are explicitly set
- [ ] All pointer fields nil when no flags are changed
- [ ] Only changed flags populated when partial flags provided

## Implementation Notes

### Approach
Describe what approach you took and why.

`parseCLIFlags` only populates the 7 pointer fields listed in the issue spec. The `Config` field (plain `string`, no `Changed()` guard in original code) is intentionally left to the caller, keeping the helper's contract minimal and exactly matching the issue spec's flag list.

### Key Decisions
- `Config` is set by callers (`flags.Config = configPath`) rather than inside the helper, because it's a plain string always read unconditionally — not one of the 7 `Changed()`-guarded flags
- No error return on `parseCLIFlags` — consistent with original code where `Get*` errors are ignored (only fail for unregistered flags, which can't happen here since both callers register all 7 flags)

### Known Limitations
None. All acceptance criteria met.

### Architecture
- New `cmdutil.go` lives in `internal/cmd/` (cmd layer)
- Imports `config.CLIFlags` (foundation layer) and `*cobra.Command` (third-party) — both already in scope
- No layer violations: cmd → foundation is an allowed dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #394