### PR TITLE
refactor: extract shouldHandoff helper (closes #406)

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -263,7 +263,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 				)
 
 				var qualityHandoff string
-				if qAttempt >= cfg.MaxResumeRetries {
+				if shouldHandoff(qAttempt, cfg.MaxResumeRetries) {
 					qualityHandoff = assembleHandoffContext(cfg.Repo, prNum, logger)
 				}
 
@@ -597,7 +597,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			)
 
 			var handoff string
-			if attempt >= cfg.MaxResumeRetries {
+			if shouldHandoff(attempt, cfg.MaxResumeRetries) {
 				handoff = assembleHandoffContext(cfg.Repo, prNum, logger)
 			}
 
@@ -914,6 +914,13 @@ func checkDriftAndClose(baseSHA string, cfg *config.Config, prNum int, logger *s
 		logger.Warn("failed to close PR", "error", closeErr)
 	}
 	return fmt.Errorf("protected path drift: %v", touched)
+}
+
+// shouldHandoff returns true when the current attempt count has reached or
+// exceeded the maximum number of resume retries, indicating the agent should
+// include full handoff context for the next run.
+func shouldHandoff(attempt int, maxResumeRetries int) bool {
+	return attempt >= maxResumeRetries
 }
 
 // topologicalSortModules returns module names sorted in dependency order

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -360,6 +360,27 @@ func TestProcessIssue_MergeOnApproval(t *testing.T) {
 	}
 }
 
+func TestShouldHandoff(t *testing.T) {
+	tests := []struct {
+		name             string
+		attempt          int
+		maxResumeRetries int
+		want             bool
+	}{
+		{"at threshold returns true", 2, 2, true},
+		{"below threshold returns false", 1, 2, false},
+		{"zero threshold returns true", 0, 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldHandoff(tc.attempt, tc.maxResumeRetries)
+			if got != tc.want {
+				t.Errorf("shouldHandoff(%d, %d) = %v, want %v", tc.attempt, tc.maxResumeRetries, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCheckDriftAndClose_NoDrift(t *testing.T) {
 	stubGuardRunner(t, func(name string, args ...string) ([]byte, error) {
 		return []byte("src/main.go\n"), nil


### PR DESCRIPTION
## Summary

- Add unexported `shouldHandoff(attempt, maxResumeRetries int) bool` to `internal/agent/loop.go`
- Replace the 2 inline `attempt >= cfg.MaxResumeRetries` checks (quality-retry loop and functional-retry loop) with `shouldHandoff(...)` calls
- Add `TestShouldHandoff` table-driven test covering the three acceptance-criteria cases

## Test plan

- [x] `TestShouldHandoff/at_threshold_returns_true`: `shouldHandoff(2, 2)` → true
- [x] `TestShouldHandoff/below_threshold_returns_false`: `shouldHandoff(1, 2)` → false
- [x] `TestShouldHandoff/zero_threshold_returns_true`: `shouldHandoff(0, 0)` → true
- [x] `TestCheckDriftAndClose_NoDrift` still passes
- [x] `TestCheckDriftAndClose_Drift` still passes
- [x] `TestCheckDriftAndClose_GitDiffError` still passes

## Implementation Notes

### Approach
Added `shouldHandoff` as a pure unexported helper near the bottom of `loop.go` alongside the existing `checkDriftAndClose` helper. Replaced both inline `attempt >= cfg.MaxResumeRetries` guards with `shouldHandoff(attempt, cfg.MaxResumeRetries)`. The `driftGuard` wrapper described in the issue is optional and was intentionally skipped — the existing `checkDriftAndClose` naming is already consistent across all 7 call sites and the three existing drift tests call it by name directly.

### Key Decisions
- Kept `checkDriftAndClose` unchanged (no `driftGuard` alias) to avoid unnecessary churn and to keep existing drift tests unchanged.
- Used a table-driven test for `shouldHandoff` to cover all three spec cases concisely.
- No new imports were needed.

### Known Limitations
None. All acceptance criteria are met.

### Architecture
Only `internal/agent/` (orchestration layer) was touched. `shouldHandoff` is a pure function with no dependencies beyond primitive types — no layer constraints are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #406