### PR TITLE
feat: adopt CommandRunnerFunc type in infrastructure and foundation packages

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"time"
 
+	darkexec "github.com/phs/dark-factory/internal/exec"
 	"gopkg.in/yaml.v3"
 )
 
 // CommandRunner executes a command and returns its combined output.
 // Replaceable for testing.
-var CommandRunner = func(name string, args ...string) ([]byte, error) {
+var CommandRunner darkexec.CommandRunnerFunc = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
 }
 

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	darkexec "github.com/phs/dark-factory/internal/exec"
 )
 
 // Issue represents a GitHub issue with the fields needed for orchestration.
@@ -41,7 +43,7 @@ var priorityRank = map[string]int{
 
 // CommandRunner executes a command and returns its combined output.
 // Replaceable for testing.
-var CommandRunner = func(name string, args ...string) ([]byte, error) {
+var CommandRunner darkexec.CommandRunnerFunc = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).Output()
 }
 

--- a/internal/sandbox/build.go
+++ b/internal/sandbox/build.go
@@ -9,11 +9,12 @@ import (
 	"path/filepath"
 
 	"github.com/phs/dark-factory/internal/agent/runner"
+	darkexec "github.com/phs/dark-factory/internal/exec"
 )
 
 // CommandRunner executes a command and returns its combined output.
 // Replaceable for testing.
-var CommandRunner = func(name string, args ...string) ([]byte, error) {
+var CommandRunner darkexec.CommandRunnerFunc = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
 }
 


### PR DESCRIPTION
Closes #401

## Summary
- Add `darkexec.CommandRunnerFunc` type annotation to `var CommandRunner` in `internal/github/issues.go`, `internal/sandbox/build.go`, and `internal/config/config.go`
- Import `github.com/phs/dark-factory/internal/exec` aliased as `darkexec` in each file to avoid collision with stdlib `os/exec`
- Function literal bodies and all callers are unchanged

## Test plan
- [x] `go build ./internal/github/... ./internal/sandbox/... ./internal/config/...` passes
- [x] All tests in `internal/github`, `internal/sandbox`, `internal/config`, and `internal/exec` pass without modification

## Implementation Notes

### Approach
The `internal/exec` package (introduced by #385) was already present on the target branch with `CommandRunnerFunc` defined. The change is purely a type annotation: adding `darkexec.CommandRunnerFunc` between `var CommandRunner` and `=` in each of the three files.

### Key Decisions
- Aliased the internal exec import as `darkexec` in all three files to avoid shadowing the existing stdlib `"os/exec"` import, which is still needed to call `exec.Command(...)` in the function literals.
- No callers changed — Go function literals with the same underlying signature are assignable to named function types.

### Known Limitations
None. This is a complete mechanical type annotation change as specified.

### Architecture
- `internal/exec` — **foundation** layer (zero-dependency utility)
- `internal/config` — **foundation** layer; importing a sibling foundation package introduces no cycle
- `internal/github` — **infrastructure** layer; importing foundation is explicitly permitted
- `internal/sandbox` — **infrastructure** layer; importing foundation is explicitly permitted