### PR TITLE
feat: unify verdict prefix to AGENT_RESULT= across all agents

### DIFF
--- a/internal/agent/checks_test.go
+++ b/internal/agent/checks_test.go
@@ -324,8 +324,8 @@ func TestProcessIssue_WaitForChecks_AllPass(t *testing.T) {
 	// Agent outputs: implementer, quality(APPROVED), reviewer(APPROVED)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -363,8 +363,8 @@ func TestProcessIssue_WaitForChecks_Nil(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -406,8 +406,8 @@ func TestProcessIssue_WaitForChecks_Timeout(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -457,8 +457,8 @@ func TestProcessIssue_WaitForChecks_FixSucceeds(t *testing.T) {
 	// Agent outputs: implementer, quality(APPROVED), reviewer(APPROVED), verify-fix agent
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 		"verify-fix output", // CI fix agent
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
@@ -518,8 +518,8 @@ func TestProcessIssue_WaitForChecks_FixExhausted(t *testing.T) {
 	// Agent outputs: implementer, quality(APPROVED), reviewer(APPROVED), one verify-fix attempt
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 		"verify-fix output",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
@@ -571,8 +571,8 @@ func TestProcessIssue_WaitForChecks_NoVerifyFix(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {

--- a/internal/agent/guardrails.go
+++ b/internal/agent/guardrails.go
@@ -113,10 +113,10 @@ func ClosePR(repo string, prNum int, reason string) error {
 	return nil
 }
 
-// ParseReviewResult scans the agent stdout for a REVIEW_RESULT line and
+// ParseReviewResult scans the agent stdout for an AGENT_RESULT line and
 // returns "APPROVED", "CHANGES_REQUESTED", or "" if not found.
 func ParseReviewResult(stdout string) string {
-	return ParseVerdict(stdout, "REVIEW")
+	return ParseVerdict(stdout, "AGENT")
 }
 
 // HasScenarioSpec returns true if any .md file in scenarioDir (including

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -125,8 +125,8 @@ func TestProcessIssue_ImplementedOnFirstApproval(t *testing.T) {
 	// Agent outputs: 1=implementer, 2=quality_reviewer(APPROVED), 3=reviewer(APPROVED)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -162,10 +162,10 @@ func TestProcessIssue_RetriesOnChangesRequested(t *testing.T) {
 	callIdx := 0
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -201,10 +201,10 @@ func TestProcessIssue_NeedsHumanReviewAfterMaxRetries(t *testing.T) {
 	// Agent outputs: implementer, quality(APPROVED), reviewer(CHANGES), retry, reviewer(CHANGES)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -283,8 +283,8 @@ func TestProcessIssue_RechecksProtectedDriftAfterRetry(t *testing.T) {
 	driftCheckCount := 0
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
@@ -322,8 +322,8 @@ func TestProcessIssue_MergeOnApproval(t *testing.T) {
 	var mergedCalled bool
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -414,7 +414,7 @@ func TestProcessIssue_SkipsSpecGenWhenNoPrompt(t *testing.T) {
 	agentCallCount := 0
 	setupLoopTest(t, []string{
 		"implementer output",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -441,9 +441,9 @@ func TestProcessIssue_SkipsSpecGenWhenNoPrompt(t *testing.T) {
 		case 1:
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2:
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default:
-			return []byte(wrapRunnerJSON("reviewer output\nREVIEW_RESULT=APPROVED\n")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("reviewer output\nAGENT_RESULT=APPROVED\n")), []byte(""), 0, nil
 		}
 	}
 
@@ -496,9 +496,9 @@ func TestProcessIssue_PassesSessionIDToFirstRetry(t *testing.T) {
 			out := `{"session_id":"sess-impl-001","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 2: // quality reviewer — approve
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		case 3: // reviewer — requests changes
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 4: // first retry — capture env
 			retryEnv = make(map[string]string, len(env))
 			for k, v := range env {
@@ -507,7 +507,7 @@ func TestProcessIssue_PassesSessionIDToFirstRetry(t *testing.T) {
 			out := `{"session_id":"sess-retry-002","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		default: // reviewer after retry — approve
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -543,14 +543,14 @@ func TestProcessIssue_UpdatesSessionIDFromRetryResult(t *testing.T) {
 			out := `{"session_id":"sess-impl","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 2: // quality reviewer — approve
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		case 3: // reviewer — changes requested
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 4: // first retry — returns its own session ID
 			out := `{"session_id":"sess-retry-1","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 5: // reviewer — changes requested again
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 6: // second retry — capture env
 			secondRetryEnv = make(map[string]string, len(env))
 			for k, v := range env {
@@ -559,7 +559,7 @@ func TestProcessIssue_UpdatesSessionIDFromRetryResult(t *testing.T) {
 			out := `{"session_id":"sess-retry-2","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		default: // reviewer after second retry — approve
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -592,14 +592,14 @@ func TestProcessIssue_ReviewerHasNoSessionID(t *testing.T) {
 			out := `{"session_id":"sess-impl-001","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 2: // quality reviewer — approve
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // reviewer calls — capture env
 			captured := make(map[string]string, len(env))
 			for k, v := range env {
 				captured[k] = v
 			}
 			reviewerEnvs = append(reviewerEnvs, captured)
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -619,10 +619,10 @@ func TestProcessIssue_QualityReviewChangesRequestedTriggersRetry(t *testing.T) {
 	// Agent outputs: implementer, quality(CHANGES), retry, quality(APPROVED), reviewer(APPROVED)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -676,16 +676,16 @@ func TestProcessIssue_PassesCycleToQualityReview(t *testing.T) {
 			if env["GODARK_ROLE"] == "quality_reviewer" {
 				qualityPrompts = append(qualityPrompts, env["GODARK_PROMPT"])
 			}
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 3: // retry
 			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
 		case 4: // quality review cycle=1 (should have directive)
 			if env["GODARK_ROLE"] == "quality_reviewer" {
 				qualityPrompts = append(qualityPrompts, env["GODARK_PROMPT"])
 			}
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -714,8 +714,8 @@ func TestProcessIssue_AutoMergeNone_SkipsMergeOnApproval(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -755,8 +755,8 @@ func TestProcessIssue_AutoMergeNone_OutcomeStatus(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -775,8 +775,8 @@ func TestProcessIssue_AutoMergeEmpty_SkipsMerge(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -814,8 +814,8 @@ func TestProcessIssue_AutoMergeAll_Merges(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -869,9 +869,9 @@ func TestProcessIssue_AutoMergeNone_QualityReviewStillRuns(t *testing.T) {
 			if env["GODARK_ROLE"] != "quality_reviewer" {
 				return []byte(wrapRunnerJSON("unexpected role: " + env["GODARK_ROLE"])), []byte(""), 0, nil
 			}
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -912,7 +912,7 @@ func TestProcessIssue_SkipsQualityReviewWhenNoPrompt(t *testing.T) {
 		case 1:
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		default:
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -994,8 +994,8 @@ func TestProcessIssue_HookCalledOnImplement(t *testing.T) {
 	hook := &testRunDataHook{}
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
@@ -1009,8 +1009,8 @@ func TestProcessIssue_HookCalledOnReview(t *testing.T) {
 	hook := &testRunDataHook{}
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
@@ -1041,8 +1041,8 @@ func TestProcessIssue_HookCalledOnOutcome(t *testing.T) {
 	hook := &testRunDataHook{}
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
@@ -1105,8 +1105,8 @@ func TestProcessIssue_HookOutcomeIncludesError(t *testing.T) {
 func TestProcessIssue_NilHookSafe(t *testing.T) {
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	// Should not panic with nil hook.
@@ -1120,8 +1120,8 @@ func TestProcessIssue_HookWritesImplementingAndInReviewStatuses(t *testing.T) {
 	hook := &testRunDataHook{}
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
@@ -1161,8 +1161,8 @@ func TestProcessIssue_HookCalledOnSpecGeneratorSuccess(t *testing.T) {
 	setupLoopTest(t, []string{
 		"spec gen output",
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPromptsWithSpecGen(t), nil, testLogger(t), hook)
@@ -1191,7 +1191,7 @@ func TestProcessIssue_HookCalledOnSpecGeneratorError(t *testing.T) {
 			return nil, nil, 0, fmt.Errorf("spec gen failed")
 		}
 		// Subsequent calls: implementer, quality reviewer, reviewer
-		outputs := []string{"implementer output", "QUALITY_RESULT=APPROVED", "REVIEW_RESULT=APPROVED"}
+		outputs := []string{"implementer output", "AGENT_RESULT=APPROVED", "AGENT_RESULT=APPROVED"}
 		idx := callIdx - 2
 		if idx < len(outputs) {
 			return []byte(wrapRunnerJSON(outputs[idx])), []byte(""), 0, nil
@@ -1227,7 +1227,7 @@ func TestProcessIssue_HookCalledOnSpecGeneratorTimeout(t *testing.T) {
 			cancel()
 			return []byte(""), []byte(""), 0, nil
 		}
-		outputs := []string{"implementer output", "QUALITY_RESULT=APPROVED", "REVIEW_RESULT=APPROVED"}
+		outputs := []string{"implementer output", "AGENT_RESULT=APPROVED", "AGENT_RESULT=APPROVED"}
 		idx := callIdx - 2
 		if idx < len(outputs) {
 			return []byte(wrapRunnerJSON(outputs[idx])), []byte(""), 0, nil
@@ -1247,8 +1247,8 @@ func TestProcessIssue_HookCalledOnVerifyPass(t *testing.T) {
 	cfg := verifyLoopConfig(true)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -1289,8 +1289,8 @@ func TestProcessIssue_HookCalledOnVerifyFixRetries(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 		"verify-fix output",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
@@ -1444,8 +1444,8 @@ func TestProcessIssue_QualityFlagsLoggedAsWarnings(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, logger, nil)
@@ -1471,8 +1471,8 @@ func TestProcessIssue_FlagsIncludedInHookStepResult(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
@@ -1515,8 +1515,8 @@ func TestProcessIssue_QualityReviewerExemptInLoop(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
@@ -1597,7 +1597,7 @@ func TestProcessIssue_PreMergeGuardRerunsReviewer(t *testing.T) {
 
 	reviewerWithoutTests := func() []byte {
 		final := runnerFinalResult{
-			Result:    "REVIEW_RESULT=APPROVED",
+			Result:    "AGENT_RESULT=APPROVED",
 			ToolTrace: []string{"Read tests/existing_test.go", "go test ./..."},
 		}
 		b, _ := json.Marshal(final)
@@ -1606,7 +1606,7 @@ func TestProcessIssue_PreMergeGuardRerunsReviewer(t *testing.T) {
 
 	reviewerWithTests := func() []byte {
 		final := runnerFinalResult{
-			Result:    "REVIEW_RESULT=APPROVED",
+			Result:    "AGENT_RESULT=APPROVED",
 			ToolTrace: []string{"Write tests/review/my_test.go", "go test ./..."},
 		}
 		b, _ := json.Marshal(final)
@@ -1619,7 +1619,7 @@ func TestProcessIssue_PreMergeGuardRerunsReviewer(t *testing.T) {
 		case 1: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2: // quality reviewer — approve
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		case 3: // functional reviewer — approves without writing tests (guard re-runs reviewer)
 			return reviewerWithoutTests(), []byte(""), 0, nil
 		default: // second functional reviewer — approves with tests written (no implementer retry in between)
@@ -1691,9 +1691,9 @@ func TestProcessIssue_SpecGeneratedNoFetchNeeded(t *testing.T) {
 		case 2: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 3: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer — include Write to review dir
-			return []byte(wrapRunnerJSONWithTrace("REVIEW_RESULT=APPROVED", []string{"Write tests/review/test_main.go", "Bash go test ./tests/review/ -v"})), []byte(""), 0, nil
+			return []byte(wrapRunnerJSONWithTrace("AGENT_RESULT=APPROVED", []string{"Write tests/review/test_main.go", "Bash go test ./tests/review/ -v"})), []byte(""), 0, nil
 		}
 	}
 
@@ -1754,9 +1754,9 @@ func TestProcessIssue_SpecGeneratedSetsHasSpec(t *testing.T) {
 		case 2: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 3: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer — must include Write to review dir
-			return []byte(wrapRunnerJSONWithTrace("REVIEW_RESULT=APPROVED", []string{"Write tests/review/test_main.go", "Bash go test ./tests/review/ -v"})), []byte(""), 0, nil
+			return []byte(wrapRunnerJSONWithTrace("AGENT_RESULT=APPROVED", []string{"Write tests/review/test_main.go", "Bash go test ./tests/review/ -v"})), []byte(""), 0, nil
 		}
 	}
 
@@ -1799,10 +1799,10 @@ func TestProcessIssue_PreMergeGuardAllowsApprovalWithTests(t *testing.T) {
 		case 1: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2: // quality reviewer — approve
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer — approves WITH tests written
 			final := runnerFinalResult{
-				Result:    "REVIEW_RESULT=APPROVED",
+				Result:    "AGENT_RESULT=APPROVED",
 				ToolTrace: []string{"Write tests/review/my_test.go", "go test ./..."},
 			}
 			b, _ := json.Marshal(final)
@@ -1848,10 +1848,10 @@ func TestProcessIssue_FunctionalReviewOnRetry_WritesToRetryDir(t *testing.T) {
 	hook := &captureRetryFunctionalHook{}
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
@@ -1887,10 +1887,10 @@ func TestProcessIssue_FunctionalReviewExhausted_WritesToTopLevel(t *testing.T) {
 	hook := &captureRetryFunctionalHook{}
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 	}, loopGuardFn)
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), hook)
@@ -1921,8 +1921,8 @@ func TestProcessIssue_FunctionalReviewApproved_WritesToTopLevel(t *testing.T) {
 	hook := &captureRetryFunctionalHook{}
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), hook)
@@ -2164,8 +2164,8 @@ func TestNewHostRunner_UsesShC(t *testing.T) {
 func TestProcessIssue_VerifyPassedProceedsToReview(t *testing.T) {
 	stubs := setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -2196,8 +2196,8 @@ func TestProcessIssue_VerifyPassedProceedsToReview(t *testing.T) {
 func TestProcessIssue_VerifySkippedWhenNoCommands(t *testing.T) {
 	stubs := setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, loopGuardFn)
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil)
@@ -2219,8 +2219,8 @@ func TestProcessIssue_VerifyHostMode(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -2297,8 +2297,8 @@ func TestProcessIssue_VerifyBlockingFailure(t *testing.T) {
 func TestProcessIssue_VerifyNonBlockingProceedsToReview(t *testing.T) {
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -2465,9 +2465,9 @@ func TestProcessIssue_VerifyFixSucceedsOnFirstAttempt(t *testing.T) {
 			out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 3: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -2579,9 +2579,9 @@ func TestProcessIssue_VerifyFixExhaustedNonBlocking(t *testing.T) {
 			out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 3: // quality reviewer (non-blocking proceeds here)
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -2705,9 +2705,9 @@ func TestProcessIssue_VerifyFixSessionContinuity(t *testing.T) {
 			out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 3: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -2770,9 +2770,9 @@ func TestProcessIssue_VerifyFixPromptContainsErrorOutput(t *testing.T) {
 			out := `{"session_id":"sess-fix","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 3: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -2887,8 +2887,8 @@ func TestProcessIssue_VerifySandboxMode(t *testing.T) {
 	// Agent runs go through Docker in sandbox mode; stub Docker infrastructure.
 	setupSandboxDockerStubs(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	})
 
 	// git/gh commands still run on the host.
@@ -2926,8 +2926,8 @@ func TestProcessIssue_VerifyHostModeUnchangedWithNoSandbox(t *testing.T) {
 	var shCalled bool
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		if name == "sh" && len(args) > 0 && args[0] == "-c" {
 			shCalled = true
@@ -3000,7 +3000,7 @@ func TestProcessIssue_QualityRetryHasNoSessionID(t *testing.T) {
 			out := `{"session_id":"sess-impl-001","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 2: // quality reviewer — requests changes
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 3: // quality retry — capture env
 			qualityRetryEnv = make(map[string]string, len(env))
 			for k, v := range env {
@@ -3009,9 +3009,9 @@ func TestProcessIssue_QualityRetryHasNoSessionID(t *testing.T) {
 			out := `{"session_id":"sess-qual-retry","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 4: // quality reviewer — approves after retry
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer — approves
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -3047,9 +3047,9 @@ func TestProcessIssue_FunctionalRetryHasSessionID(t *testing.T) {
 			out := `{"session_id":"sess-impl-001","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 2: // quality reviewer — approves
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		case 3: // functional reviewer — requests changes
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 4: // functional retry — capture env
 			functionalRetryEnv = make(map[string]string, len(env))
 			for k, v := range env {
@@ -3058,7 +3058,7 @@ func TestProcessIssue_FunctionalRetryHasSessionID(t *testing.T) {
 			out := `{"session_id":"sess-func-retry","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		default: // functional reviewer — approves after retry
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -3097,14 +3097,14 @@ func TestProcessIssue_QualityRetrySessionIDUsedByFunctionalRetry(t *testing.T) {
 			out := `{"session_id":"sess-impl","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 2: // quality reviewer — requests changes
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 3: // quality retry — returns its own session ID
 			out := `{"session_id":"sess-qual-retry","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		case 4: // quality reviewer — approves
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		case 5: // functional reviewer — requests changes
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 6: // functional retry — capture env; should have quality retry's session ID
 			functionalRetryEnv = make(map[string]string, len(env))
 			for k, v := range env {
@@ -3113,7 +3113,7 @@ func TestProcessIssue_QualityRetrySessionIDUsedByFunctionalRetry(t *testing.T) {
 			out := `{"session_id":"sess-func-retry","result":"ok","cost_usd":0,"is_error":false}`
 			return []byte(out), []byte(""), 0, nil
 		default: // functional reviewer — approves
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -3181,8 +3181,8 @@ func TestProcessIssue_NoneModeLabelsAwaitingReview(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, standardLoopGuard())
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -3231,8 +3231,8 @@ func TestProcessIssue_LowRiskMode_HighRiskLabelsAwaitingReview(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, standardLoopGuard())
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -3284,14 +3284,14 @@ func TestProcessIssue_LowRiskMode_LowRiskMerges(t *testing.T) {
 		Runner = origRunner
 		GuardRunner = origGuard
 	})
-	reviewerOut := wrapRunnerJSONWithTrace("reviewer output\nREVIEW_RESULT=APPROVED\n", []string{"Read pr diff"})
+	reviewerOut := wrapRunnerJSONWithTrace("reviewer output\nAGENT_RESULT=APPROVED\n", []string{"Read pr diff"})
 	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		callIdx++
 		switch callIdx {
 		case 1: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer
 			return []byte(reviewerOut), []byte(""), 0, nil
 		}
@@ -3355,8 +3355,8 @@ func TestProcessIssue_LowRiskMode_ProtectedPathLabels(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, standardLoopGuard())
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -3407,14 +3407,14 @@ func TestProcessIssue_LowRiskMode_RiskAssessmentWritten(t *testing.T) {
 		Runner = origRunner
 		GuardRunner = origGuard
 	})
-	reviewerOut := wrapRunnerJSONWithTrace("reviewer output\nREVIEW_RESULT=APPROVED\n", []string{"Read pr diff"})
+	reviewerOut := wrapRunnerJSONWithTrace("reviewer output\nAGENT_RESULT=APPROVED\n", []string{"Read pr diff"})
 	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		callIdx++
 		switch callIdx {
 		case 1:
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2:
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default:
 			return []byte(reviewerOut), []byte(""), 0, nil
 		}
@@ -3455,8 +3455,8 @@ func TestProcessIssue_AllMode_IgnoresRisk(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -3495,8 +3495,8 @@ func TestProcessIssue_AllModeSkipsLifecycleLabel(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, standardLoopGuard())
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -3520,8 +3520,8 @@ func TestProcessIssue_MergeRemovesLifecycleLabels(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 	}, standardLoopGuard())
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -3563,8 +3563,8 @@ func TestProcessIssue_FunctionalEscalationLabelsAwaitingReview(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 	}, standardLoopGuard())
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -3594,7 +3594,7 @@ func TestProcessIssue_QualityEscalationLabelsAwaitingReview(t *testing.T) {
 
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 	}, standardLoopGuard())
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -3655,13 +3655,13 @@ func TestProcessIssue_VerifyRerunsAfterQualityGateRetry(t *testing.T) {
 		case 1: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2: // quality reviewer — requests changes
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 3: // retry agent
 			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
 		case 4: // quality reviewer — approves after retry+verify
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -3722,7 +3722,7 @@ func TestProcessIssue_VerifyBlockingFailsAfterQualityGateRetry(t *testing.T) {
 		case 1: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2: // quality reviewer — requests changes
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		default: // retry agent
 			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
 		}
@@ -3778,13 +3778,13 @@ func TestProcessIssue_VerifyNonBlockingContinuesAfterQualityGateRetry(t *testing
 		case 1: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2: // quality reviewer — requests changes
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
 		case 3: // retry agent
 			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
 		case 4: // quality reviewer — approves (verify non-blocking, so we get here)
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -3820,9 +3820,9 @@ func TestProcessIssue_ReconRunsBeforeImplement(t *testing.T) {
 		case 2: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 3: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -3870,9 +3870,9 @@ func TestProcessIssue_ReconOutputPassedToImplementer(t *testing.T) {
 			implementerPrompt = env["GODARK_PROMPT"]
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 3: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -3914,9 +3914,9 @@ func TestProcessIssue_ReconFailureNonBlocking(t *testing.T) {
 			implementerPrompt = env["GODARK_PROMPT"]
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 3: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -4020,9 +4020,9 @@ func TestProcessIssue_ReconSkippedWhenUnconfigured(t *testing.T) {
 		case 1: // implementer
 			return []byte(wrapRunnerJSON("implementer output")), []byte(""), 0, nil
 		case 2: // quality reviewer
-			return []byte(wrapRunnerJSON("QUALITY_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		default: // functional reviewer
-			return []byte(wrapRunnerJSON("REVIEW_RESULT=APPROVED")), []byte(""), 0, nil
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
 		}
 	}
 
@@ -4187,10 +4187,10 @@ func TestProcessIssue_ResumeOnAttempt0WithMaxResumeRetries2(t *testing.T) {
 	// Agent outputs: implementer, quality(APPROVED), reviewer(CHANGES), retry, reviewer(APPROVED)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, handoffTrackingGuard(&handoffCallCount))
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)
@@ -4214,14 +4214,14 @@ func TestProcessIssue_FreshOnAttempt2WithMaxResumeRetries2(t *testing.T) {
 	// Agent outputs: implementer, quality(APPROVED), review(CHANGES)×3, retry×3, review(APPROVED)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output 1",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output 2",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output 3",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -4265,12 +4265,12 @@ func TestProcessIssue_AllFreshWithMaxResumeRetries0(t *testing.T) {
 	// Agent outputs: implementer, quality(APPROVED), review(CHANGES)×2, retry×2, review(APPROVED)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output 1",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output 2",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, func(name string, args ...string) ([]byte, error) {
 		joined := strings.Join(args, " ")
 		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
@@ -4314,14 +4314,14 @@ func TestProcessIssue_AllResumeWithMaxResumeRetriesHigherThanMaxRetries(t *testi
 	// Agent outputs: implementer, quality(APPROVED), review(CHANGES)×3, retry×3, review(APPROVED)
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output 1",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output 2",
-		"REVIEW_RESULT=CHANGES_REQUESTED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
 		"retry output 3",
-		"REVIEW_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
 	}, handoffTrackingGuard(&handoffCalled))
 
 	outcome := ProcessIssue(context.Background(), loopIssue(), cfg, testPrompts(t), nil, testLogger(t), nil)

--- a/internal/agent/quality_reviewer.go
+++ b/internal/agent/quality_reviewer.go
@@ -70,13 +70,13 @@ func strictnessDirective(cycle, maxAttempts int, decay bool) string {
 		return ""
 	}
 	if cycle == maxAttempts-1 {
-		return "STRICTNESS OVERRIDE: This is the final quality review cycle. Only block on security vulnerabilities or data-safety issues. All other observations should be noted as comments but must NOT result in CHANGES_REQUESTED. Only print QUALITY_RESULT=CHANGES_REQUESTED if you find a genuine security vulnerability."
+		return "STRICTNESS OVERRIDE: This is the final quality review cycle. Only block on security vulnerabilities or data-safety issues. All other observations should be noted as comments but must NOT result in CHANGES_REQUESTED. Only print AGENT_RESULT=CHANGES_REQUESTED if you find a genuine security vulnerability."
 	}
-	return fmt.Sprintf("STRICTNESS OVERRIDE: This is quality review retry %d. Narrow your focus to security vulnerabilities and correctness issues only. Do not block on style, naming, minor performance, or code craft observations. Only print QUALITY_RESULT=CHANGES_REQUESTED for security or correctness defects.", cycle+1)
+	return fmt.Sprintf("STRICTNESS OVERRIDE: This is quality review retry %d. Narrow your focus to security vulnerabilities and correctness issues only. Do not block on style, naming, minor performance, or code craft observations. Only print AGENT_RESULT=CHANGES_REQUESTED for security or correctness defects.", cycle+1)
 }
 
-// ParseQualityResult scans agent output for a QUALITY_RESULT line and
+// ParseQualityResult scans agent output for an AGENT_RESULT line and
 // returns "APPROVED", "CHANGES_REQUESTED", or "" if not found.
 func ParseQualityResult(stdout string) string {
-	return ParseVerdict(stdout, "QUALITY")
+	return ParseVerdict(stdout, "AGENT")
 }

--- a/internal/agent/quality_reviewer_test.go
+++ b/internal/agent/quality_reviewer_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestQualityReview_ReturnsVerdict(t *testing.T) {
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
-		out := `{"session_id":"","result":"output\nQUALITY_RESULT=APPROVED\nmore output","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"output\nAGENT_RESULT=APPROVED\nmore output","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -25,7 +25,7 @@ func TestQualityReview_ReturnsVerdict(t *testing.T) {
 
 func TestQualityReview_ChangesRequested(t *testing.T) {
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
-		out := `{"session_id":"","result":"QUALITY_RESULT=CHANGES_REQUESTED\n","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=CHANGES_REQUESTED\n","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -42,7 +42,7 @@ func TestQualityReview_SetsQualityReviewerRole(t *testing.T) {
 	var capturedEnv map[string]string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedEnv = env
-		return []byte("QUALITY_RESULT=APPROVED\n"), []byte(""), 0, nil
+		return []byte("AGENT_RESULT=APPROVED\n"), []byte(""), 0, nil
 	})
 
 	_, err := QualityReview(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t), 0)
@@ -140,7 +140,7 @@ func TestQualityReview_Cycle0NoDirectiveInPrompt(t *testing.T) {
 	var capturedPrompt string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedPrompt = env["GODARK_PROMPT"]
-		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=APPROVED","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -159,7 +159,7 @@ func TestQualityReview_Cycle1NarrowsScope(t *testing.T) {
 	var capturedPrompt string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedPrompt = env["GODARK_PROMPT"]
-		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=APPROVED","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -178,7 +178,7 @@ func TestQualityReview_FinalCycleSecurityOnly(t *testing.T) {
 	var capturedPrompt string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedPrompt = env["GODARK_PROMPT"]
-		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=APPROVED","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -200,7 +200,7 @@ func TestQualityReview_SingleAttemptNoDirective(t *testing.T) {
 	var capturedPrompt string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedPrompt = env["GODARK_PROMPT"]
-		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=APPROVED","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -219,7 +219,7 @@ func TestQualityReview_DecayDisabledNoDirective(t *testing.T) {
 	var capturedPrompt string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedPrompt = env["GODARK_PROMPT"]
-		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=APPROVED","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -240,7 +240,7 @@ func TestQualityReview_DirectiveAppendedNotReplaced(t *testing.T) {
 	var capturedPrompt string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedPrompt = env["GODARK_PROMPT"]
-		out := `{"session_id":"","result":"QUALITY_RESULT=APPROVED","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=APPROVED","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 

--- a/internal/agent/rebase_test.go
+++ b/internal/agent/rebase_test.go
@@ -356,8 +356,8 @@ func TestProcessIssue_PreMergeRebase_LabelsNeedsHumanReview(t *testing.T) {
 	// Agent calls: implementer, quality_reviewer (APPROVED), reviewer (APPROVED), conflict fix
 	setupLoopTest(t, []string{
 		"implementer output",
-		"QUALITY_RESULT=APPROVED",
-		"reviewer output\nREVIEW_RESULT=APPROVED\n",
+		"AGENT_RESULT=APPROVED",
+		"reviewer output\nAGENT_RESULT=APPROVED\n",
 		"conflict fix output",
 	}, standardLoopGuard())
 

--- a/internal/agent/reviewer_test.go
+++ b/internal/agent/reviewer_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestReview_ReturnsVerdict(t *testing.T) {
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
-		out := `{"session_id":"","result":"output\nREVIEW_RESULT=APPROVED\nmore output","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"output\nAGENT_RESULT=APPROVED\nmore output","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -22,7 +22,7 @@ func TestReview_ReturnsVerdict(t *testing.T) {
 
 func TestReview_ChangesRequested(t *testing.T) {
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
-		out := `{"session_id":"","result":"REVIEW_RESULT=CHANGES_REQUESTED\n","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=CHANGES_REQUESTED\n","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 
@@ -39,7 +39,7 @@ func TestReview_SetsReviewerRole(t *testing.T) {
 	var capturedEnv map[string]string
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		capturedEnv = env
-		return []byte("REVIEW_RESULT=APPROVED\n"), []byte(""), 0, nil
+		return []byte("AGENT_RESULT=APPROVED\n"), []byte(""), 0, nil
 	})
 
 	_, err := Review(context.Background(), testIssue(), 10, testConfig(), testPrompts(t), nil, testLogger(t), false)
@@ -85,7 +85,7 @@ func TestReview_StructuredVerdictChangesRequested(t *testing.T) {
 func TestReview_NoStructuredVerdict_FallsBackToStdout(t *testing.T) {
 	stubRunnerFunc(t, func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
 		// No verdict field in JSON; result text contains the sentinel.
-		out := `{"session_id":"","result":"REVIEW_RESULT=APPROVED\n","cost_usd":0,"is_error":false}`
+		out := `{"session_id":"","result":"AGENT_RESULT=APPROVED\n","cost_usd":0,"is_error":false}`
 		return []byte(out), []byte(""), 0, nil
 	})
 

--- a/internal/agent/verdict_test.go
+++ b/internal/agent/verdict_test.go
@@ -5,7 +5,7 @@ import "testing"
 // --- ParseReviewResult verdict tests ---
 
 func TestParseReviewResult_Approved(t *testing.T) {
-	stdout := "some output\nREVIEW_RESULT=APPROVED\nmore output"
+	stdout := "some output\nAGENT_RESULT=APPROVED\nmore output"
 	got := ParseReviewResult(stdout)
 	if got != "APPROVED" {
 		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
@@ -13,7 +13,7 @@ func TestParseReviewResult_Approved(t *testing.T) {
 }
 
 func TestParseReviewResult_ChangesRequested(t *testing.T) {
-	stdout := "output\nREVIEW_RESULT=CHANGES_REQUESTED\n"
+	stdout := "output\nAGENT_RESULT=CHANGES_REQUESTED\n"
 	got := ParseReviewResult(stdout)
 	if got != "CHANGES_REQUESTED" {
 		t.Errorf("ParseReviewResult() = %q, want %q", got, "CHANGES_REQUESTED")
@@ -29,7 +29,7 @@ func TestParseReviewResult_NotFound(t *testing.T) {
 }
 
 func TestParseReviewResult_FirstMatchWins(t *testing.T) {
-	stdout := "REVIEW_RESULT=APPROVED\nREVIEW_RESULT=CHANGES_REQUESTED\n"
+	stdout := "AGENT_RESULT=APPROVED\nAGENT_RESULT=CHANGES_REQUESTED\n"
 	got := ParseReviewResult(stdout)
 	if got != "APPROVED" {
 		t.Errorf("ParseReviewResult() = %q, want %q (first match should win)", got, "APPROVED")
@@ -37,7 +37,7 @@ func TestParseReviewResult_FirstMatchWins(t *testing.T) {
 }
 
 func TestParseReviewResult_WhitespaceHandling(t *testing.T) {
-	stdout := "  REVIEW_RESULT=APPROVED  \n"
+	stdout := "  AGENT_RESULT=APPROVED  \n"
 	got := ParseReviewResult(stdout)
 	if got != "APPROVED" {
 		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
@@ -45,7 +45,7 @@ func TestParseReviewResult_WhitespaceHandling(t *testing.T) {
 }
 
 func TestParseReviewResult_ColonFormat(t *testing.T) {
-	stdout := "REVIEW RESULT: APPROVED\n"
+	stdout := "AGENT RESULT: APPROVED\n"
 	got := ParseReviewResult(stdout)
 	if got != "APPROVED" {
 		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
@@ -53,7 +53,7 @@ func TestParseReviewResult_ColonFormat(t *testing.T) {
 }
 
 func TestParseReviewResult_ColonFormatChanges(t *testing.T) {
-	stdout := "REVIEW RESULT: CHANGES_REQUESTED\n"
+	stdout := "AGENT RESULT: CHANGES_REQUESTED\n"
 	got := ParseReviewResult(stdout)
 	if got != "CHANGES_REQUESTED" {
 		t.Errorf("ParseReviewResult() = %q, want %q", got, "CHANGES_REQUESTED")
@@ -61,24 +61,32 @@ func TestParseReviewResult_ColonFormatChanges(t *testing.T) {
 }
 
 func TestParseReviewResult_CaseInsensitive(t *testing.T) {
-	stdout := "Review Result: Approved\n"
+	stdout := "Agent Result: Approved\n"
 	got := ParseReviewResult(stdout)
 	if got != "APPROVED" {
 		t.Errorf("ParseReviewResult() = %q, want %q", got, "APPROVED")
 	}
 }
 
+func TestParseReviewResult_OldFormatNotMatched(t *testing.T) {
+	stdout := "REVIEW_RESULT=APPROVED\n"
+	got := ParseReviewResult(stdout)
+	if got != "" {
+		t.Errorf("ParseReviewResult() = %q, want %q (old REVIEW_RESULT format must not match)", got, "")
+	}
+}
+
 // --- ParseQualityResult verdict tests ---
 
 func TestParseQualityResult_Approved(t *testing.T) {
-	got := ParseQualityResult("some output\nQUALITY_RESULT=APPROVED\nmore output")
+	got := ParseQualityResult("some output\nAGENT_RESULT=APPROVED\nmore output")
 	if got != "APPROVED" {
 		t.Errorf("ParseQualityResult() = %q, want %q", got, "APPROVED")
 	}
 }
 
 func TestParseQualityResult_ChangesRequested(t *testing.T) {
-	got := ParseQualityResult("QUALITY_RESULT=CHANGES_REQUESTED\n")
+	got := ParseQualityResult("AGENT_RESULT=CHANGES_REQUESTED\n")
 	if got != "CHANGES_REQUESTED" {
 		t.Errorf("ParseQualityResult() = %q, want %q", got, "CHANGES_REQUESTED")
 	}
@@ -88,5 +96,12 @@ func TestParseQualityResult_NoMatch(t *testing.T) {
 	got := ParseQualityResult("no sentinel here")
 	if got != "" {
 		t.Errorf("ParseQualityResult() = %q, want %q", got, "")
+	}
+}
+
+func TestParseQualityResult_OldFormatNotMatched(t *testing.T) {
+	got := ParseQualityResult("QUALITY_RESULT=APPROVED\n")
+	if got != "" {
+		t.Errorf("ParseQualityResult() = %q, want %q (old QUALITY_RESULT format must not match)", got, "")
 	}
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -631,10 +631,8 @@ func stepToView(name string, step rundata.StepResult) TimelineStepView {
 	verdictClass := "neutral"
 	markerClass := "neutral"
 
-	approved := strings.Contains(step.Output, "QUALITY_RESULT=APPROVED") ||
-		strings.Contains(step.Output, "REVIEW_RESULT=APPROVED")
-	changesRequested := strings.Contains(step.Output, "QUALITY_RESULT=CHANGES_REQUESTED") ||
-		strings.Contains(step.Output, "REVIEW_RESULT=CHANGES_REQUESTED")
+	approved := strings.Contains(step.Output, "AGENT_RESULT=APPROVED")
+	changesRequested := strings.Contains(step.Output, "AGENT_RESULT=CHANGES_REQUESTED")
 
 	switch {
 	case step.Error != "":

--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -786,7 +786,7 @@ func TestServer_IssueDetail_ToolTraceSection(t *testing.T) {
 		rundata.Outcome{IssueNumber: 6, Status: "implemented"})
 	writeJSON(t, filepath.Join(issueDir, "functional-review.json"),
 		rundata.StepResult{
-			Output:          "REVIEW_RESULT=APPROVED",
+			Output:          "AGENT_RESULT=APPROVED",
 			ToolTrace:       []string{"Read src/main.go", "Write tests/review/test_main.go", "go test ./..."},
 			DurationSeconds: 15,
 		})
@@ -848,13 +848,13 @@ func TestServer_IssueDetail_RetryFunctionalReviewInTimeline(t *testing.T) {
 		t.Fatalf("creating retry dir: %v", err)
 	}
 	writeJSON(t, filepath.Join(retryDir, "functional-review.json"),
-		rundata.StepResult{Output: "REVIEW_RESULT=CHANGES_REQUESTED", DurationSeconds: 8})
+		rundata.StepResult{Output: "AGENT_RESULT=CHANGES_REQUESTED", DurationSeconds: 8})
 	writeJSON(t, filepath.Join(retryDir, "retry.json"),
 		rundata.StepResult{Output: "retry output", DurationSeconds: 25})
 
 	// Final functional review (APPROVED)
 	writeJSON(t, filepath.Join(issueDir, "functional-review.json"),
-		rundata.StepResult{Output: "REVIEW_RESULT=APPROVED", DurationSeconds: 7})
+		rundata.StepResult{Output: "AGENT_RESULT=APPROVED", DurationSeconds: 7})
 
 	srv := newServer(t, tmpDir)
 	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/15", nil)
@@ -874,9 +874,9 @@ func TestServer_IssueDetail_RetryFunctionalReviewInTimeline(t *testing.T) {
 	}
 
 	// The pre-retry functional review (Changes Requested) should appear before Retry 1.
-	idxFR := strings.Index(body, "REVIEW_RESULT=CHANGES_REQUESTED")
+	idxFR := strings.Index(body, "AGENT_RESULT=CHANGES_REQUESTED")
 	idxRetry := strings.Index(body, "retry output")
-	idxFinal := strings.Index(body, "REVIEW_RESULT=APPROVED")
+	idxFinal := strings.Index(body, "AGENT_RESULT=APPROVED")
 
 	if idxFR < 0 {
 		t.Error("body missing pre-retry functional review output")

--- a/internal/dashboard/handlers_review_chain_test.go
+++ b/internal/dashboard/handlers_review_chain_test.go
@@ -37,7 +37,7 @@ func TestServer_ReviewChain_WithReconStep(t *testing.T) {
 		rundata.Outcome{IssueNumber: 8, Status: "implemented", PRNumber: 42},
 		rundata.StepResult{Output: "impl done", DurationSeconds: 60},
 		rundata.StepResult{},
-		rundata.StepResult{Output: "review done REVIEW_RESULT=APPROVED", DurationSeconds: 15},
+		rundata.StepResult{Output: "review done AGENT_RESULT=APPROVED", DurationSeconds: 15},
 	)
 	issueDir := filepath.Join(runDir, "issues", "8")
 	writeReconFile(t, issueDir, rundata.StepResult{
@@ -78,7 +78,7 @@ func TestServer_ReviewChain_WithoutReconStep(t *testing.T) {
 
 	writeIssueFiles(t, runDir, 9,
 		rundata.Outcome{IssueNumber: 9, Status: "implemented"},
-		rundata.StepResult{Output: "impl done REVIEW_RESULT=APPROVED", DurationSeconds: 30},
+		rundata.StepResult{Output: "impl done AGENT_RESULT=APPROVED", DurationSeconds: 30},
 		rundata.StepResult{},
 		rundata.StepResult{},
 	)
@@ -116,9 +116,9 @@ func TestServer_ReviewChain_WithSteps(t *testing.T) {
 
 	writeIssueFiles(t, runDir, 5,
 		rundata.Outcome{IssueNumber: 5, Status: "implemented", PRNumber: 99},
-		rundata.StepResult{Output: "impl trace QUALITY_RESULT=APPROVED", DurationSeconds: 45},
-		rundata.StepResult{Output: "quality trace QUALITY_RESULT=APPROVED", DurationSeconds: 12},
-		rundata.StepResult{Output: "functional trace REVIEW_RESULT=APPROVED", DurationSeconds: 8},
+		rundata.StepResult{Output: "impl trace AGENT_RESULT=APPROVED", DurationSeconds: 45},
+		rundata.StepResult{Output: "quality trace AGENT_RESULT=APPROVED", DurationSeconds: 12},
+		rundata.StepResult{Output: "functional trace AGENT_RESULT=APPROVED", DurationSeconds: 8},
 	)
 
 	srv := newServer(t, tmpDir)

--- a/prompts/quality_reviewer.txt
+++ b/prompts/quality_reviewer.txt
@@ -65,8 +65,8 @@ violates (security, performance, idiom, or code craft).
 After posting the comment, print your verdict.
 
 CRITICAL: You MUST print exactly one of these lines:
-  QUALITY_RESULT=APPROVED
-  QUALITY_RESULT=CHANGES_REQUESTED
+  AGENT_RESULT=APPROVED
+  AGENT_RESULT=CHANGES_REQUESTED
 {{if .StrictnessDirective}}
 {{.StrictnessDirective}}
 {{end}}

--- a/prompts/reviewer.txt
+++ b/prompts/reviewer.txt
@@ -52,9 +52,9 @@ criteria check, architecture compliance) to your output — even if you also pos
 a PR comment. This analysis is captured for operational review in the run dashboard.
 
 - If ALL tests pass and the implementation meets acceptance criteria:
-  Delete the {{.ReviewDir}} directory, approve the PR, and print REVIEW_RESULT=APPROVED
+  Delete the {{.ReviewDir}} directory, approve the PR, and print AGENT_RESULT=APPROVED
 - If ANY tests fail or acceptance criteria are not met:
-  Delete the {{.ReviewDir}} directory, request changes on the PR with specific feedback, and print REVIEW_RESULT=CHANGES_REQUESTED
+  Delete the {{.ReviewDir}} directory, request changes on the PR with specific feedback, and print AGENT_RESULT=CHANGES_REQUESTED
 
 ALWAYS post a PR comment with the following format, regardless of your verdict.
 This comment is required for the dialogue trail visible in the run dashboard.
@@ -87,5 +87,5 @@ scenario it violates.
 After posting the comment, print your verdict.
 
 CRITICAL: You MUST print exactly one of these lines:
-  REVIEW_RESULT=APPROVED
-  REVIEW_RESULT=CHANGES_REQUESTED
+  AGENT_RESULT=APPROVED
+  AGENT_RESULT=CHANGES_REQUESTED


### PR DESCRIPTION
Closes #405

## Implementation Notes

### Approach
Replaced the divergent `REVIEW_RESULT=` and `QUALITY_RESULT=` sentinel prefixes with a single `AGENT_RESULT=` prefix throughout the codebase. Both `ParseReviewResult` and `ParseQualityResult` now delegate to `ParseVerdict(stdout, "AGENT")`. The dashboard's `stepToView` scanner was also updated (a silent regression fix not called out in the issue but clearly required for consistency).

### Key Decisions
- **`strictnessDirective` text updated**: The mid/final-cycle strictness override strings in `quality_reviewer.go` embed the sentinel directly in AI-facing prompt text. These were updated to `AGENT_RESULT=CHANGES_REQUESTED` so agents operating under strictness decay continue to produce parseable verdicts.
- **Dashboard `handlers.go` updated**: `stepToView` was doing its own raw-string scan of step output using the old prefixes. Not mentioned in the issue but necessary to avoid a silent regression where reviewer/quality steps stop showing "Passed"/"Changes Requested" in the run dashboard.
- **Negative-case tests added**: Two new tests (`TestParseReviewResult_OldFormatNotMatched`, `TestParseQualityResult_OldFormatNotMatched`) verify the clean break — old prefix strings no longer produce a verdict.
- **Colon-format tests updated**: `REVIEW RESULT: APPROVED` → `AGENT RESULT: APPROVED` and similarly for `CHANGES_REQUESTED`, since `ParseVerdict` requires the keyword to match.

### Known Limitations
None. All tests pass (`go test ./internal/agent/... ./internal/dashboard/...`).

### Architecture
- `prompts/` — `content` layer (no dependencies)
- `internal/agent/guardrails.go`, `quality_reviewer.go` — `orchestration` layer; `ParseVerdict` is in the same package, no cross-layer import
- `internal/dashboard/handlers.go` — `presentation` layer; change is to a raw string literal scan, no new imports