### PR TITLE
refactor: consolidate file scaffold functions with writeFileWithDirs

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -12,7 +12,6 @@ import (
 	"github.com/phs/dark-factory/internal/label"
 	"github.com/phs/dark-factory/internal/lock"
 	"github.com/phs/dark-factory/internal/skills"
-	"github.com/phs/dark-factory/prompts"
 	"github.com/spf13/cobra"
 )
 
@@ -194,14 +193,7 @@ func writeHarnessDocs(cmd *cobra.Command) error {
 		}
 	}
 
-	docFiles := []struct{ src, dest string }{
-		{"architecture.md", "docs/architecture.md"},
-		{"architecture.json", "docs/architecture.json"},
-		{"conventions.md", "docs/conventions.md"},
-		{"roadmap.md", "docs/ROADMAP.md"},
-	}
-
-	for _, f := range docFiles {
+	for _, f := range harnessDocFiles {
 		written, err := templates.WriteIfNotExists(f.src, f.dest)
 		if err != nil {
 			return err
@@ -216,24 +208,8 @@ func writeHarnessDocs(cmd *cobra.Command) error {
 	// Prompt templates are always overwritten (managed by godark, like skills).
 	// Read from prompts.FS (single source of truth) rather than maintaining a
 	// separate copy in the harness templates.
-	promptFiles := []struct{ name, dest string }{
-		{"implementer.txt", "prompts/implementer.txt"},
-		{"implementer_retry.txt", "prompts/implementer_retry.txt"},
-		{"reviewer.txt", "prompts/reviewer.txt"},
-	}
-
-	for _, f := range promptFiles {
-		data, err := prompts.FS.ReadFile(f.name)
-		if err != nil {
-			return fmt.Errorf("reading embedded prompt %s: %w", f.name, err)
-		}
-		if err := os.MkdirAll(filepath.Dir(f.dest), 0o755); err != nil {
-			return fmt.Errorf("creating directory for %s: %w", f.dest, err)
-		}
-		if err := os.WriteFile(f.dest, data, 0o644); err != nil {
-			return fmt.Errorf("writing %s: %w", f.dest, err)
-		}
-		fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", f.dest)
+	if err := writeHarnessPrompts(cmd); err != nil {
+		return err
 	}
 
 	claudeMDWritten := false

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/phs/dark-factory/internal/harness/templates"
-	"github.com/phs/dark-factory/prompts"
 	"github.com/spf13/cobra"
 )
 
@@ -148,14 +147,7 @@ func writeNewProjectHarnessDocs(cmd *cobra.Command) error {
 		}
 	}
 
-	docFiles := []struct{ src, dest string }{
-		{"architecture.md", "docs/architecture.md"},
-		{"architecture.json", "docs/architecture.json"},
-		{"conventions.md", "docs/conventions.md"},
-		{"roadmap.md", "docs/ROADMAP.md"},
-	}
-
-	for _, f := range docFiles {
+	for _, f := range harnessDocFiles {
 		written, err := templates.WriteIfNotExists(f.src, f.dest)
 		if err != nil {
 			return err
@@ -167,25 +159,5 @@ func writeNewProjectHarnessDocs(cmd *cobra.Command) error {
 
 	// Prompt templates are always overwritten from prompts.FS (single source
 	// of truth), matching the behavior of godark init.
-	promptFiles := []struct{ name, dest string }{
-		{"implementer.txt", "prompts/implementer.txt"},
-		{"implementer_retry.txt", "prompts/implementer_retry.txt"},
-		{"reviewer.txt", "prompts/reviewer.txt"},
-	}
-
-	for _, f := range promptFiles {
-		data, err := prompts.FS.ReadFile(f.name)
-		if err != nil {
-			return fmt.Errorf("reading embedded prompt %s: %w", f.name, err)
-		}
-		if err := os.MkdirAll(filepath.Dir(f.dest), 0o755); err != nil {
-			return fmt.Errorf("creating directory for %s: %w", f.dest, err)
-		}
-		if err := os.WriteFile(f.dest, data, 0o644); err != nil {
-			return fmt.Errorf("writing %s: %w", f.dest, err)
-		}
-		fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", f.dest)
-	}
-
-	return nil
+	return writeHarnessPrompts(cmd)
 }

--- a/internal/cmd/scaffold.go
+++ b/internal/cmd/scaffold.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/phs/dark-factory/prompts"
+	"github.com/spf13/cobra"
+)
+
+// harnessDocFiles is the canonical list of harness documentation templates
+// written by both "init" and "new". Entries map embedded template names to
+// destination paths relative to the project root.
+var harnessDocFiles = []struct{ src, dest string }{
+	{"architecture.md", "docs/architecture.md"},
+	{"architecture.json", "docs/architecture.json"},
+	{"conventions.md", "docs/conventions.md"},
+	{"roadmap.md", "docs/ROADMAP.md"},
+}
+
+// harnessPromptFiles is the canonical list of prompt template files written
+// by both "init" and "new". Entries map embedded prompt names to destination
+// paths relative to the project root.
+var harnessPromptFiles = []struct{ name, dest string }{
+	{"implementer.txt", "prompts/implementer.txt"},
+	{"implementer_retry.txt", "prompts/implementer_retry.txt"},
+	{"reviewer.txt", "prompts/reviewer.txt"},
+}
+
+// writeFileWithDirs creates parent directories for path and writes data to it,
+// always overwriting any existing file.
+func writeFileWithDirs(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating directory for %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// writeHarnessPrompts writes all harness prompt files to disk using
+// writeFileWithDirs. Prompt files are always overwritten (they are managed by
+// godark, like skills).
+func writeHarnessPrompts(cmd *cobra.Command) error {
+	for _, f := range harnessPromptFiles {
+		data, err := prompts.FS.ReadFile(f.name)
+		if err != nil {
+			return fmt.Errorf("reading embedded prompt %s: %w", f.name, err)
+		}
+		if err := writeFileWithDirs(f.dest, data); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "wrote %s\n", f.dest)
+	}
+	return nil
+}

--- a/internal/cmd/scaffold_test.go
+++ b/internal/cmd/scaffold_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileWithDirsCreatesDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a", "b", "c.txt")
+
+	if err := writeFileWithDirs(path, []byte("hello")); err != nil {
+		t.Fatalf("writeFileWithDirs: %v", err)
+	}
+
+	parentDir := filepath.Join(dir, "a", "b")
+	info, err := os.Stat(parentDir)
+	if err != nil {
+		t.Fatalf("parent directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("expected %s to be a directory", parentDir)
+	}
+}
+
+func TestWriteFileWithDirsWritesContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "file.txt")
+	content := []byte("expected content")
+
+	if err := writeFileWithDirs(path, content); err != nil {
+		t.Fatalf("writeFileWithDirs: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+}
+
+func TestWriteFileWithDirsOverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	if err := writeFileWithDirs(path, []byte("original")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	newContent := []byte("updated")
+	if err := writeFileWithDirs(path, newContent); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading file after overwrite: %v", err)
+	}
+	if string(got) != string(newContent) {
+		t.Errorf("expected overwritten content %q, got %q", newContent, got)
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `writeFileWithDirs(path string, data []byte) error` helper that creates parent dirs and writes a file unconditionally
- Lift `harnessDocFiles` and `harnessPromptFiles` into a new `internal/cmd/scaffold.go` — single source of truth for both `init` and `new`
- Extract `writeHarnessPrompts(cmd *cobra.Command) error` shared helper for the always-overwrite prompt loop
- Refactor `writeHarnessDocs` (init.go) and `writeNewProjectHarnessDocs` (new.go) to use the shared definitions

## Test plan

- [x] New `TestWriteFileWithDirsCreatesDirs` — verifies parent dirs are created
- [x] New `TestWriteFileWithDirsWritesContent` — verifies correct bytes are written
- [x] New `TestWriteFileWithDirsOverwritesExisting` — verifies unconditional overwrite
- [x] All existing `TestInit*` tests pass (including idempotent, skip, prompts-always-overwritten)
- [x] All existing `TestNew*` tests pass

## Implementation Notes

### Approach
Added `internal/cmd/scaffold.go` as home for the shared helpers. This keeps everything in the `cmd` package — no new dependency edges, no layer violations.

### Key Decisions
- `writeFileWithDirs` receives pre-read `[]byte` data; callers still perform `FS.ReadFile` themselves, keeping the helper generic and the read-source explicit.
- `writeHarnessPrompts` encapsulates the identical prompt-write loop (both commands always overwrite prompts), using `writeFileWithDirs` internally.
- The docFiles loop is **not** unified into a single shared helper because `init` prints "skipped ... (already exists)" while `new` does not — keeping the loops in each command preserves this output behavior clearly.

### Known Limitations
None. All acceptance criteria met.

### Architecture
Only the `cmd` layer (`internal/cmd/`) was touched. `scaffold.go` imports `prompts` (content layer) and `cobra` — both already imported by the surrounding package. No new layer dependencies introduced.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)