### PR TITLE
feat(progress): ProgressReporter interface and TextReporter implementation

### DIFF
--- a/docs/architecture.json
+++ b/docs/architecture.json
@@ -45,7 +45,7 @@
     {
       "name": "foundation",
       "description": "Zero-dependency utilities importable by all layers. Configuration and logging.",
-      "paths": ["internal/config/", "internal/logging/", "internal/label/", "internal/mdutil/", "internal/exec/"],
+      "paths": ["internal/config/", "internal/logging/", "internal/label/", "internal/mdutil/", "internal/exec/", "internal/progress/"],
       "may_depend_on": [],
       "must_not_depend_on": ["cmd", "orchestration", "service", "domain", "infrastructure", "presentation", "content"]
     },

--- a/internal/progress/reporter.go
+++ b/internal/progress/reporter.go
@@ -1,0 +1,23 @@
+package progress
+
+// ProgressReporter receives progress events from the orchestrator.
+type ProgressReporter interface {
+	// RunStarted signals the beginning of a run with metadata.
+	RunStarted(repo, milestone, timestamp, baseBranch, mergeFeature, mergeRollup string, issueCount int)
+	// IssueStarted signals that processing has begun for an issue.
+	IssueStarted(issueNumber int, title string)
+	// IssueStageChanged signals a stage transition for an in-progress issue.
+	IssueStageChanged(issueNumber int, stage string)
+	// IssueCompleted signals the final outcome for an issue.
+	IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string)
+	// WaveStarted signals a new dependency re-resolution wave.
+	WaveStarted(wave, count int)
+	// AllBlocked signals that all issues are blocked.
+	AllBlocked(total, blocked int)
+	// RollupCreated signals rollup PR creation and optional merge.
+	RollupCreated(prNumber int, prURL string, merged bool)
+	// RunFinished signals the final summary.
+	RunFinished(implemented, readyToMerge, needsHumanReview, failed, blocked int)
+	// PunchlistText outputs a punchlist fragment as it becomes available.
+	PunchlistText(text string)
+}

--- a/internal/progress/text.go
+++ b/internal/progress/text.go
@@ -1,0 +1,83 @@
+package progress
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// TextReporter implements ProgressReporter by writing plain text to an io.Writer.
+// Its format strings match the current fmt.Printf calls in orchestrator.go exactly.
+type TextReporter struct {
+	w io.Writer
+}
+
+// NewTextReporter returns a TextReporter that writes to w.
+func NewTextReporter(w io.Writer) *TextReporter {
+	return &TextReporter{w: w}
+}
+
+// New returns a TextReporter that writes to os.Stdout.
+func New() *TextReporter {
+	return NewTextReporter(os.Stdout)
+}
+
+// RunStarted is a no-op for TextReporter; the orchestrator emits this via structured logging.
+func (r *TextReporter) RunStarted(repo, milestone, timestamp, baseBranch, mergeFeature, mergeRollup string, issueCount int) {
+}
+
+// IssueStarted is a no-op for TextReporter; the orchestrator emits this via structured logging.
+func (r *TextReporter) IssueStarted(issueNumber int, title string) {
+}
+
+// IssueStageChanged is a no-op for TextReporter; the orchestrator emits this via structured logging.
+func (r *TextReporter) IssueStageChanged(issueNumber int, stage string) {
+}
+
+// IssueCompleted writes the outcome line for an issue.
+func (r *TextReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string) {
+	switch status {
+	case "implemented":
+		fmt.Fprintf(r.w, "  #%d %s \u2014 implemented (PR #%d, %d retries)\n", issueNumber, title, prNumber, retries)
+	case "ready-to-merge":
+		fmt.Fprintf(r.w, "  #%d %s \u2014 ready-to-merge (PR #%d, %d retries)\n", issueNumber, title, prNumber, retries)
+	case "needs-human-review":
+		fmt.Fprintf(r.w, "  #%d %s \u2014 needs human review (PR #%d)\n", issueNumber, title, prNumber)
+	default:
+		fmt.Fprintf(r.w, "  #%d %s \u2014 failed: %s\n", issueNumber, title, errMsg)
+	}
+}
+
+// WaveStarted writes the wave header line.
+func (r *TextReporter) WaveStarted(wave, count int) {
+	fmt.Fprintf(r.w, "\n--- Wave %d: %d newly unblocked issues ---\n", wave, count)
+}
+
+// AllBlocked writes the all-blocked message followed by the summary line.
+func (r *TextReporter) AllBlocked(total, blocked int) {
+	fmt.Fprintln(r.w, "All issues are blocked \u2014 nothing to process.")
+	fmt.Fprintf(r.w, "Summary: %d total, %d blocked, %d processable\n", total, blocked, 0)
+}
+
+// RollupCreated writes the rollup PR creation line, then either the merged or
+// open-for-review line.
+func (r *TextReporter) RollupCreated(prNumber int, prURL string, merged bool) {
+	fmt.Fprintf(r.w, "Rollup PR #%d created: %s\n", prNumber, prURL)
+	if merged {
+		fmt.Fprintf(r.w, "Rollup PR #%d merged.\n", prNumber)
+	} else {
+		fmt.Fprintf(r.w, "Rollup PR #%d is open for review: %s\n", prNumber, prURL)
+	}
+}
+
+// RunFinished writes a blank line followed by the results summary.
+func (r *TextReporter) RunFinished(implemented, readyToMerge, needsHumanReview, failed, blocked int) {
+	fmt.Fprintln(r.w)
+	fmt.Fprintf(r.w, "Results: %d implemented, %d ready-to-merge, %d needs-human-review, %d failed, %d skipped (blocked)\n",
+		implemented, readyToMerge, needsHumanReview, failed, blocked)
+}
+
+// PunchlistText writes a punchlist fragment directly.
+func (r *TextReporter) PunchlistText(text string) {
+	fmt.Fprint(r.w, text)
+}

--- a/internal/progress/text_test.go
+++ b/internal/progress/text_test.go
@@ -1,0 +1,145 @@
+package progress
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestIssueCompleted_Implemented(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.IssueCompleted(42, "add cost tracking", "implemented", 87, 0, "")
+	want := "  #42 add cost tracking \u2014 implemented (PR #87, 0 retries)\n"
+	if got := buf.String(); got != want {
+		t.Errorf("IssueCompleted implemented\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestIssueCompleted_ReadyToMerge(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.IssueCompleted(10, "fix login", "ready-to-merge", 55, 2, "")
+	want := "  #10 fix login \u2014 ready-to-merge (PR #55, 2 retries)\n"
+	if got := buf.String(); got != want {
+		t.Errorf("IssueCompleted ready-to-merge\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestIssueCompleted_NeedsHumanReview(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.IssueCompleted(7, "refactor auth", "needs-human-review", 33, 1, "")
+	want := "  #7 refactor auth \u2014 needs human review (PR #33)\n"
+	if got := buf.String(); got != want {
+		t.Errorf("IssueCompleted needs-human-review\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestIssueCompleted_Failed(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.IssueCompleted(42, "add cost tracking", "failed", 0, 0, "timeout")
+	want := "  #42 add cost tracking \u2014 failed: timeout\n"
+	if got := buf.String(); got != want {
+		t.Errorf("IssueCompleted failed\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestRunFinished(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.RunFinished(3, 1, 1, 1, 2)
+	want := "\nResults: 3 implemented, 1 ready-to-merge, 1 needs-human-review, 1 failed, 2 skipped (blocked)\n"
+	if got := buf.String(); got != want {
+		t.Errorf("RunFinished\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestWaveStarted(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.WaveStarted(2, 3)
+	want := "\n--- Wave 2: 3 newly unblocked issues ---\n"
+	if got := buf.String(); got != want {
+		t.Errorf("WaveStarted\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestAllBlocked(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.AllBlocked(5, 5)
+	got := buf.String()
+	wantFirst := "All issues are blocked \u2014 nothing to process.\n"
+	wantSecond := "Summary: 5 total, 5 blocked, 0 processable\n"
+	if !strings.HasPrefix(got, wantFirst) {
+		t.Errorf("AllBlocked first line\ngot:  %q\nwant prefix: %q", got, wantFirst)
+	}
+	if !strings.HasSuffix(got, wantSecond) {
+		t.Errorf("AllBlocked second line\ngot:  %q\nwant suffix: %q", got, wantSecond)
+	}
+}
+
+func TestRollupCreated_Merged(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.RollupCreated(12, "https://github.com/org/repo/pull/12", true)
+	got := buf.String()
+	wantCreated := "Rollup PR #12 created: https://github.com/org/repo/pull/12\n"
+	wantMerged := "Rollup PR #12 merged.\n"
+	if !strings.Contains(got, wantCreated) {
+		t.Errorf("RollupCreated merged: missing created line\ngot: %q", got)
+	}
+	if !strings.Contains(got, wantMerged) {
+		t.Errorf("RollupCreated merged: missing merged line\ngot: %q", got)
+	}
+}
+
+func TestRollupCreated_Open(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.RollupCreated(12, "https://github.com/org/repo/pull/12", false)
+	got := buf.String()
+	wantCreated := "Rollup PR #12 created: https://github.com/org/repo/pull/12\n"
+	wantOpen := "Rollup PR #12 is open for review: https://github.com/org/repo/pull/12\n"
+	if !strings.Contains(got, wantCreated) {
+		t.Errorf("RollupCreated open: missing created line\ngot: %q", got)
+	}
+	if !strings.Contains(got, wantOpen) {
+		t.Errorf("RollupCreated open: missing open line\ngot: %q", got)
+	}
+}
+
+func TestPunchlistText(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.PunchlistText("- fix the thing\n")
+	want := "- fix the thing\n"
+	if got := buf.String(); got != want {
+		t.Errorf("PunchlistText\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestWriterInjection(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.WaveStarted(1, 5)
+	if buf.Len() == 0 {
+		t.Error("expected output in buffer, got none")
+	}
+}
+
+func TestNoOpMethods(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf)
+	r.RunStarted("org/repo", "v1.0", "2026-03-14", "main", "true", "true", 10)
+	r.IssueStarted(1, "some issue")
+	r.IssueStageChanged(1, "implementing")
+	if buf.Len() != 0 {
+		t.Errorf("expected no output from no-op methods, got %q", buf.String())
+	}
+}
+
+// Verify TextReporter satisfies the ProgressReporter interface at compile time.
+var _ ProgressReporter = (*TextReporter)(nil)


### PR DESCRIPTION
## Summary

- Defines `ProgressReporter` interface in new `internal/progress/` package (foundation layer)
- Implements `TextReporter` that reproduces current `orchestrator.go` `fmt.Printf` output exactly
- Adds `internal/progress/` to the foundation layer in `docs/architecture.json`

## Test plan

- [x] `TestIssueCompleted_Implemented` — verifies implemented format string matches orchestrator.go exactly
- [x] `TestIssueCompleted_Failed` — verifies failed format string with errMsg
- [x] `TestRunFinished` — verifies blank line + results line with all 5 fields
- [x] `TestWaveStarted` — verifies wave header format
- [x] `TestAllBlocked` — verifies both the blocked message and summary line
- [x] `TestRollupCreated_Merged` / `_Open` — verifies both rollup PR variants
- [x] `TestWriterInjection` — verifies output goes to injected buffer, not stdout
- [x] `TestNoOpMethods` — verifies RunStarted/IssueStarted/IssueStageChanged write nothing
- [x] Compile-time interface satisfaction: `var _ ProgressReporter = (*TextReporter)(nil)`
- [x] `go test ./internal/progress/...` passes

## Implementation Notes

### Approach
Created `internal/progress/reporter.go` with the `ProgressReporter` interface exactly as specified in the issue. Created `internal/progress/text.go` with `TextReporter` implementing all 9 methods using `fmt.Fprintf` to an injected `io.Writer`. Updated `docs/architecture.json` to register the package in the foundation layer.

### Key Decisions
- `RunStarted`, `IssueStarted`, and `IssueStageChanged` are no-ops in `TextReporter` since the orchestrator currently emits these only via structured logging (`logger.Info`), not `fmt.Printf`. Making them no-ops preserves zero behavior change.
- `RollupCreated` always emits the "created" line first, then either "merged" or "open for review" based on the `merged` bool — matching the two distinct code paths in `handleRollupPR`.
- `AllBlocked` emits both the message line and the summary line (matching the two-line pattern at orchestrator.go lines 231–232 and 320–322).
- `RunFinished` emits the blank line itself so callers don't need to print it separately.
- Em-dashes (`—`, U+2014) in format strings use Go `\u2014` escapes to avoid encoding ambiguity.

### Known Limitations
- `implement.go`'s results format string omits the `blocked` field; it will need updating when it's wired to use `TextReporter`. That migration is out of scope for this issue.
- `fmt.Println("No issues found in milestone.")` (orchestrator.go:65) and the rollup warning line have no interface method and remain as bare `fmt.Println`/`fmt.Printf` calls.

### Architecture
- Only the `foundation` layer was touched: new `internal/progress/` package imports only `fmt`, `io`, `os` (stdlib).
- `docs/architecture.json` updated to register `internal/progress/` in the foundation `paths` array.
- No other layers were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #440