### PR TITLE
refactor: consolidate skills test helpers into helpers_test.go

### DIFF
--- a/internal/skills/godark_configure_project_test.go
+++ b/internal/skills/godark_configure_project_test.go
@@ -8,15 +8,6 @@ import (
 	"github.com/phs/dark-factory/internal/skills"
 )
 
-func readConfigureProjectSkill(t *testing.T) string {
-	t.Helper()
-	data, err := fs.ReadFile(skills.SkillFiles, "godark-configure-project/SKILL.md")
-	if err != nil {
-		t.Fatalf("reading godark-configure-project/SKILL.md: %v", err)
-	}
-	return string(data)
-}
-
 func TestConfigureProjectSkillEmbedded(t *testing.T) {
 	_, err := fs.ReadFile(skills.SkillFiles, "godark-configure-project/SKILL.md")
 	if err != nil {
@@ -25,7 +16,7 @@ func TestConfigureProjectSkillEmbedded(t *testing.T) {
 }
 
 func TestConfigureProjectSkillFrontmatterName(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "name: godark-configure-project") {
 		t.Error("frontmatter missing 'name: godark-configure-project'")
@@ -33,7 +24,7 @@ func TestConfigureProjectSkillFrontmatterName(t *testing.T) {
 }
 
 func TestConfigureProjectSkillFrontmatterDescription(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "description:") {
 		t.Error("frontmatter missing 'description' field")
@@ -41,7 +32,7 @@ func TestConfigureProjectSkillFrontmatterDescription(t *testing.T) {
 }
 
 func TestConfigureProjectSkillFrontmatterArgumentHint(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "argument-hint:") {
 		t.Error("frontmatter missing 'argument-hint' field")
@@ -49,7 +40,7 @@ func TestConfigureProjectSkillFrontmatterArgumentHint(t *testing.T) {
 }
 
 func TestConfigureProjectSkillFrontmatterDisableModelInvocation(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "disable-model-invocation: true") {
 		t.Error("frontmatter missing 'disable-model-invocation: true'")
@@ -57,7 +48,7 @@ func TestConfigureProjectSkillFrontmatterDisableModelInvocation(t *testing.T) {
 }
 
 func TestConfigureProjectSkillDetectsMultipleModules(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	hasGoMod := strings.Contains(content, "go.mod")
 	hasPackageJSON := strings.Contains(content, "package.json")
 	hasPubspec := strings.Contains(content, "pubspec.yaml")
@@ -67,21 +58,21 @@ func TestConfigureProjectSkillDetectsMultipleModules(t *testing.T) {
 }
 
 func TestConfigureProjectSkillSuggestsModulesConfig(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, "modules:") {
 		t.Error("skill does not suggest modules: config for multi-module projects")
 	}
 }
 
 func TestConfigureProjectSkillModulesIncludeDependsOn(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, "depends_on") {
 		t.Error("skill does not mention depends_on for module dependency ordering")
 	}
 }
 
 func TestConfigureProjectSkillDetectsCodegenConfigs(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	hasSqlc := strings.Contains(content, "sqlc")
 	hasGqlgen := strings.Contains(content, "gqlgen")
 	if !hasSqlc || !hasGqlgen {
@@ -90,42 +81,42 @@ func TestConfigureProjectSkillDetectsCodegenConfigs(t *testing.T) {
 }
 
 func TestConfigureProjectSkillDetectsProtoFiles(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, ".proto") {
 		t.Error("skill does not describe detecting .proto files for protobuf codegen")
 	}
 }
 
 func TestConfigureProjectSkillDetectsMakefileGenerateTargets(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, "Makefile") {
 		t.Error("skill does not describe detecting Makefile generate targets")
 	}
 }
 
 func TestConfigureProjectSkillSuggestsGenerateCommand(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, "generate_command") {
 		t.Error("skill does not suggest generate_command for codegen")
 	}
 }
 
 func TestConfigureProjectSkillSuggestsGeneratedPaths(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, "generated_paths") {
 		t.Error("skill does not suggest generated_paths for codegen output directories")
 	}
 }
 
 func TestConfigureProjectSkillDetectsEnvExample(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, ".env.example") {
 		t.Error("skill does not describe detecting .env.example for required_env")
 	}
 }
 
 func TestConfigureProjectSkillDetectsComposeSecrets(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	hasCompose := strings.Contains(content, "docker-compose") || strings.Contains(content, "compose.yml")
 	hasSecrets := strings.Contains(content, "secrets:")
 	if !hasCompose || !hasSecrets {
@@ -134,28 +125,28 @@ func TestConfigureProjectSkillDetectsComposeSecrets(t *testing.T) {
 }
 
 func TestConfigureProjectSkillSuggestsRequiredEnv(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, "required_env") {
 		t.Error("skill does not suggest required_env field")
 	}
 }
 
 func TestConfigureProjectSkillDetectsCIWorkflows(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, ".github/workflows") {
 		t.Error("skill does not describe detecting CI workflow files in .github/workflows/")
 	}
 }
 
 func TestConfigureProjectSkillSuggestsWaitForChecks(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, "wait_for_checks") {
 		t.Error("skill does not suggest wait_for_checks from CI workflow job names")
 	}
 }
 
 func TestConfigureProjectSkillDetectsDockerCompose(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	hasCompose := strings.Contains(content, "docker-compose.yml") || strings.Contains(content, "compose.yml")
 	if !hasCompose {
 		t.Error("skill does not describe detecting Docker Compose files")
@@ -163,14 +154,14 @@ func TestConfigureProjectSkillDetectsDockerCompose(t *testing.T) {
 }
 
 func TestConfigureProjectSkillNotesNoSandbox(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	if !strings.Contains(content, "no_sandbox") {
 		t.Error("skill does not note that no_sandbox: true may be needed for Docker Compose integration tests")
 	}
 }
 
 func TestConfigureProjectSkillMergesExistingConfig(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	hasMerge := strings.Contains(content, "merge") || strings.Contains(content, "overwrite")
 	if !hasMerge {
 		t.Error("skill does not describe merging into existing godark.yaml without overwriting existing fields")
@@ -178,7 +169,7 @@ func TestConfigureProjectSkillMergesExistingConfig(t *testing.T) {
 }
 
 func TestConfigureProjectSkillRequiresUserConfirmation(t *testing.T) {
-	content := readConfigureProjectSkill(t)
+	content := readSkill(t, "godark-configure-project")
 	hasConfirm := strings.Contains(content, "confirm") || strings.Contains(content, "approve")
 	if !hasConfirm {
 		t.Error("skill does not require user confirmation before writing")

--- a/internal/skills/godark_create_phase_overview_test.go
+++ b/internal/skills/godark_create_phase_overview_test.go
@@ -8,15 +8,6 @@ import (
 	"github.com/phs/dark-factory/internal/skills"
 )
 
-func readCreatePhaseOverviewSkill(t *testing.T) string {
-	t.Helper()
-	data, err := fs.ReadFile(skills.SkillFiles, "godark-create-phase-overview/SKILL.md")
-	if err != nil {
-		t.Fatalf("reading godark-create-phase-overview/SKILL.md: %v", err)
-	}
-	return string(data)
-}
-
 func TestCreatePhaseOverviewSkillEmbedded(t *testing.T) {
 	_, err := fs.ReadFile(skills.SkillFiles, "godark-create-phase-overview/SKILL.md")
 	if err != nil {
@@ -25,7 +16,7 @@ func TestCreatePhaseOverviewSkillEmbedded(t *testing.T) {
 }
 
 func TestCreatePhaseOverviewSkillFrontmatterName(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "name: godark-create-phase-overview") {
 		t.Error("frontmatter missing 'name: godark-create-phase-overview'")
@@ -33,7 +24,7 @@ func TestCreatePhaseOverviewSkillFrontmatterName(t *testing.T) {
 }
 
 func TestCreatePhaseOverviewSkillFrontmatterDescription(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "description:") {
 		t.Error("frontmatter missing 'description' field")
@@ -41,7 +32,7 @@ func TestCreatePhaseOverviewSkillFrontmatterDescription(t *testing.T) {
 }
 
 func TestCreatePhaseOverviewSkillFrontmatterArgumentHint(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "argument-hint:") {
 		t.Error("frontmatter missing 'argument-hint' field")
@@ -49,7 +40,7 @@ func TestCreatePhaseOverviewSkillFrontmatterArgumentHint(t *testing.T) {
 }
 
 func TestCreatePhaseOverviewSkillFrontmatterDisableModelInvocation(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "disable-model-invocation: true") {
 		t.Error("frontmatter missing 'disable-model-invocation: true'")
@@ -57,35 +48,35 @@ func TestCreatePhaseOverviewSkillFrontmatterDisableModelInvocation(t *testing.T)
 }
 
 func TestCreatePhaseOverviewSkillReadsRoadmap(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	if !strings.Contains(content, "ROADMAP.md") {
 		t.Error("skill does not reference ROADMAP.md")
 	}
 }
 
 func TestCreatePhaseOverviewSkillReadsPlanningDoc(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	if !strings.Contains(content, "docs/planning/") {
 		t.Error("skill does not reference docs/planning/ for planning docs")
 	}
 }
 
 func TestCreatePhaseOverviewSkillExploresCodebase(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	if !strings.Contains(content, "docs/architecture.json") {
 		t.Error("skill does not instruct agent to use docs/architecture.json for codebase exploration")
 	}
 }
 
 func TestCreatePhaseOverviewSkillWritesToOverviewsDir(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	if !strings.Contains(content, "docs/phase-overviews/") {
 		t.Error("skill does not specify docs/phase-overviews/ as output directory")
 	}
 }
 
 func TestCreatePhaseOverviewSkillWarnsOnIncompletePhase(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	hasWarn := strings.Contains(content, "incomplete") || strings.Contains(content, "not marked")
 	if !hasWarn {
 		t.Error("skill does not warn when phase is not marked complete")
@@ -93,14 +84,14 @@ func TestCreatePhaseOverviewSkillWarnsOnIncompletePhase(t *testing.T) {
 }
 
 func TestCreatePhaseOverviewSkillRequiresRealWorldExamples(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	if !strings.Contains(content, "Example") {
 		t.Error("skill does not require real-world examples for each feature")
 	}
 }
 
 func TestCreatePhaseOverviewSkillGroundsInCodebase(t *testing.T) {
-	content := readCreatePhaseOverviewSkill(t)
+	content := readSkill(t, "godark-create-phase-overview")
 	hasGrounded := strings.Contains(content, "grounded") || strings.Contains(content, "actual codebase")
 	if !hasGrounded {
 		t.Error("skill does not emphasize grounding examples in actual codebase")

--- a/internal/skills/godark_create_planning_doc_test.go
+++ b/internal/skills/godark_create_planning_doc_test.go
@@ -8,31 +8,22 @@ import (
 	"github.com/phs/dark-factory/internal/skills"
 )
 
-func readCreatePlanningDocSkill(t *testing.T) string {
-	t.Helper()
-	data, err := fs.ReadFile(skills.SkillFiles, "godark-create-planning-doc/SKILL.md")
-	if err != nil {
-		t.Fatalf("reading godark-create-planning-doc/SKILL.md: %v", err)
-	}
-	return string(data)
-}
-
 func TestCreatePlanningDocSkillStep3ReferencesArchitectureJSON(t *testing.T) {
-	content := readCreatePlanningDocSkill(t)
+	content := readSkill(t, "godark-create-planning-doc")
 	if !strings.Contains(content, "docs/architecture.json") {
 		t.Error("step 3 does not reference docs/architecture.json")
 	}
 }
 
 func TestCreatePlanningDocSkillStep3ReferencesConventionsMD(t *testing.T) {
-	content := readCreatePlanningDocSkill(t)
+	content := readSkill(t, "godark-create-planning-doc")
 	if !strings.Contains(content, "docs/conventions.md") {
 		t.Error("step 3 does not reference docs/conventions.md")
 	}
 }
 
 func TestCreatePlanningDocSkillStep4PromptsArchitectureUpdate(t *testing.T) {
-	content := readCreatePlanningDocSkill(t)
+	content := readSkill(t, "godark-create-planning-doc")
 	if !strings.Contains(content, "docs/architecture.json") {
 		t.Error("step 4 does not mention updating docs/architecture.json when layers don't fit")
 	}
@@ -42,7 +33,7 @@ func TestCreatePlanningDocSkillStep4PromptsArchitectureUpdate(t *testing.T) {
 }
 
 func TestCreatePlanningDocSkillStep4MentionsDefineArchitectureSkill(t *testing.T) {
-	content := readCreatePlanningDocSkill(t)
+	content := readSkill(t, "godark-create-planning-doc")
 	if !strings.Contains(content, "/godark-define-architecture") {
 		t.Error("step 4 does not suggest /godark-define-architecture for revising layer definitions")
 	}

--- a/internal/skills/godark_create_roadmap_test.go
+++ b/internal/skills/godark_create_roadmap_test.go
@@ -8,38 +8,29 @@ import (
 	"github.com/phs/dark-factory/internal/skills"
 )
 
-func readCreateRoadmapSkill(t *testing.T) string {
-	t.Helper()
-	data, err := fs.ReadFile(skills.SkillFiles, "godark-create-roadmap/SKILL.md")
-	if err != nil {
-		t.Fatalf("reading godark-create-roadmap/SKILL.md: %v", err)
-	}
-	return string(data)
-}
-
 func TestCreateRoadmapSkillStep1ReferencesArchitectureJSON(t *testing.T) {
-	content := readCreateRoadmapSkill(t)
+	content := readSkill(t, "godark-create-roadmap")
 	if !strings.Contains(content, "docs/architecture.json") {
 		t.Error("step 1 does not reference docs/architecture.json")
 	}
 }
 
 func TestCreateRoadmapSkillStep1ReferencesConventionsMD(t *testing.T) {
-	content := readCreateRoadmapSkill(t)
+	content := readSkill(t, "godark-create-roadmap")
 	if !strings.Contains(content, "docs/conventions.md") {
 		t.Error("step 1 does not reference docs/conventions.md")
 	}
 }
 
 func TestCreateRoadmapSkillMentionsDefineArchitectureSkill(t *testing.T) {
-	content := readCreateRoadmapSkill(t)
+	content := readSkill(t, "godark-create-roadmap")
 	if !strings.Contains(content, "/godark-define-architecture") {
 		t.Error("skill does not mention /godark-define-architecture when architecture is missing")
 	}
 }
 
 func TestCreateRoadmapSkillStep2AskAboutArchitectureLayers(t *testing.T) {
-	content := readCreateRoadmapSkill(t)
+	content := readSkill(t, "godark-create-roadmap")
 	if !strings.Contains(content, "Architecture layers") && !strings.Contains(content, "architecture layers") {
 		t.Error("step 2 does not ask about architecture layers for structural decisions")
 	}

--- a/internal/skills/godark_define_architecture_test.go
+++ b/internal/skills/godark_define_architecture_test.go
@@ -1,33 +1,12 @@
 package skills_test
 
 import (
-	"io/fs"
 	"strings"
 	"testing"
-
-	"github.com/phs/dark-factory/internal/skills"
 )
 
-func readDefineArchitectureSkill(t *testing.T) string {
-	t.Helper()
-	data, err := fs.ReadFile(skills.SkillFiles, "godark-define-architecture/SKILL.md")
-	if err != nil {
-		t.Fatalf("reading godark-define-architecture/SKILL.md: %v", err)
-	}
-	return string(data)
-}
-
-// parseFrontmatter extracts the YAML block between the first pair of --- delimiters.
-func parseFrontmatter(content string) string {
-	parts := strings.SplitN(content, "---", 3)
-	if len(parts) < 3 {
-		return ""
-	}
-	return parts[1]
-}
-
 func TestDefineArchitectureSkillFrontmatterName(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "name:") {
 		t.Error("frontmatter missing 'name' field")
@@ -35,7 +14,7 @@ func TestDefineArchitectureSkillFrontmatterName(t *testing.T) {
 }
 
 func TestDefineArchitectureSkillFrontmatterDescription(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "description:") {
 		t.Error("frontmatter missing 'description' field")
@@ -43,7 +22,7 @@ func TestDefineArchitectureSkillFrontmatterDescription(t *testing.T) {
 }
 
 func TestDefineArchitectureSkillFrontmatterArgumentHint(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "argument-hint:") {
 		t.Error("frontmatter missing 'argument-hint' field")
@@ -51,7 +30,7 @@ func TestDefineArchitectureSkillFrontmatterArgumentHint(t *testing.T) {
 }
 
 func TestDefineArchitectureSkillFrontmatterDisableModelInvocation(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "disable-model-invocation: true") {
 		t.Error("frontmatter missing 'disable-model-invocation: true'")
@@ -59,56 +38,56 @@ func TestDefineArchitectureSkillFrontmatterDisableModelInvocation(t *testing.T) 
 }
 
 func TestDefineArchitectureSkillStepsDescribePackageScanning(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	if !strings.Contains(content, "package") && !strings.Contains(content, "module") {
 		t.Error("steps do not describe scanning for package or module directories")
 	}
 }
 
 func TestDefineArchitectureSkillStepsDescribeImportRelationships(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	if !strings.Contains(content, "import") {
 		t.Error("steps do not describe identifying import relationships")
 	}
 }
 
 func TestDefineArchitectureSkillStepsDescribeLanguageFrameworkQuestions(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	if !strings.Contains(content, "language") && !strings.Contains(content, "framework") {
 		t.Error("steps do not describe asking about language and framework for new projects")
 	}
 }
 
 func TestDefineArchitectureSkillStepsDescribeIdiomaticLayers(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	if !strings.Contains(content, "idiomatic") {
 		t.Error("steps do not describe proposing idiomatic layers for new projects")
 	}
 }
 
 func TestDefineArchitectureSkillStepsIncludeVetArchitecture(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	if !strings.Contains(content, "godark vet architecture") {
 		t.Error("steps do not include running 'godark vet architecture'")
 	}
 }
 
 func TestDefineArchitectureSkillStepsSuggestCreateRoadmapForDiscrepancies(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	if !strings.Contains(content, "/godark-create-roadmap") {
 		t.Error("steps do not suggest running /godark-create-roadmap for discrepancies")
 	}
 }
 
 func TestDefineArchitectureSkillStepsWriteArchitectureJSON(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	if !strings.Contains(content, "docs/architecture.json") {
 		t.Error("steps do not include writing docs/architecture.json")
 	}
 }
 
 func TestDefineArchitectureSkillStepsWriteArchitectureMD(t *testing.T) {
-	content := readDefineArchitectureSkill(t)
+	content := readSkill(t, "godark-define-architecture")
 	if !strings.Contains(content, "docs/architecture.md") {
 		t.Error("steps do not include writing or updating docs/architecture.md")
 	}

--- a/internal/skills/godark_define_conventions_test.go
+++ b/internal/skills/godark_define_conventions_test.go
@@ -1,24 +1,12 @@
 package skills_test
 
 import (
-	"io/fs"
 	"strings"
 	"testing"
-
-	"github.com/phs/dark-factory/internal/skills"
 )
 
-func readDefineConventionsSkill(t *testing.T) string {
-	t.Helper()
-	data, err := fs.ReadFile(skills.SkillFiles, "godark-define-conventions/SKILL.md")
-	if err != nil {
-		t.Fatalf("reading godark-define-conventions/SKILL.md: %v", err)
-	}
-	return string(data)
-}
-
 func TestDefineConventionsSkillFrontmatterName(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "name:") {
 		t.Error("frontmatter missing 'name' field")
@@ -26,7 +14,7 @@ func TestDefineConventionsSkillFrontmatterName(t *testing.T) {
 }
 
 func TestDefineConventionsSkillFrontmatterDescription(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "description:") {
 		t.Error("frontmatter missing 'description' field")
@@ -34,7 +22,7 @@ func TestDefineConventionsSkillFrontmatterDescription(t *testing.T) {
 }
 
 func TestDefineConventionsSkillFrontmatterArgumentHint(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "argument-hint:") {
 		t.Error("frontmatter missing 'argument-hint' field")
@@ -42,7 +30,7 @@ func TestDefineConventionsSkillFrontmatterArgumentHint(t *testing.T) {
 }
 
 func TestDefineConventionsSkillFrontmatterDisableModelInvocation(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	fm := parseFrontmatter(content)
 	if !strings.Contains(fm, "disable-model-invocation: true") {
 		t.Error("frontmatter missing 'disable-model-invocation: true'")
@@ -50,56 +38,56 @@ func TestDefineConventionsSkillFrontmatterDisableModelInvocation(t *testing.T) {
 }
 
 func TestDefineConventionsSkillStepsDescribeSourceFileAnalysis(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	if !strings.Contains(content, "source file") && !strings.Contains(content, "source files") {
 		t.Error("steps do not describe reading source files for existing projects")
 	}
 }
 
 func TestDefineConventionsSkillStepsIdentifyPatterns(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	if !strings.Contains(content, "pattern") && !strings.Contains(content, "Pattern") {
 		t.Error("steps do not describe identifying patterns in existing code")
 	}
 }
 
 func TestDefineConventionsSkillStepsDescribeAgentFriendlinessExplicitOverImplicit(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	if !strings.Contains(content, "explicit") || !strings.Contains(content, "implicit") {
 		t.Error("steps do not describe explicit over implicit principle for agent-friendliness")
 	}
 }
 
 func TestDefineConventionsSkillStepsDescribeAgentFriendlinessLocalOverGlobal(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	if !strings.Contains(content, "local") || !strings.Contains(content, "global") {
 		t.Error("steps do not describe local over global principle for agent-friendliness")
 	}
 }
 
 func TestDefineConventionsSkillStepsFlagCodeGeneration(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	if !strings.Contains(content, "code generation") && !strings.Contains(content, "generators") {
 		t.Error("steps do not flag heavy code generation as an anti-pattern")
 	}
 }
 
 func TestDefineConventionsSkillStepsFlagConventionOverConfiguration(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	if !strings.Contains(content, "convention-over-configuration") && !strings.Contains(content, "Convention-over-configuration") {
 		t.Error("steps do not flag convention-over-configuration magic as an anti-pattern")
 	}
 }
 
 func TestDefineConventionsSkillStepsSuggestRoadmapForInconsistencies(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	if !strings.Contains(content, "/godark-create-roadmap") {
 		t.Error("steps do not suggest running /godark-create-roadmap for inconsistent conventions")
 	}
 }
 
 func TestDefineConventionsSkillStepsWriteConventionsMD(t *testing.T) {
-	content := readDefineConventionsSkill(t)
+	content := readSkill(t, "godark-define-conventions")
 	if !strings.Contains(content, "docs/conventions.md") {
 		t.Error("steps do not include writing docs/conventions.md")
 	}

--- a/internal/skills/helpers_test.go
+++ b/internal/skills/helpers_test.go
@@ -1,0 +1,28 @@
+package skills_test
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/phs/dark-factory/internal/skills"
+)
+
+func readSkill(t *testing.T, name string) string {
+	t.Helper()
+	path := name + "/SKILL.md"
+	data, err := fs.ReadFile(skills.SkillFiles, path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// parseFrontmatter extracts the YAML block between the first pair of --- delimiters.
+func parseFrontmatter(content string) string {
+	parts := strings.SplitN(content, "---", 3)
+	if len(parts) < 3 {
+		return ""
+	}
+	return parts[1]
+}


### PR DESCRIPTION
## Summary

- Create `internal/skills/helpers_test.go` with shared `readSkill(t, name)` and `parseFrontmatter(content)` helpers
- Remove 6 near-identical `readXxxSkill` per-file helper functions from 6 test files
- Remove `parseFrontmatter` definition from `godark_define_architecture_test.go` (it lived there but was used package-wide)
- Update all call sites to use `readSkill(t, "godark-xxx")` instead of the per-file helpers
- Drop `"io/fs"` and `skills` imports from `godark_define_architecture_test.go` and `godark_define_conventions_test.go` (no longer needed after removing local helpers)

Closes #399

## Test plan
- [x] `go test ./internal/skills/...` passes — all existing tests green
- [x] `readSkill` calls `t.Fatalf` on missing skill (matches original per-file helper behavior)
- [x] `parseFrontmatter` moved verbatim, no logic change

## Implementation Notes

### Approach
Created a single `helpers_test.go` in `package skills_test` with two shared helpers: `readSkill(t, name)` that constructs the path `<name>/SKILL.md` and reads from `skills.SkillFiles`, and `parseFrontmatter` moved verbatim from `godark_define_architecture_test.go`. All 6 per-file `readXxxSkill` functions were deleted and their call sites updated.

### Key Decisions
- Kept `"io/fs"` and `skills` imports in files that still use `fs.ReadFile(skills.SkillFiles, ...)` directly in `TestXxxEmbedded` tests (4 files). Only removed those imports from the 2 files that had no remaining direct usage.
- `helpers_test.go` imports `"io/fs"`, `"strings"`, `"testing"`, and `skills` — exactly what both helpers need.
- No production code changes — purely test-file refactoring within `package skills_test`.

### Known Limitations
None. All acceptance criteria met.

### Architecture
Touches only `internal/skills/` (`content` layer). All imports remain within the same package or stdlib — no new cross-layer dependencies introduced. Architecture constraints fully respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)