### PR TITLE
feat: adopt CommandRunnerFunc in domain and orchestration packages

### DIFF
--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -9,12 +9,13 @@ import (
 	"strconv"
 	"strings"
 
+	gexec "github.com/phs/dark-factory/internal/exec"
 	"github.com/phs/dark-factory/internal/mdutil"
 )
 
 // GuardRunner executes a command and returns its combined output.
 // Replaceable for testing.
-var GuardRunner = func(name string, args ...string) ([]byte, error) {
+var GuardRunner gexec.CommandRunnerFunc = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/phs/dark-factory/internal/deps"
 	"github.com/phs/dark-factory/internal/detect"
 	"github.com/phs/dark-factory/internal/dialogue"
+	gexec "github.com/phs/dark-factory/internal/exec"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/label"
 	"github.com/phs/dark-factory/internal/lock"
@@ -666,7 +667,7 @@ func buildRollupBody(issues []github.Issue) string {
 
 // CommandRunner executes a command and returns its combined output.
 // Replaceable for testing.
-var CommandRunner = func(name string, args ...string) ([]byte, error) {
+var CommandRunner gexec.CommandRunnerFunc = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
 }
 

--- a/internal/punchlist/punchlist.go
+++ b/internal/punchlist/punchlist.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	gexec "github.com/phs/dark-factory/internal/exec"
 	"github.com/phs/dark-factory/internal/mdutil"
 )
 
 // CommandRunner executes a command and returns its combined output.
 // Replaceable for testing.
-var CommandRunner = func(name string, args ...string) ([]byte, error) {
+var CommandRunner gexec.CommandRunnerFunc = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
 }
 


### PR DESCRIPTION
Closes #402

## Implementation Notes

### Approach
Added explicit `gexec.CommandRunnerFunc` type annotations to the three package-level `CommandRunner`/`GuardRunner` variables in `internal/punchlist/punchlist.go`, `internal/orchestrator/orchestrator.go`, and `internal/agent/guardrails.go`. The `internal/exec` package (from #385) was already present on `p19-dev-t1`.

Each file already imports `"os/exec"` as the bare name `exec`, so the new import uses the alias `gexec` to avoid collision: `gexec "github.com/phs/dark-factory/internal/exec"`.

### Key Decisions
- Used `gexec` as the import alias consistently across all three files to avoid collision with the stdlib `"os/exec"` import that each file already uses.
- No test files were modified — existing anonymous function literals are assignable to named function types in Go when the underlying types match.

### Known Limitations
None. This is a purely mechanical type annotation change with no logic modifications.

### Architecture
- `internal/punchlist/` (domain layer) importing `internal/exec/` (foundation layer) — allowed per architecture rules
- `internal/orchestrator/` (orchestration layer) importing `internal/exec/` (foundation layer) — allowed per architecture rules
- `internal/agent/` (orchestration layer) importing `internal/exec/` (foundation layer) — allowed per architecture rules

No layer violations introduced.