### PR TITLE
refactor: extract runQualityReviewCycle from ProcessIssue

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -215,103 +215,14 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 
 	// Step 4: Quality review gate (if prompt is configured).
 	if prompts.QualityReviewer != "" {
-		qualityMaxAttempts := cfg.MaxRetries + 1
-		qualityPassed := false
-		for qAttempt := 0; qAttempt < qualityMaxAttempts; qAttempt++ {
-			if ctx.Err() != nil {
-				outcome.Status = StatusFailed
-				outcome.Err = ctx.Err()
-				return outcome
-			}
-
-			qResult, err := QualityReview(ctx, issue, prNum, cfg, prompts, authEnv, logger, qAttempt)
-			if err != nil {
-				outcome.Status = StatusFailed
-				outcome.Err = fmt.Errorf("quality reviewer agent: %w", err)
-				return outcome
-			}
-			// Quality reviewer is exempt from CheckReviewTestExecution.
-			qFlags := computeReviewFlags(qResult.AgentResult, cfg, false, false)
-			qRDFlags := logAndRecordFlags(qFlags, logger, issue.Number)
-			if hook != nil {
-				qStep := ResultToStep(qResult.AgentResult)
-				qStep.Flags = qRDFlags
-				if qAttempt == 0 {
-					if err := hook.WriteReviewResult(issue.Number, "quality", qStep); err != nil {
-						logger.Warn("failed to write quality review result", "error", err)
-					}
-				} else {
-					if err := hook.WriteRetryReviewResult(issue.Number, qAttempt-1, qStep); err != nil {
-						logger.Warn("failed to write retry review result", "error", err)
-					}
-				}
-			}
-
-			switch qResult.Verdict {
-			case "APPROVED":
-				qualityPassed = true
-			case "CHANGES_REQUESTED":
-				retriesLeft := qualityMaxAttempts - qAttempt - 1
-				if retriesLeft <= 0 {
-					break // exit loop, will label needs-human-review
-				}
-
-				logger.Info("quality review requested changes, retrying implementation",
-					"issue_number", issue.Number,
-					"attempt", qAttempt+1,
-					"retries_left", retriesLeft,
-				)
-
-				var qualityHandoff string
-				if shouldHandoff(qAttempt, cfg.MaxResumeRetries) {
-					qualityHandoff = assembleHandoffContext(cfg.Repo, prNum, logger)
-				}
-
-				retryResult, err := Retry(ctx, issue, prNum, "", "", qualityHandoff, cfg, prompts, authEnv, logger)
-				if err != nil {
-					outcome.Status = StatusFailed
-					outcome.Err = fmt.Errorf("retry agent (quality): %w", err)
-					return outcome
-				}
-				if retryResult.TimedOut {
-					outcome.Status = StatusFailed
-					outcome.Err = fmt.Errorf("retry agent (quality) timed out")
-					return outcome
-				}
-				if hook != nil {
-					if err := hook.WriteRetryResult(issue.Number, qAttempt, ResultToStep(retryResult)); err != nil {
-						logger.Warn("failed to write retry result", "error", err)
-					}
-				}
-
-				sessionID = retryResult.SessionID
-
-				if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
-					outcome.Status = StatusFailed
-					outcome.Err = driftErr
-					return outcome
-				}
-
-				// Re-run verify after quality-gate retry so that changes introduced
-				// by the retry agent are caught before the next quality review cycle.
-				if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles); verifyErr != nil {
-					outcome.Status = StatusFailed
-					outcome.Err = fmt.Errorf("verify after quality-gate retry: %w", verifyErr)
-					return outcome
-				}
-
-			default:
-				outcome.Status = StatusFailed
-				outcome.Err = fmt.Errorf("quality reviewer agent did not produce a verdict")
-				return outcome
-			}
-
-			if qualityPassed {
-				break
-			}
+		passed, err := runQualityReviewCycle(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles)
+		if err != nil {
+			outcome.Status = StatusFailed
+			outcome.Err = err
+			return outcome
 		}
-
-		if !qualityPassed {
+		if !passed {
+			qualityMaxAttempts := cfg.MaxRetries + 1
 			if err := LabelPR(cfg.Repo, prNum, "needs-human-review"); err != nil {
 				logger.Warn("failed to label PR", "error", err)
 			}
@@ -921,6 +832,105 @@ func checkDriftAndClose(baseSHA string, cfg *config.Config, prNum int, logger *s
 // include full handoff context for the next run.
 func shouldHandoff(attempt int, maxResumeRetries int) bool {
 	return attempt >= maxResumeRetries
+}
+
+// runQualityReviewCycle runs the quality review loop for a single issue.
+// It calls QualityReview up to cfg.MaxRetries+1 times, invoking Retry and
+// runVerifyPhase on each CHANGES_REQUESTED verdict. Returns (true, nil) when
+// the quality reviewer approves, (false, nil) when all attempts are exhausted
+// without approval, and (false, err) on any hard failure (agent error, drift,
+// context cancellation). sessionID and fixCycles are updated in-place.
+func runQualityReviewCycle(
+	ctx context.Context,
+	issue github.Issue,
+	prNum int,
+	branch string,
+	baseSHA string,
+	cfg *config.Config,
+	prompts *Prompts,
+	authEnv map[string]string,
+	logger *slog.Logger,
+	hook RunDataHook,
+	sessionID *string,
+	fixCycles *int,
+) (bool, error) {
+	qualityMaxAttempts := cfg.MaxRetries + 1
+	for qAttempt := 0; qAttempt < qualityMaxAttempts; qAttempt++ {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+
+		qResult, err := QualityReview(ctx, issue, prNum, cfg, prompts, authEnv, logger, qAttempt)
+		if err != nil {
+			return false, fmt.Errorf("quality reviewer agent: %w", err)
+		}
+		// Quality reviewer is exempt from CheckReviewTestExecution.
+		qFlags := computeReviewFlags(qResult.AgentResult, cfg, false, false)
+		qRDFlags := logAndRecordFlags(qFlags, logger, issue.Number)
+		if hook != nil {
+			qStep := ResultToStep(qResult.AgentResult)
+			qStep.Flags = qRDFlags
+			if qAttempt == 0 {
+				if err := hook.WriteReviewResult(issue.Number, "quality", qStep); err != nil {
+					logger.Warn("failed to write quality review result", "error", err)
+				}
+			} else {
+				if err := hook.WriteRetryReviewResult(issue.Number, qAttempt-1, qStep); err != nil {
+					logger.Warn("failed to write retry review result", "error", err)
+				}
+			}
+		}
+
+		switch qResult.Verdict {
+		case "APPROVED":
+			return true, nil
+		case "CHANGES_REQUESTED":
+			retriesLeft := qualityMaxAttempts - qAttempt - 1
+			if retriesLeft <= 0 {
+				return false, nil // exhausted — caller handles labeling
+			}
+
+			logger.Info("quality review requested changes, retrying implementation",
+				"issue_number", issue.Number,
+				"attempt", qAttempt+1,
+				"retries_left", retriesLeft,
+			)
+
+			var qualityHandoff string
+			if shouldHandoff(qAttempt, cfg.MaxResumeRetries) {
+				qualityHandoff = assembleHandoffContext(cfg.Repo, prNum, logger)
+			}
+
+			retryResult, err := Retry(ctx, issue, prNum, "", "", qualityHandoff, cfg, prompts, authEnv, logger)
+			if err != nil {
+				return false, fmt.Errorf("retry agent (quality): %w", err)
+			}
+			if retryResult.TimedOut {
+				return false, fmt.Errorf("retry agent (quality) timed out")
+			}
+			if hook != nil {
+				if err := hook.WriteRetryResult(issue.Number, qAttempt, ResultToStep(retryResult)); err != nil {
+					logger.Warn("failed to write retry result", "error", err)
+				}
+			}
+
+			*sessionID = retryResult.SessionID
+
+			if driftErr := checkDriftAndClose(baseSHA, cfg, prNum, logger); driftErr != nil {
+				return false, driftErr
+			}
+
+			// Re-run verify after quality-gate retry so that changes introduced
+			// by the retry agent are caught before the next quality review cycle.
+			if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, sessionID, fixCycles); verifyErr != nil {
+				return false, fmt.Errorf("verify after quality-gate retry: %w", verifyErr)
+			}
+
+		default:
+			return false, fmt.Errorf("quality reviewer agent did not produce a verdict")
+		}
+	}
+	return false, nil
 }
 
 // topologicalSortModules returns module names sorted in dependency order

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -4459,3 +4459,229 @@ func TestHandleNonBlockingResult_NilHook(t *testing.T) {
 		t.Errorf("expected %q, got %q", "ok", result)
 	}
 }
+
+// qualityGuardFn is a minimal GuardRunner stub for runQualityReviewCycle tests.
+// It handles git rev-parse (baseSHA), git diff (drift check), gh pr view, and
+// gh pr comment without error.
+func qualityGuardFn(name string, args ...string) ([]byte, error) {
+	joined := strings.Join(args, " ")
+	if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+		return []byte("abc123\n"), nil
+	}
+	if name == "git" && strings.Contains(joined, "diff --name-only") {
+		return []byte("src/main.go\n"), nil // non-protected file → no drift
+	}
+	if name == "gh" && strings.Contains(joined, "pr view") {
+		return []byte(""), nil
+	}
+	if name == "gh" && strings.Contains(joined, "pr comment") {
+		return []byte(""), nil
+	}
+	return []byte(""), nil
+}
+
+// TestRunQualityReviewCycle_ApprovedFirstTry verifies that the cycle returns
+// (true, nil) when the quality reviewer approves on the first attempt.
+func TestRunQualityReviewCycle_ApprovedFirstTry(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = qualityGuardFn
+
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
+	}
+
+	cfg := loopConfig()
+	sessionID := "sess-init"
+	fixCycles := 0
+	passed, err := runQualityReviewCycle(
+		context.Background(),
+		loopIssue(),
+		10,
+		"issue-5-test-issue",
+		"abc123",
+		cfg,
+		testPrompts(t),
+		nil,
+		testLogger(t),
+		nil,
+		&sessionID,
+		&fixCycles,
+	)
+
+	if !passed {
+		t.Errorf("passed = false, want true")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+// TestRunQualityReviewCycle_ApprovedAfterRetry verifies that the cycle returns
+// (true, nil) after CHANGES_REQUESTED on the first attempt and APPROVED on
+// the second.
+func TestRunQualityReviewCycle_ApprovedAfterRetry(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = qualityGuardFn
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		switch callIdx {
+		case 1: // quality reviewer — requests changes
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		case 2: // retry agent
+			return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
+		default: // quality reviewer — approves
+			return []byte(wrapRunnerJSON("AGENT_RESULT=APPROVED")), []byte(""), 0, nil
+		}
+	}
+
+	cfg := loopConfig()
+	sessionID := "sess-init"
+	fixCycles := 0
+	passed, err := runQualityReviewCycle(
+		context.Background(),
+		loopIssue(),
+		10,
+		"issue-5-test-issue",
+		"abc123",
+		cfg,
+		testPrompts(t),
+		nil,
+		testLogger(t),
+		nil,
+		&sessionID,
+		&fixCycles,
+	)
+
+	if !passed {
+		t.Errorf("passed = false, want true")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+// TestRunQualityReviewCycle_ExhaustsRetries verifies that the cycle returns
+// (false, nil) when all quality review attempts are exhausted without approval.
+func TestRunQualityReviewCycle_ExhaustsRetries(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+	GuardRunner = qualityGuardFn
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		if callIdx%2 == 1 {
+			// quality reviewer — always requests changes
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		}
+		// retry agent
+		return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
+	}
+
+	cfg := loopConfig()
+	cfg.MaxRetries = 1 // qualityMaxAttempts = 2
+	sessionID := "sess-init"
+	fixCycles := 0
+	passed, err := runQualityReviewCycle(
+		context.Background(),
+		loopIssue(),
+		10,
+		"issue-5-test-issue",
+		"abc123",
+		cfg,
+		testPrompts(t),
+		nil,
+		testLogger(t),
+		nil,
+		&sessionID,
+		&fixCycles,
+	)
+
+	if passed {
+		t.Errorf("passed = true, want false")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+// TestRunQualityReviewCycle_DriftDuringQuality verifies that the cycle returns
+// (false, driftErr) when drift is detected after a quality-gate retry.
+func TestRunQualityReviewCycle_DriftDuringQuality(t *testing.T) {
+	origRunner := Runner
+	origGuard := GuardRunner
+	t.Cleanup(func() {
+		Runner = origRunner
+		GuardRunner = origGuard
+	})
+
+	callIdx := 0
+	Runner = func(ctx context.Context, env map[string]string, name string, args ...string) ([]byte, []byte, int, error) {
+		callIdx++
+		if callIdx == 1 {
+			// quality reviewer — requests changes
+			return []byte(wrapRunnerJSON("AGENT_RESULT=CHANGES_REQUESTED")), []byte(""), 0, nil
+		}
+		// retry agent
+		return []byte(wrapRunnerJSON("retry output")), []byte(""), 0, nil
+	}
+
+	GuardRunner = func(name string, args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		if name == "git" && len(args) > 0 && args[0] == "rev-parse" {
+			return []byte("abc123\n"), nil
+		}
+		if name == "git" && strings.Contains(joined, "diff --name-only") {
+			// Return a protected file to trigger drift detection.
+			return []byte("CLAUDE.md\n"), nil
+		}
+		if name == "gh" && strings.Contains(joined, "pr view") {
+			return []byte(""), nil
+		}
+		return []byte(""), nil
+	}
+
+	cfg := loopConfig()
+	sessionID := "sess-init"
+	fixCycles := 0
+	passed, err := runQualityReviewCycle(
+		context.Background(),
+		loopIssue(),
+		10,
+		"issue-5-test-issue",
+		"abc123",
+		cfg,
+		testPrompts(t),
+		nil,
+		testLogger(t),
+		nil,
+		&sessionID,
+		&fixCycles,
+	)
+
+	if passed {
+		t.Errorf("passed = true, want false")
+	}
+	if err == nil {
+		t.Errorf("err = nil, want drift error")
+	}
+	if !strings.Contains(err.Error(), "protected path drift") {
+		t.Errorf("err = %q, want to contain %q", err.Error(), "protected path drift")
+	}
+}


### PR DESCRIPTION
## Summary

- Extract the quality review loop from `ProcessIssue` into `runQualityReviewCycle`, a dedicated unexported function in `internal/agent/loop.go`
- Replace the ~111-line inline block with a compact call-site in `ProcessIssue` that maps `(bool, error)` returns to outcome status
- Add 4 unit tests for `runQualityReviewCycle` covering: approved first try, approved after retry, exhausted retries, and drift detection

## Test plan

- [x] `TestRunQualityReviewCycle_ApprovedFirstTry` — new unit test
- [x] `TestRunQualityReviewCycle_ApprovedAfterRetry` — new unit test
- [x] `TestRunQualityReviewCycle_ExhaustsRetries` — new unit test
- [x] `TestRunQualityReviewCycle_DriftDuringQuality` — new unit test
- [x] All existing `TestProcessIssue_Quality*` tests pass
- [x] `TestProcessIssue_VerifyRerunsAfterQualityGateRetry` passes
- [x] `TestProcessIssue_VerifyBlockingFailsAfterQualityGateRetry` passes
- [x] `TestProcessIssue_VerifyNonBlockingContinuesAfterQualityGateRetry` passes
- [x] Full `internal/agent` package test suite passes

## Implementation Notes

### Approach
Extracted the `for qAttempt := 0; qAttempt < qualityMaxAttempts` loop and its body verbatim into `runQualityReviewCycle`. The function returns `(true, nil)` on APPROVED, `(false, err)` on any hard failure, and `(false, nil)` when retries are exhausted.

The post-exhaustion actions (`LabelPR`, `applyLifecycleLabel`, PR comment) remain in `ProcessIssue` so the function avoids the `applyLifecycleLabel` closure dependency.

### Key Decisions

1. **Added `branch string` and `fixCycles *int` parameters** — the spec's signature omitted both, but they are required for the `runVerifyPhase` call inside the loop. Passing them in is cleaner than re-deriving branch from the issue inside the function.

2. **Exhaustion handling stays in ProcessIssue** — `applyLifecycleLabel` is a closure capturing `currentLifecycleLabel` and `prNum` from `ProcessIssue`. Rather than pass it as a function parameter, the exhausted-retries path returns `(false, nil)` and `ProcessIssue` handles labeling. This keeps the new function's signature free of closure dependencies.

3. **`shouldHandoff` used as-is** — the function was introduced by the blocker #406 and already exists in the codebase at `loop.go:833`.

### Known Limitations
None. All acceptance criteria are met.

### Architecture
Only `internal/agent/` (orchestration layer) was touched. No new imports were added; all dependencies remain within the same package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #407