### PR TITLE
refactor: migrate callers to mdutil.WalkMarkdownFiles

### DIFF
--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -6,9 +6,10 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/phs/dark-factory/internal/mdutil"
 )
 
 // GuardRunner executes a command and returns its combined output.
@@ -123,11 +124,8 @@ func HasScenarioSpec(scenarioDir string, issueNum int) bool {
 	ref := fmt.Sprintf("#%d", issueNum)
 
 	found := false
-	_ = filepath.WalkDir(scenarioDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil || found {
-			return err
-		}
-		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+	_ = mdutil.WalkMarkdownFiles(scenarioDir, func(path string) error {
+		if found {
 			return nil
 		}
 		data, err := os.ReadFile(path)

--- a/internal/punchlist/punchlist.go
+++ b/internal/punchlist/punchlist.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/phs/dark-factory/internal/mdutil"
 )
 
 // CommandRunner executes a command and returns its combined output.
@@ -67,15 +69,9 @@ func FetchPRDiff(repo string, prNum int, maxLen int) (string, error) {
 func ReadScenarioSpec(scenarioDir string, issueNum int) (string, error) {
 	ref := fmt.Sprintf("#%d", issueNum)
 	var content string
-	err := filepath.WalkDir(scenarioDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
+	err := mdutil.WalkMarkdownFiles(scenarioDir, func(path string) error {
 		if content != "" {
 			return filepath.SkipAll
-		}
-		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
-			return nil
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {

--- a/internal/vet/scenarios.go
+++ b/internal/vet/scenarios.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/phs/dark-factory/internal/github"
+	"github.com/phs/dark-factory/internal/mdutil"
 	"github.com/phs/dark-factory/internal/patterns"
 )
 
@@ -21,13 +22,8 @@ func ValidateScenarios(scenarioDir string, milestoneIssues []github.Issue, allIs
 	r := &Report{}
 
 	var files []string
-	err := filepath.WalkDir(scenarioDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !d.IsDir() && strings.HasSuffix(d.Name(), ".md") {
-			files = append(files, path)
-		}
+	err := mdutil.WalkMarkdownFiles(scenarioDir, func(path string) error {
+		files = append(files, path)
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Replace inline `filepath.WalkDir` + `.md` filter in `ReadScenarioSpec` (punchlist), `ValidateScenarios` (vet), and `HasScenarioSpec` (guardrails) with `mdutil.WalkMarkdownFiles`
- Remove `"path/filepath"` import from `guardrails.go` (no remaining uses after migration)
- All existing tests pass without modification

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./internal/punchlist/...` passes
- [x] `go test ./internal/vet/...` passes
- [x] `go test ./internal/agent/...` passes

## Implementation Notes

### Approach
Replaced the three inline `filepath.WalkDir` + `.md` suffix filter patterns with `mdutil.WalkMarkdownFiles` calls. The helper (introduced by #384) handles the directory-skip and `.md` suffix check internally, so the callbacks only contain the business logic.

### Key Decisions
- `punchlist.go`: `filepath.SkipAll` is preserved in the callback for early termination after finding the first matching file; the `"path/filepath"` import stays for this reason.
- `guardrails.go`: `"path/filepath"` import removed entirely — it was only used for `filepath.WalkDir`, which is now replaced. The `found` guard (`if found { return nil }`) preserves the original walk-all-files-but-skip-processing-after-match semantics.
- `vet/scenarios.go`: The callback reduces to a single `files = append(files, path)` line.

### Known Limitations
None. All acceptance criteria met.

### Architecture
- `internal/punchlist` (domain layer) → imports `internal/mdutil` (foundation) ✓
- `internal/vet` (service layer) → imports `internal/mdutil` (foundation) ✓
- `internal/agent` (orchestration layer) → imports `internal/mdutil` (foundation) ✓

All imports follow the allowed dependency directions per `docs/architecture.md`.

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)