### PR TITLE
refactor: clean up punchlist parsing (#398)

### DIFF
--- a/internal/agent/punchlist.go
+++ b/internal/agent/punchlist.go
@@ -121,14 +121,11 @@ func EnrichPunchlistEntries(ctx context.Context, entries []punchlist.Entry, prom
 	wg.Wait()
 }
 
-// parseAcceptanceTests extracts a JSON array of strings from LLM output.
-// Handles optional markdown code fences. Caps at 5 items.
-func parseAcceptanceTests(text string, issueNumber int, logger *slog.Logger) []string {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return nil
-	}
-
+// extractJSONArray finds and returns a JSON array substring from text.
+// It strips markdown code fences first, then tries to unmarshal the full text.
+// On failure, it scans for the outermost [...] using bracket-depth tracking.
+// Returns (jsonSubstring, true) on success, ("", false) if no valid array found.
+func extractJSONArray(text string) (string, bool) {
 	// Strip markdown code fences if present.
 	if strings.HasPrefix(text, "```") {
 		lines := strings.Split(text, "\n")
@@ -147,20 +144,55 @@ func parseAcceptanceTests(text string, issueNumber int, logger *slog.Logger) []s
 		}
 	}
 
-	var tests []string
-	if err := json.Unmarshal([]byte(text), &tests); err != nil {
-		// Try to find a JSON array within the text.
-		start := strings.Index(text, "[")
-		end := strings.LastIndex(text, "]")
-		if start >= 0 && end > start {
-			if err2 := json.Unmarshal([]byte(text[start:end+1]), &tests); err2 != nil {
-				logger.Warn("failed to parse acceptance tests JSON", "issue_number", issueNumber, "error", err2, "raw_response", text)
-				return nil
+	// Try the full text first.
+	var probe []string
+	if json.Unmarshal([]byte(text), &probe) == nil {
+		return text, true
+	}
+
+	// Find outermost [...] using bracket-depth tracking.
+	start := -1
+	depth := 0
+	for i, ch := range text {
+		switch ch {
+		case '[':
+			if depth == 0 {
+				start = i
 			}
-		} else {
-			logger.Warn("failed to parse acceptance tests JSON", "issue_number", issueNumber, "error", err, "raw_response", text)
-			return nil
+			depth++
+		case ']':
+			depth--
+			if depth == 0 && start >= 0 {
+				candidate := text[start : i+1]
+				if json.Unmarshal([]byte(candidate), &probe) == nil {
+					return candidate, true
+				}
+				// Reset and keep scanning for another array.
+				start = -1
+			}
 		}
+	}
+	return "", false
+}
+
+// parseAcceptanceTests extracts a JSON array of strings from LLM output.
+// Handles optional markdown code fences. Caps at 5 items.
+func parseAcceptanceTests(text string, issueNumber int, logger *slog.Logger) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	jsonStr, ok := extractJSONArray(text)
+	if !ok {
+		logger.Warn("failed to parse acceptance tests JSON", "issue_number", issueNumber, "raw_response", text)
+		return nil
+	}
+
+	var tests []string
+	if err := json.Unmarshal([]byte(jsonStr), &tests); err != nil {
+		logger.Warn("failed to parse acceptance tests JSON", "issue_number", issueNumber, "error", err, "raw_response", text)
+		return nil
 	}
 
 	if len(tests) > 5 {

--- a/internal/agent/punchlist_test.go
+++ b/internal/agent/punchlist_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"testing"
@@ -9,6 +10,83 @@ import (
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/punchlist"
 )
+
+func TestExtractJSONArray_PlainJSON(t *testing.T) {
+	s, ok := extractJSONArray(`["a","b"]`)
+	if !ok {
+		t.Fatal("expected ok=true for plain JSON array")
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(s), &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("got %v, want [a b]", got)
+	}
+}
+
+func TestExtractJSONArray_CodeFence(t *testing.T) {
+	input := "```json\n[\"a\"]\n```"
+	s, ok := extractJSONArray(input)
+	if !ok {
+		t.Fatal("expected ok=true for fenced JSON array")
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(s), &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "a" {
+		t.Errorf("got %v, want [a]", got)
+	}
+}
+
+func TestExtractJSONArray_SurroundingText(t *testing.T) {
+	input := `Here are tests: ["a"] done`
+	s, ok := extractJSONArray(input)
+	if !ok {
+		t.Fatal("expected ok=true for JSON embedded in text")
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(s), &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "a" {
+		t.Errorf("got %v, want [a]", got)
+	}
+}
+
+func TestExtractJSONArray_NestedBrackets(t *testing.T) {
+	// The text contains nested brackets; depth tracking must find outermost.
+	input := `text [with [nested] brackets] more`
+	// This is not valid JSON so should return false (no valid JSON array found).
+	_, ok := extractJSONArray(input)
+	if ok {
+		t.Error("expected ok=false for text with only non-JSON nested brackets")
+	}
+}
+
+func TestExtractJSONArray_ValidNestedJSON(t *testing.T) {
+	// Valid JSON array with nested structure.
+	input := `prefix ["a","b"] suffix`
+	s, ok := extractJSONArray(input)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	var got []string
+	if err := json.Unmarshal([]byte(s), &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("got %v, want [a b]", got)
+	}
+}
+
+func TestExtractJSONArray_NoBrackets(t *testing.T) {
+	_, ok := extractJSONArray("no brackets here")
+	if ok {
+		t.Error("expected ok=false for text without brackets")
+	}
+}
 
 func TestParseAcceptanceTests_ValidJSON(t *testing.T) {
 	input := `["Test one", "Test two", "Test three"]`

--- a/internal/punchlist/punchlist.go
+++ b/internal/punchlist/punchlist.go
@@ -167,6 +167,17 @@ func (e Entry) ExtractScenarioCases() []string {
 	return extractScenarioCases(e.ScenarioSpec)
 }
 
+// extractPrefixedItem checks each prefix in order and returns the line with the
+// first matching prefix stripped. Returns ("", false) if no prefix matches.
+func extractPrefixedItem(line string, prefixes ...string) (string, bool) {
+	for _, p := range prefixes {
+		if strings.HasPrefix(line, p) {
+			return strings.TrimPrefix(line, p), true
+		}
+	}
+	return "", false
+}
+
 // extractVerificationSteps extracts manual verification items from an issue body.
 // It collects checkbox items (- [ ]) from anywhere in the body, plus plain
 // bullet points within test/acceptance/verification/cases section headers.
@@ -189,29 +200,15 @@ func extractVerificationSteps(body string) []string {
 		}
 
 		// Explicit checkboxes anywhere in the body.
-		if strings.HasPrefix(trimmed, "- [ ] ") || strings.HasPrefix(trimmed, "* [ ] ") {
-			var item string
-			if strings.HasPrefix(trimmed, "- [ ] ") {
-				item = strings.TrimPrefix(trimmed, "- [ ] ")
-			} else {
-				item = strings.TrimPrefix(trimmed, "* [ ] ")
-			}
+		if item, ok := extractPrefixedItem(trimmed, "- [ ] ", "* [ ] "); ok {
 			items = append(items, item)
 			continue
 		}
 
 		// Bullet points within test/acceptance sections.
 		if inTestSection {
-			if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
-				var item string
-				if strings.HasPrefix(trimmed, "- ") {
-					item = strings.TrimPrefix(trimmed, "- ")
-				} else {
-					item = strings.TrimPrefix(trimmed, "* ")
-				}
-				if item != "" {
-					items = append(items, item)
-				}
+			if item, ok := extractPrefixedItem(trimmed, "- ", "* "); ok && item != "" {
+				items = append(items, item)
 			}
 		}
 	}

--- a/internal/punchlist/punchlist_test.go
+++ b/internal/punchlist/punchlist_test.go
@@ -138,6 +138,54 @@ func TestGenerate_NoScenarioSection(t *testing.T) {
 	}
 }
 
+func TestExtractPrefixedItem_CheckboxDash(t *testing.T) {
+	item, ok := extractPrefixedItem("- [ ] foo", "- [ ] ", "* [ ] ")
+	if !ok {
+		t.Fatal("expected ok=true for dash checkbox prefix")
+	}
+	if item != "foo" {
+		t.Errorf("item = %q, want %q", item, "foo")
+	}
+}
+
+func TestExtractPrefixedItem_CheckboxStar(t *testing.T) {
+	item, ok := extractPrefixedItem("* [ ] foo", "- [ ] ", "* [ ] ")
+	if !ok {
+		t.Fatal("expected ok=true for star checkbox prefix")
+	}
+	if item != "foo" {
+		t.Errorf("item = %q, want %q", item, "foo")
+	}
+}
+
+func TestExtractPrefixedItem_NoMatch(t *testing.T) {
+	item, ok := extractPrefixedItem("plain text", "- ")
+	if ok {
+		t.Errorf("expected ok=false for non-matching line, got item=%q", item)
+	}
+	if item != "" {
+		t.Errorf("expected empty item on no match, got %q", item)
+	}
+}
+
+func TestExtractPrefixedItem_FirstPrefixWins(t *testing.T) {
+	// Line starts with "- ", not "* " — first prefix should win.
+	item, ok := extractPrefixedItem("- hello", "- ", "* ")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if item != "hello" {
+		t.Errorf("item = %q, want %q", item, "hello")
+	}
+}
+
+func TestExtractPrefixedItem_NoPrefixes(t *testing.T) {
+	_, ok := extractPrefixedItem("- [ ] foo")
+	if ok {
+		t.Error("expected ok=false when no prefixes provided")
+	}
+}
+
 func TestExtractVerificationSteps_Checkboxes(t *testing.T) {
 	body := "Some intro.\n- [ ] Step one\n- [ ] Step two\n"
 	items := extractVerificationSteps(body)


### PR DESCRIPTION
## Summary

- Extract `extractJSONArray` helper in `internal/agent/punchlist.go` that uses bracket-depth tracking to find the outermost `[...]` pair, replacing the fragile `strings.Index`/`strings.LastIndex` approach
- Extract `extractPrefixedItem` helper in `internal/punchlist/punchlist.go` that replaces duplicated `HasPrefix`/`TrimPrefix` chains with a single variadic helper
- Add unit tests for both new helpers covering all issue test cases

## Test plan

- [x] `TestExtractJSONArray_PlainJSON` — plain JSON array
- [x] `TestExtractJSONArray_CodeFence` — JSON in ` ```json ` fence
- [x] `TestExtractJSONArray_SurroundingText` — JSON embedded in surrounding text
- [x] `TestExtractJSONArray_NestedBrackets` — non-JSON nested brackets return false
- [x] `TestExtractJSONArray_ValidNestedJSON` — valid array with prefix/suffix text
- [x] `TestExtractJSONArray_NoBrackets` — returns false for bracketless text
- [x] `TestExtractPrefixedItem_CheckboxDash` — dash checkbox prefix
- [x] `TestExtractPrefixedItem_CheckboxStar` — star checkbox prefix
- [x] `TestExtractPrefixedItem_NoMatch` — returns false for non-matching line
- [x] All existing punchlist tests pass

## Implementation Notes

### Approach
`extractJSONArray` moves the existing fence-stripping logic into a self-contained helper. After stripping, it tries `json.Unmarshal` on the full text first (fast path). On failure it scans character-by-character tracking bracket depth — when depth returns to 0, it attempts to unmarshal the substring and returns it if valid.

`extractPrefixedItem` is a simple loop over `prefixes`, returning the first matching `TrimPrefix` result.

### Key Decisions
- `extractJSONArray` resets `start` and continues scanning after a depth=0 close bracket that fails to unmarshal — this handles edge cases where there are multiple bracket groups.
- The `item != ""` guard on bullet points (present in original code) is preserved in the `extractPrefixedItem` call site.

### Known Limitations
None. All existing test cases and new helper test cases pass.

### Architecture
- `internal/agent/` (orchestration layer): changes are self-contained, no new imports added
- `internal/punchlist/` (domain layer): changes are self-contained, no new imports added
- Both helpers are unexported; no cross-layer surface area changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #398