### PR TITLE
refactor: replace bare outcome status string literals with named constants

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -196,16 +196,16 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			}
 
 			switch outcome.Status {
-			case "implemented":
+			case agent.StatusImplemented:
 				implemented++
 				fmt.Printf("  #%d %s — implemented (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
 				if err := orchestrator.PullAfterMerge(cfg.EffectiveBaseBranch(), logger); err != nil {
 					logger.Warn("could not sync local repo after merge", "error", err)
 				}
-			case "ready-to-merge":
+			case agent.StatusReadyToMerge:
 				readyToMerge++
 				fmt.Printf("  #%d %s — ready-to-merge (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
-			case "needs-human-review":
+			case agent.StatusNeedsHumanReview:
 				needsHumanReview++
 				fmt.Printf("  #%d %s — needs human review (PR #%d)\n", issue.Number, issue.Title, outcome.PRNumber)
 			default:

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -557,13 +557,13 @@ func issueToRowView(issue rundata.IssueDetail, owner, repo, timestamp string) Is
 func issueStatusLabelAndClass(issue rundata.IssueDetail) (label, class string) {
 	// Final outcomes take precedence over live status.
 	switch issue.Outcome.Status {
-	case "implemented":
+	case rundata.OutcomeStatusImplemented:
 		return "Implemented", "success"
-	case "ready-to-merge":
+	case rundata.OutcomeStatusReadyToMerge:
 		return "Ready to Merge", "success"
-	case "needs-human-review":
+	case rundata.OutcomeStatusNeedsHumanReview:
 		return "Needs Human Review", "warning"
-	case "failed":
+	case rundata.OutcomeStatusFailed:
 		return "Failed", "danger"
 	}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -368,7 +368,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 			}
 
 			switch outcome.Status {
-			case "implemented":
+			case agent.StatusImplemented:
 				stats.implemented++
 				implementedIssues = append(implementedIssues, issue)
 				fmt.Printf("  #%d %s — implemented (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
@@ -378,10 +378,10 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 					goto done
 				}
 				merged = true
-			case "ready-to-merge":
+			case agent.StatusReadyToMerge:
 				stats.readyToMerge++
 				fmt.Printf("  #%d %s — ready-to-merge (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
-			case "needs-human-review":
+			case agent.StatusNeedsHumanReview:
 				stats.needsHumanReview++
 				fmt.Printf("  #%d %s — needs human review (PR #%d)\n", issue.Number, issue.Title, outcome.PRNumber)
 			default:

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -74,6 +74,16 @@ type StepResult struct {
 	SessionID       string     `json:"session_id,omitempty"`
 }
 
+// OutcomeStatus constants mirror the agent.OutcomeStatus values for use in
+// packages that cannot import the orchestration layer (e.g. presentation).
+// These must stay in sync with the constants defined in internal/agent/loop.go.
+const (
+	OutcomeStatusImplemented      = "implemented"
+	OutcomeStatusReadyToMerge     = "ready-to-merge"
+	OutcomeStatusNeedsHumanReview = "needs-human-review"
+	OutcomeStatusFailed           = "failed"
+)
+
 // Outcome records the final result for a single issue.
 type Outcome struct {
 	IssueNumber int    `json:"issue_number"`


### PR DESCRIPTION
## Summary

- Replaces 3 bare string literals in `internal/cmd/implement.go` switch with `agent.StatusImplemented`, `agent.StatusReadyToMerge`, `agent.StatusNeedsHumanReview`
- Replaces 3 bare string literals in `internal/orchestrator/orchestrator.go` switch with the same `agent` constants
- Adds `OutcomeStatus*` string constants to `internal/rundata/writer.go` (domain layer) and uses them in `internal/dashboard/handlers.go` to replace 4 string literals — respecting the architectural rule that `presentation` must not import `orchestration`

## Test plan

- [x] `go build ./...` succeeds with no errors
- [x] `go vet` passes on all modified packages
- [x] All existing tests pass: `internal/cmd`, `internal/orchestrator`, `internal/dashboard`, `internal/rundata`, `internal/agent`

## Implementation Notes

### Approach
Replace string literals in the three consumer switch statements with named constants. For `implement.go` and `orchestrator.go`, which already import `internal/agent`, use `agent.StatusImplemented` etc. directly — `IssueOutcome.Status` is typed `OutcomeStatus` so the constants match without casting.

For `dashboard/handlers.go`, the `presentation` layer cannot import `orchestration` (`internal/agent`). Additionally, `rundata.Outcome.Status` is `string`, not `OutcomeStatus`, so `agent.Status*` typed constants would not be usable in a switch even if the import were allowed. The solution is to define untyped string constants in `internal/rundata/writer.go` (domain layer, which presentation may depend on) and use `rundata.OutcomeStatus*` in `handlers.go`.

### Key Decisions
- Added `OutcomeStatusImplemented/ReadyToMerge/NeedsHumanReview/Failed` to `rundata` rather than leaving `handlers.go` with string literals. This fully satisfies the acceptance criteria while respecting layer rules.
- The `rundata` constants are untyped string constants (not a named type), so they are directly comparable to `rundata.Outcome.Status string` in switch cases without casting.
- A comment in `rundata/writer.go` flags that these must stay in sync with `internal/agent/loop.go`.

### Known Limitations
None. All four acceptance criteria are met.

### Architecture
- **cmd layer** (`implement.go`): uses `agent.StatusImplemented` — allowed, cmd may depend on orchestration
- **orchestration layer** (`orchestrator.go`): uses `agent.StatusImplemented` — allowed, orchestration may depend on agent (same layer)
- **domain layer** (`rundata/writer.go`): adds string constants — no new dependencies introduced
- **presentation layer** (`dashboard/handlers.go`): uses `rundata.OutcomeStatus*` — allowed, presentation may depend on domain

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)