### PR TITLE
refactor: use CommandRunnerFunc and external timeout in doctor.go

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,30 +1,32 @@
 package doctor
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
+
+	goexec "github.com/phs/dark-factory/internal/exec"
 )
 
 // CommandRunner executes a command and returns its combined output.
 // Replaceable for testing.
-var CommandRunner = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, name, args...).CombinedOutput()
-}
+var CommandRunner goexec.CommandRunnerFunc = goexec.Default
 
 // EnvLookup looks up an environment variable.
 // Replaceable for testing.
 var EnvLookup = os.Getenv
 
+// CheckTimeout is the per-check deadline enforced by Run.
+// Overridable in tests.
+var CheckTimeout = 15 * time.Second
+
 // Check represents a single pre-flight check.
 type Check struct {
 	Name string
 	Fix  string
-	run  func(ctx context.Context) bool
+	run  func() bool
 }
 
 // runtimeVersionCmd returns the command and args to verify a named runtime is
@@ -56,31 +58,31 @@ func Checks(runtime, lintCommand string) []*Check {
 		{
 			Name: "Docker daemon running",
 			Fix:  "Start Docker Desktop or the Docker daemon (e.g. `sudo systemctl start docker`).",
-			run: func(ctx context.Context) bool {
-				_, err := CommandRunner(ctx, "docker", "info")
+			run: func() bool {
+				_, err := CommandRunner("docker", "info")
 				return err == nil
 			},
 		},
 		{
 			Name: "gh CLI installed",
 			Fix:  "Install the GitHub CLI: https://cli.github.com",
-			run: func(ctx context.Context) bool {
-				_, err := CommandRunner(ctx, "gh", "--version")
+			run: func() bool {
+				_, err := CommandRunner("gh", "--version")
 				return err == nil
 			},
 		},
 		{
 			Name: "gh CLI authenticated",
 			Fix:  "Run `gh auth login` to authenticate.",
-			run: func(ctx context.Context) bool {
-				_, err := CommandRunner(ctx, "gh", "auth", "status")
+			run: func() bool {
+				_, err := CommandRunner("gh", "auth", "status")
 				return err == nil
 			},
 		},
 		{
 			Name: "ANTHROPIC_API_KEY set",
 			Fix:  "Export ANTHROPIC_API_KEY in your shell profile or pass it in the environment.",
-			run: func(ctx context.Context) bool {
+			run: func() bool {
 				return EnvLookup("ANTHROPIC_API_KEY") != ""
 			},
 		},
@@ -95,8 +97,8 @@ func Checks(runtime, lintCommand string) []*Check {
 			checks = append(checks, &Check{
 				Name: fmt.Sprintf("%s toolchain available", rt),
 				Fix:  fmt.Sprintf("Install the %s toolchain and ensure it is on your PATH.", rt),
-				run: func(ctx context.Context) bool {
-					_, err := CommandRunner(ctx, b, a...)
+				run: func() bool {
+					_, err := CommandRunner(b, a...)
 					return err == nil
 				},
 			})
@@ -106,8 +108,8 @@ func Checks(runtime, lintCommand string) []*Check {
 	checks = append(checks, &Check{
 		Name: "Python 3 available",
 		Fix:  "Install Python 3: https://www.python.org/downloads/",
-		run: func(ctx context.Context) bool {
-			_, err := CommandRunner(ctx, "python3", "--version")
+		run: func() bool {
+			_, err := CommandRunner("python3", "--version")
 			return err == nil
 		},
 	})
@@ -116,8 +118,8 @@ func Checks(runtime, lintCommand string) []*Check {
 		checks = append(checks, &Check{
 			Name: "golangci-lint installed",
 			Fix:  "Install golangci-lint: `brew install golangci-lint` or see https://golangci-lint.run/usage/install/",
-			run: func(ctx context.Context) bool {
-				_, err := CommandRunner(ctx, "golangci-lint", "--version")
+			run: func() bool {
+				_, err := CommandRunner("golangci-lint", "--version")
 				return err == nil
 			},
 		})
@@ -127,13 +129,12 @@ func Checks(runtime, lintCommand string) []*Check {
 }
 
 // Run executes all checks, writes a pass/fail report to w, and returns true
-// if every check passed.
+// if every check passed. Each check is run in a goroutine; if it does not
+// complete within CheckTimeout it is reported as a failure.
 func Run(w io.Writer, checks []*Check) bool {
 	allPassed := true
 	for _, c := range checks {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		passed := c.run(ctx)
-		cancel()
+		passed := runWithTimeout(c)
 		if passed {
 			fmt.Fprintf(w, "[PASS] %s\n", c.Name)
 		} else {
@@ -144,4 +145,21 @@ func Run(w io.Writer, checks []*Check) bool {
 		}
 	}
 	return allPassed
+}
+
+// runWithTimeout runs a single check in a goroutine and returns its result,
+// or false if it exceeds CheckTimeout.
+func runWithTimeout(c *Check) bool {
+	result := make(chan bool, 1)
+	go func() {
+		result <- c.run()
+	}()
+	timer := time.NewTimer(CheckTimeout)
+	defer timer.Stop()
+	select {
+	case passed := <-result:
+		return passed
+	case <-timer.C:
+		return false
+	}
 }

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -2,20 +2,20 @@ package doctor
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 // stubRunner returns a CommandRunner stub that succeeds for the listed
 // commands (identified by name+args[0] if any) and fails for all others.
-func stubRunner(pass ...string) func(context.Context, string, ...string) ([]byte, error) {
+func stubRunner(pass ...string) func(string, ...string) ([]byte, error) {
 	passSet := make(map[string]bool, len(pass))
 	for _, p := range pass {
 		passSet[p] = true
 	}
-	return func(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return func(name string, args ...string) ([]byte, error) {
 		key := name
 		if len(args) > 0 {
 			key = name + " " + args[0]
@@ -283,5 +283,37 @@ func TestRuntimeVersionCmd(t *testing.T) {
 		if bin != tc.wantBin {
 			t.Errorf("runtimeVersionCmd(%q) bin = %q, want %q", tc.runtime, bin, tc.wantBin)
 		}
+	}
+}
+
+func TestRun_Timeout(t *testing.T) {
+	origTimeout := CheckTimeout
+	defer func() { CheckTimeout = origTimeout }()
+	CheckTimeout = 50 * time.Millisecond
+
+	// A check that blocks indefinitely.
+	block := make(chan struct{})
+	checks := []*Check{
+		{
+			Name: "blocking check",
+			Fix:  "unblock it",
+			run: func() bool {
+				<-block // never returns
+				return true
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	passed := Run(&buf, checks)
+
+	close(block) // allow goroutine to exit after test
+
+	if passed {
+		t.Error("expected Run to return false on timeout")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[FAIL] blocking check") {
+		t.Errorf("expected blocking check to be reported as FAIL, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
Closes #403

## Summary

- Change `doctor.CommandRunner` from a context-carrying closure to `exec.CommandRunnerFunc` (the shared type from `internal/exec`)
- Remove `ctx context.Context` from `Check.run` and all closure bodies
- Move the 15-second per-check timeout from `exec.CommandContext` inside each check to `Run()`, which now runs each check in a goroutine and selects on result vs `time.NewTimer`
- Add `var CheckTimeout = 15 * time.Second` as a test seam
- Update `stubRunner` in tests to drop the `context.Context` parameter
- Add `TestRun_Timeout` to verify blocking checks are reported as `[FAIL]`

## Implementation Notes

### Approach
Introduced `runWithTimeout(c *Check) bool` as a private helper that launches `c.run()` in a goroutine and uses `select` to enforce the deadline. This keeps `Run()` clean and the timeout logic self-contained. `CheckTimeout` is a package-level variable (rather than a function parameter) to match the pattern used elsewhere in the codebase for testability seams.

### Key Decisions
- Used `var CheckTimeout = 15 * time.Second` instead of hardcoding in `Run()` to allow fast timeout tests (`TestRun_Timeout` sets it to 50ms)
- Aliased the new dependency as `goexec` to avoid collision with the standard `"os/exec"` import (which is no longer needed in doctor.go but the alias keeps intent clear)
- Buffered the result channel (`make(chan bool, 1)`) so the goroutine never leaks if the timer fires first

### Known Limitations
- The goroutine spawned for a timed-out check continues running until the underlying command returns (there is no kill mechanism). This is consistent with how the other `CommandRunner` usages work across the codebase.

### Architecture
- `internal/doctor/` is in the **domain** layer
- `internal/exec/` is in the **foundation** layer
- Domain may depend on foundation — no architecture violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)