### PR TITLE
refactor: extract fetchVetData helper from vet commands

### DIFF
--- a/internal/cmd/vet_helpers.go
+++ b/internal/cmd/vet_helpers.go
@@ -58,6 +58,33 @@ func resolveRepo(cmd *cobra.Command) string {
 	return cfg.Repo
 }
 
+// fetchVetData fetches milestone issues and all issue numbers for vet commands.
+// When milestone is non-empty, both FetchMilestoneIssues and FetchAllIssueNumbers
+// are called. When milestone is empty but repo is non-empty, only
+// FetchAllIssueNumbers is called (issues is nil). If both are empty, zero values
+// are returned with no error.
+func fetchVetData(repo, milestone string) (issues []github.Issue, allNums map[int]bool, err error) {
+	if milestone != "" {
+		issues, err = github.FetchMilestoneIssues(repo, milestone)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetching milestone issues: %w", err)
+		}
+		allNums, err = github.FetchAllIssueNumbers(repo)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetching all issue numbers: %w", err)
+		}
+		return issues, allNums, nil
+	}
+	if repo != "" {
+		allNums, err = github.FetchAllIssueNumbers(repo)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fetching all issue numbers: %w", err)
+		}
+		return nil, allNums, nil
+	}
+	return nil, nil, nil
+}
+
 // resolveTag resolves --milestone and --tag flags into a milestone title.
 // --milestone takes precedence. If --tag is provided, it looks up the
 // matching milestone from the repo. Returns ("", nil) if neither is set.

--- a/internal/cmd/vet_issues.go
+++ b/internal/cmd/vet_issues.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/vet"
 	"github.com/spf13/cobra"
 )
@@ -23,17 +22,12 @@ var vetIssuesCmd = &cobra.Command{
 			return fmt.Errorf("--repo and either --milestone or --tag are required")
 		}
 
-		issues, err := github.FetchMilestoneIssues(repo, milestone)
+		issues, allNums, err := fetchVetData(repo, milestone)
 		if err != nil {
-			return fmt.Errorf("fetching milestone issues: %w", err)
+			return err
 		}
 		if len(issues) == 0 {
 			return fmt.Errorf("no open issues found for milestone %q — check that the milestone exists and has open issues", milestone)
-		}
-
-		allNums, err := github.FetchAllIssueNumbers(repo)
-		if err != nil {
-			return fmt.Errorf("fetching all issue numbers: %w", err)
 		}
 
 		phaseLabel := milestoneToLabel(milestone)

--- a/internal/cmd/vet_roadmap.go
+++ b/internal/cmd/vet_roadmap.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/vet"
 	"github.com/spf13/cobra"
 )
@@ -24,14 +23,9 @@ var vetRoadmapCmd = &cobra.Command{
 			return fmt.Errorf("--repo and either --milestone or --tag are required")
 		}
 
-		issues, err := github.FetchMilestoneIssues(repo, milestone)
+		issues, allNums, err := fetchVetData(repo, milestone)
 		if err != nil {
-			return fmt.Errorf("fetching milestone issues: %w", err)
-		}
-
-		allNums, err := github.FetchAllIssueNumbers(repo)
-		if err != nil {
-			return fmt.Errorf("fetching all issue numbers: %w", err)
+			return err
 		}
 
 		report := vet.ValidateRoadmap(planningDir, issues, milestone, allNums)

--- a/internal/cmd/vet_scenarios.go
+++ b/internal/cmd/vet_scenarios.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/vet"
 	"github.com/spf13/cobra"
 )
@@ -21,28 +20,13 @@ var vetScenariosCmd = &cobra.Command{
 			return err
 		}
 
-		var issues []github.Issue
-		var allNums map[int]bool
+		if milestone != "" && repo == "" {
+			return fmt.Errorf("--repo is required when --milestone or --tag is specified")
+		}
 
-		if milestone != "" {
-			if repo == "" {
-				return fmt.Errorf("--repo is required when --milestone or --tag is specified")
-			}
-			var err error
-			issues, err = github.FetchMilestoneIssues(repo, milestone)
-			if err != nil {
-				return fmt.Errorf("fetching milestone issues: %w", err)
-			}
-			allNums, err = github.FetchAllIssueNumbers(repo)
-			if err != nil {
-				return fmt.Errorf("fetching all issue numbers: %w", err)
-			}
-		} else if repo != "" {
-			var err error
-			allNums, err = github.FetchAllIssueNumbers(repo)
-			if err != nil {
-				return fmt.Errorf("fetching all issue numbers: %w", err)
-			}
+		issues, allNums, err := fetchVetData(repo, milestone)
+		if err != nil {
+			return err
 		}
 
 		report := vet.ValidateScenarios(scenarioDir, issues, allNums)


### PR DESCRIPTION
## Summary

- Adds `fetchVetData(repo, milestone string)` helper to `internal/cmd/vet_helpers.go`
- Replaces duplicate `FetchMilestoneIssues` + `FetchAllIssueNumbers` blocks in `vet_issues.go`, `vet_roadmap.go`, and `vet_scenarios.go`
- Removes now-unused `internal/github` imports from the three callers

## Implementation Notes

### Approach
Extracted the repeated fetch-and-error-handle pattern into a single `fetchVetData` helper that handles three cases: milestone mode (both fetches), repo-only mode (allNums only), and neither (zero values). Each caller was simplified to a single call site.

### Key Decisions
- **Empty-milestone guard in `vet_issues.go`**: preserved after `fetchVetData` call since it's specific to `vet issues` semantics (not part of the fetch pattern itself)
- **`--repo is required` guard in `vet_scenarios.go`**: moved before the `fetchVetData` call to maintain identical error behaviour when milestone is set without repo
- **Import cleanup**: removed `internal/github` from all three caller files since no direct `github.X` references remain; `vet_helpers.go` already imported it
- **Error wrapping**: the helper wraps with `"fetching milestone issues: %w"` and `"fetching all issue numbers: %w"` — callers return the error directly, so the chain is identical

### Known Limitations
None. The refactor is behaviorally identical to the original.

### Architecture
Only the `cmd` layer (`internal/cmd/`) is touched. No new cross-layer dependencies introduced. `vet_helpers.go` already imported `internal/github` (infrastructure layer), so no layer boundary changes.

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)