### PR TITLE
feat: populate issue titles in run.json at run start

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -131,6 +131,20 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			logger.Warn("failed to create run data writer, run data will not be recorded", "error", writerErr)
 		}
 
+		// Pre-fetch issue titles and write them to run.json so the dashboard can
+		// display titles for all issues before they finish processing.
+		if writer != nil {
+			issueTitles := make(map[string]string, len(issueNums))
+			for _, num := range issueNums {
+				if iss, err := github.FetchIssue(cfg.Repo, num); err == nil {
+					issueTitles[strconv.Itoa(num)] = iss.Title
+				}
+			}
+			if err := writer.WriteIssueTitles(issueTitles); err != nil {
+				logger.Warn("failed to write issue titles to run metadata", "error", err)
+			}
+		}
+
 		// Initialize notifiers from config. Construction failures are logged but
 		// never abort the run — notifications are best-effort.
 		notifiers, notifyErr := notify.NewFromConfig(cfg.Notify)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -214,6 +215,14 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 		issueDeps := buildIssueDepsForRundata(allIssues, closedSet)
 		if err := writer.WriteIssueDeps(issueDeps); err != nil {
 			logger.Warn("failed to write issue deps to run metadata", "error", err)
+		}
+
+		issueTitles := make(map[string]string, len(allIssues))
+		for _, iss := range allIssues {
+			issueTitles[strconv.Itoa(iss.Number)] = iss.Title
+		}
+		if err := writer.WriteIssueTitles(issueTitles); err != nil {
+			logger.Warn("failed to write issue titles to run metadata", "error", err)
 		}
 	}
 

--- a/internal/rundata/reader.go
+++ b/internal/rundata/reader.go
@@ -200,7 +200,21 @@ func (r *Reader) LoadRun(owner, repo, timestamp string) (*RunDetail, error) {
 	// directory yet (e.g., still running, no hook data written).
 	for _, num := range meta.IssueNumbers {
 		if !seen[num] {
-			detail.Issues = append(detail.Issues, IssueDetail{IssueNumber: num})
+			d := IssueDetail{IssueNumber: num}
+			if title, ok := meta.IssueTitles[strconv.Itoa(num)]; ok {
+				d.Outcome.Title = title
+			}
+			detail.Issues = append(detail.Issues, d)
+		}
+	}
+
+	// Fill in Outcome.Title from IssueTitles for issues whose outcome.json
+	// either does not exist or was written without a title.
+	for i := range detail.Issues {
+		if detail.Issues[i].Outcome.Title == "" {
+			if title, ok := meta.IssueTitles[strconv.Itoa(detail.Issues[i].IssueNumber)]; ok {
+				detail.Issues[i].Outcome.Title = title
+			}
 		}
 	}
 

--- a/internal/rundata/reader_test.go
+++ b/internal/rundata/reader_test.go
@@ -1061,3 +1061,116 @@ func TestLoadRun_MissingReconJSONNoError(t *testing.T) {
 		t.Errorf("Recon should be zero value for old run data, got: %+v", recon)
 	}
 }
+
+func TestLoadRunPopulatesTitleForPlaceholderIssues(t *testing.T) {
+	base := t.TempDir()
+	makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:         "owner/repo",
+		IssueNumbers: []int{10, 20},
+		StartedAt:    time.Now().UTC(),
+		IssueTitles: map[string]string{
+			"10": "Fix authentication",
+			"20": "Add search feature",
+		},
+	})
+
+	// No issues/ directory — simulates a run in progress before any hook data.
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 2 {
+		t.Fatalf("expected 2 placeholder issues, got %d", len(detail.Issues))
+	}
+
+	issueMap := map[int]IssueDetail{}
+	for _, issue := range detail.Issues {
+		issueMap[issue.IssueNumber] = issue
+	}
+
+	if issueMap[10].Outcome.Title != "Fix authentication" {
+		t.Errorf("issue #10 title: got %q, want %q", issueMap[10].Outcome.Title, "Fix authentication")
+	}
+	if issueMap[20].Outcome.Title != "Add search feature" {
+		t.Errorf("issue #20 title: got %q, want %q", issueMap[20].Outcome.Title, "Add search feature")
+	}
+}
+
+func TestLoadRunFallsBackToIssueTitlesWhenOutcomeTitleEmpty(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:         "owner/repo",
+		IssueNumbers: []int{42},
+		StartedAt:    time.Now().UTC(),
+		IssueTitles:  map[string]string{"42": "Title from run.json"},
+	})
+
+	// Write an outcome.json with no title.
+	issueDir := filepath.Join(runDir, "issues", "42")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	if err := writeJSON(filepath.Join(issueDir, "outcome.json"), Outcome{
+		IssueNumber: 42,
+		Status:      "implemented",
+		PRNumber:    99,
+		// Title deliberately left empty.
+	}); err != nil {
+		t.Fatalf("writing outcome.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+
+	if detail.Issues[0].Outcome.Title != "Title from run.json" {
+		t.Errorf("Outcome.Title: got %q, want %q", detail.Issues[0].Outcome.Title, "Title from run.json")
+	}
+}
+
+func TestLoadRunOutcomeTitleTakesPrecedenceOverIssueTitles(t *testing.T) {
+	base := t.TempDir()
+	runDir := makeRunDir(t, base, "owner", "repo", "20260301-120000", RunMeta{
+		Repo:         "owner/repo",
+		IssueNumbers: []int{42},
+		StartedAt:    time.Now().UTC(),
+		IssueTitles:  map[string]string{"42": "Stale title from run.json"},
+	})
+
+	// Write an outcome.json with an explicit title.
+	issueDir := filepath.Join(runDir, "issues", "42")
+	if err := os.MkdirAll(issueDir, 0o755); err != nil {
+		t.Fatalf("creating issue dir: %v", err)
+	}
+	if err := writeJSON(filepath.Join(issueDir, "outcome.json"), Outcome{
+		IssueNumber: 42,
+		Title:       "Authoritative title from outcome",
+		Status:      "implemented",
+		PRNumber:    99,
+	}); err != nil {
+		t.Fatalf("writing outcome.json: %v", err)
+	}
+
+	r := newReaderWithBase(base)
+	detail, err := r.LoadRun("owner", "repo", "20260301-120000")
+	if err != nil {
+		t.Fatalf("LoadRun() error: %v", err)
+	}
+
+	if len(detail.Issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(detail.Issues))
+	}
+
+	if detail.Issues[0].Outcome.Title != "Authoritative title from outcome" {
+		t.Errorf("Outcome.Title: got %q, want %q", detail.Issues[0].Outcome.Title, "Authoritative title from outcome")
+	}
+}

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -21,15 +21,16 @@ type AutoMerge struct {
 
 // RunMeta is the structure persisted to run.json.
 type RunMeta struct {
-	Repo         string      `json:"repo"`
-	Milestone    string      `json:"milestone"`
-	BaseBranch   string      `json:"base_branch,omitempty"`
-	AutoMerge    *AutoMerge  `json:"auto_merge,omitempty"`
-	IssueNumbers []int       `json:"issue_numbers"`
-	IssueDeps    []IssueDep  `json:"issue_deps,omitempty"`
-	StartedAt    time.Time   `json:"started_at"`
-	FinishedAt   *time.Time  `json:"finished_at,omitempty"`
-	Summary      *RunSummary `json:"summary,omitempty"`
+	Repo         string            `json:"repo"`
+	Milestone    string            `json:"milestone"`
+	BaseBranch   string            `json:"base_branch,omitempty"`
+	AutoMerge    *AutoMerge        `json:"auto_merge,omitempty"`
+	IssueNumbers []int             `json:"issue_numbers"`
+	IssueDeps    []IssueDep        `json:"issue_deps,omitempty"`
+	IssueTitles  map[string]string `json:"issue_titles,omitempty"`
+	StartedAt    time.Time         `json:"started_at"`
+	FinishedAt   *time.Time        `json:"finished_at,omitempty"`
+	Summary      *RunSummary       `json:"summary,omitempty"`
 }
 
 // IssueDep records the dependency info for a single issue.
@@ -239,6 +240,28 @@ func (w *Writer) WriteIssueDeps(deps []IssueDep) error {
 	meta.IssueDeps = deps
 	if err := writeJSON(path, meta); err != nil {
 		return fmt.Errorf("updating run.json with issue deps: %w", err)
+	}
+	return nil
+}
+
+// WriteIssueTitles updates run.json with the title map for all issues.
+// It reads the current run.json, sets IssueTitles, and writes it back.
+func (w *Writer) WriteIssueTitles(titles map[string]string) error {
+	path := filepath.Join(w.dir, "run.json")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading run.json: %w", err)
+	}
+
+	var meta RunMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return fmt.Errorf("parsing run.json: %w", err)
+	}
+
+	meta.IssueTitles = titles
+	if err := writeJSON(path, meta); err != nil {
+		return fmt.Errorf("updating run.json with issue titles: %w", err)
 	}
 	return nil
 }

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -804,6 +804,112 @@ func TestWriteIssueDepsPreservesExistingRunJSONFields(t *testing.T) {
 	}
 }
 
+func TestWriteIssueTitlesUpdatesRunJSON(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{10, 20})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	titles := map[string]string{
+		"10": "Fix the login bug",
+		"20": "Add dark mode toggle",
+	}
+	if err := w.WriteIssueTitles(titles); err != nil {
+		t.Fatalf("WriteIssueTitles() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(w.Dir(), "run.json"))
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+
+	var meta RunMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("parsing run.json: %v", err)
+	}
+
+	if len(meta.IssueTitles) != 2 {
+		t.Fatalf("IssueTitles: got %d entries, want 2", len(meta.IssueTitles))
+	}
+	if meta.IssueTitles["10"] != "Fix the login bug" {
+		t.Errorf("IssueTitles[10]: got %q, want %q", meta.IssueTitles["10"], "Fix the login bug")
+	}
+	if meta.IssueTitles["20"] != "Add dark mode toggle" {
+		t.Errorf("IssueTitles[20]: got %q, want %q", meta.IssueTitles["20"], "Add dark mode toggle")
+	}
+}
+
+func TestWriteIssueTitlesPreservesExistingRunJSONFields(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{1, 2})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	titles := map[string]string{"1": "First issue", "2": "Second issue"}
+	if err := w.WriteIssueTitles(titles); err != nil {
+		t.Fatalf("WriteIssueTitles() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(w.Dir(), "run.json"))
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+
+	var meta RunMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("parsing run.json: %v", err)
+	}
+
+	if meta.Repo != "owner/repo" {
+		t.Errorf("Repo: got %q, want %q", meta.Repo, "owner/repo")
+	}
+	if meta.Milestone != "Phase 7" {
+		t.Errorf("Milestone: got %q, want %q", meta.Milestone, "Phase 7")
+	}
+	if len(meta.IssueNumbers) != 2 {
+		t.Errorf("IssueNumbers: got %v, want [1 2]", meta.IssueNumbers)
+	}
+}
+
+func TestIssueTitlesOmittedWhenNeverWritten(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{1})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	// Do not call WriteIssueTitles.
+	_ = w
+
+	data, err := os.ReadFile(filepath.Join(w.Dir(), "run.json"))
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parsing JSON: %v", err)
+	}
+	if _, ok := raw["issue_titles"]; ok {
+		t.Error("issue_titles key should be omitted from JSON when WriteIssueTitles was never called")
+	}
+}
+
+func TestIssueTitlesMissingInOldDataDeserializesCleanly(t *testing.T) {
+	// Simulate old run.json without issue_titles field.
+	oldJSON := []byte(`{"repo":"owner/repo","milestone":"Phase 7","issue_numbers":[1],"started_at":"2024-01-01T00:00:00Z"}`)
+
+	var meta RunMeta
+	if err := json.Unmarshal(oldJSON, &meta); err != nil {
+		t.Fatalf("Unmarshal() error: %v", err)
+	}
+
+	if meta.IssueTitles != nil {
+		t.Errorf("IssueTitles = %v, want nil for old data without issue_titles", meta.IssueTitles)
+	}
+}
+
 func TestPathTraversalRejected(t *testing.T) {
 	cases := []string{
 		"../evil/../../path",


### PR DESCRIPTION
## Summary

- Adds `IssueTitles map[string]string` to `RunMeta` (JSON: `issue_titles,omitempty`) so the dashboard can show issue titles for pending/blocked issues before `outcome.json` is written
- Adds `WriteIssueTitles` method to `Writer` using the same read-modify-write pattern as `WriteIssueDeps`
- Orchestrator calls `WriteIssueTitles` in `processIssues` alongside `WriteIssueDeps`, building the map from the `[]github.Issue` slice already available
- `godark implement` pre-fetches all issue titles in a loop before processing and calls `WriteIssueTitles`
- `LoadRun` populates `Outcome.Title` from `IssueTitles` for placeholder issues and as a fallback for issues whose `outcome.json` has an empty title; the outcome title always takes precedence

## Test plan

- [x] `TestWriteIssueTitlesUpdatesRunJSON` — verifies titles are persisted to run.json
- [x] `TestWriteIssueTitlesPreservesExistingRunJSONFields` — verifies Repo/Milestone/IssueNumbers unchanged after write
- [x] `TestIssueTitlesOmittedWhenNeverWritten` — verifies `issue_titles` key absent when not called
- [x] `TestIssueTitlesMissingInOldDataDeserializesCleanly` — verifies backwards compatibility with old run.json files
- [x] `TestLoadRunPopulatesTitleForPlaceholderIssues` — placeholder entries get title from IssueTitles
- [x] `TestLoadRunFallsBackToIssueTitlesWhenOutcomeTitleEmpty` — fallback fills empty outcome title
- [x] `TestLoadRunOutcomeTitleTakesPrecedenceOverIssueTitles` — outcome.json title wins over IssueTitles
- [x] All existing rundata and orchestrator tests pass

## Implementation Notes

### Approach
Added `IssueTitles map[string]string` to `RunMeta` with `omitempty`, a new `WriteIssueTitles` method following the existing `WriteIssueDeps` read-modify-write pattern, and title resolution in `LoadRun` (post-hoc, no signature change to `loadIssueDetail`).

### Key Decisions
- **Post-hoc title resolution in `LoadRun`**: Rather than threading `IssueTitles` through `loadIssueDetail`, titles are applied in a separate loop after all issues are loaded. Simpler, no signature change required.
- **Pre-fetch in `implement.go`**: Since `implement` fetches issues one at a time in the processing loop (unlike orchestrator which has them all upfront), a dedicated pre-fetch loop runs before processing to build the title map at run start.
- **Outcome title takes precedence**: The fallback only fills `Outcome.Title` when it is empty, so a title written by the agent in `outcome.json` always wins.

### Known Limitations
- The pre-fetch loop in `implement.go` adds one extra `FetchIssue` call per issue number before processing begins. Issues that fail to fetch in the pre-fetch loop are silently skipped (title just won't be in the map); the processing loop still fetches them independently and handles errors there.

### Architecture
- `internal/rundata/` — **domain** layer: `RunMeta` field and `WriteIssueTitles`/`LoadRun` changes are pure domain changes.
- `internal/orchestrator/` — **orchestration** layer: calls the new `WriteIssueTitles` method alongside the existing `WriteIssueDeps` call.
- `internal/cmd/` — **cmd** layer: calls `WriteIssueTitles` after writer creation.
- No layer constraints violated; `strconv` added to orchestrator imports (stdlib, no new external deps).

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)