### PR TITLE
feat(orchestrator): replace fmt progress output with ProgressReporter

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -17,6 +17,7 @@ import (
 	"github.com/phs/dark-factory/internal/logging"
 	"github.com/phs/dark-factory/internal/notify"
 	"github.com/phs/dark-factory/internal/orchestrator"
+	"github.com/phs/dark-factory/internal/progress"
 	"github.com/phs/dark-factory/internal/punchlist"
 	"github.com/phs/dark-factory/internal/pypi"
 	"github.com/phs/dark-factory/internal/rundata"
@@ -168,6 +169,8 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			}
 		}()
 
+		reporter := progress.NewTextReporter(os.Stdout)
+
 		// Stats across all issues.
 		var implemented, readyToMerge, needsHumanReview, failed int
 
@@ -186,7 +189,7 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			if err != nil {
 				logger.Warn("failed to fetch issue, skipping", "issue_number", issueNumber, "error", err)
 				failed++
-				fmt.Printf("  #%d — failed to fetch: %s\n", issueNumber, err)
+				reporter.IssueCompleted(issueNumber, "", "failed", 0, 0, err.Error())
 				continue
 			}
 
@@ -212,23 +215,23 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			switch outcome.Status {
 			case agent.StatusImplemented:
 				implemented++
-				fmt.Printf("  #%d %s — implemented (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
+				reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "")
 				if err := orchestrator.PullAfterMerge(cfg.EffectiveBaseBranch(), logger); err != nil {
 					logger.Warn("could not sync local repo after merge", "error", err)
 				}
 			case agent.StatusReadyToMerge:
 				readyToMerge++
-				fmt.Printf("  #%d %s — ready-to-merge (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
+				reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "")
 			case agent.StatusNeedsHumanReview:
 				needsHumanReview++
-				fmt.Printf("  #%d %s — needs human review (PR #%d)\n", issue.Number, issue.Title, outcome.PRNumber)
+				reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "")
 			default:
 				failed++
 				errMsg := ""
 				if outcome.Err != nil {
 					errMsg = outcome.Err.Error()
 				}
-				fmt.Printf("  #%d %s — failed: %s\n", issue.Number, issue.Title, errMsg)
+				reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg)
 			}
 
 			logger.Info("issue outcome",
@@ -274,9 +277,7 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 		}
 
 		// Print totals.
-		fmt.Println()
-		fmt.Printf("Results: %d implemented, %d ready-to-merge, %d needs-human-review, %d failed\n",
-			implemented, readyToMerge, needsHumanReview, failed)
+		reporter.RunFinished(implemented, readyToMerge, needsHumanReview, failed, 0)
 
 		// Finalize run data.
 		if writer != nil {
@@ -309,9 +310,11 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 			}
 
 			text := punchlist.Generate(punchlistEntries)
-			fmt.Println()
-			if err := punchlist.Write(text, punchlistPath); err != nil {
-				logger.Warn("failed to write punchlist", "error", err)
+			reporter.PunchlistText(text)
+			if punchlistPath != "" {
+				if err := os.WriteFile(punchlistPath, []byte(text), 0o644); err != nil {
+					logger.Warn("failed to write punchlist", "error", err)
+				}
 			}
 		}
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -10,6 +10,7 @@ import (
 	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/logging"
 	"github.com/phs/dark-factory/internal/orchestrator"
+	"github.com/phs/dark-factory/internal/progress"
 	"github.com/phs/dark-factory/internal/pypi"
 	"github.com/spf13/cobra"
 )
@@ -81,7 +82,8 @@ each unblocked issue through the implement → review → merge loop.`,
 		}
 
 		punchlistPath, _ := cmd.Flags().GetString("punchlist")
-		return orchestrator.Run(ctx, cfg, logger, milestone, issue, dryRun, force, punchlistPath)
+		reporter := progress.NewTextReporter(os.Stdout)
+		return orchestrator.Run(ctx, cfg, logger, reporter, milestone, issue, dryRun, force, punchlistPath)
 	},
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/phs/dark-factory/internal/lock"
 	"github.com/phs/dark-factory/internal/logging"
 	"github.com/phs/dark-factory/internal/notify"
+	"github.com/phs/dark-factory/internal/progress"
 	"github.com/phs/dark-factory/internal/punchlist"
 	"github.com/phs/dark-factory/internal/rundata"
 	"github.com/phs/dark-factory/internal/sandbox"
@@ -35,7 +36,7 @@ import (
 // force bypasses an existing run lock (useful to clear stale locks left by
 // crashed instances). punchlistPath is the optional file path to write the
 // punchlist to (always printed to stdout as well).
-func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone string, issue int, dryRun bool, force bool, punchlistPath string) error {
+func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, reporter progress.ProgressReporter, milestone string, issue int, dryRun bool, force bool, punchlistPath string) error {
 	// Preflight: fail fast if working tree is dirty (skip in dry-run mode).
 	if !dryRun {
 		if err := CheckWorkingTree(); err != nil {
@@ -120,7 +121,7 @@ func Run(ctx context.Context, cfg *config.Config, logger *slog.Logger, milestone
 		return nil
 	}
 
-	return processIssues(ctx, issues, closedSet, cfg, logger, writer, force, punchlistPath, milestone, notifiers)
+	return processIssues(ctx, issues, closedSet, cfg, logger, reporter, writer, force, punchlistPath, milestone, notifiers)
 }
 
 // categorizeIssues splits issues into processable and blocked based on the
@@ -206,7 +207,7 @@ func printDryRun(processable []github.Issue, blocked []blockedIssue, total int) 
 // re-resolution after each merge. When an issue is successfully merged,
 // the closed set is refreshed and dependencies re-resolved so that newly
 // unblocked issues can be processed in the same run.
-func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[int]bool, cfg *config.Config, logger *slog.Logger, writer *rundata.Writer, force bool, punchlistPath string, milestone string, notifiers []notify.Notifier) error {
+func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[int]bool, cfg *config.Config, logger *slog.Logger, reporter progress.ProgressReporter, writer *rundata.Writer, force bool, punchlistPath string, milestone string, notifiers []notify.Notifier) error {
 	// Initial categorization.
 	processable, blocked := categorizeIssues(allIssues, closedSet)
 
@@ -228,8 +229,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 	}
 
 	if len(processable) == 0 {
-		fmt.Println("All issues are blocked — nothing to process.")
-		printSummary(len(allIssues), len(blocked), 0)
+		reporter.AllBlocked(len(allIssues), len(blocked))
 		return nil
 	}
 
@@ -317,8 +317,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 
 		if len(batch) == 0 {
 			if wave == 1 {
-				fmt.Println("All issues are blocked — nothing to process.")
-				printSummary(len(allIssues), len(blocked), 0)
+				reporter.AllBlocked(len(allIssues), len(blocked))
 			}
 			break
 		}
@@ -328,7 +327,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 				"wave", wave,
 				"newly_unblocked", len(batch),
 			)
-			fmt.Printf("\n--- Wave %d: %d newly unblocked issues ---\n", wave, len(batch))
+			reporter.WaveStarted(wave, len(batch))
 		}
 
 		// Lock this wave's issues.
@@ -380,7 +379,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 			case agent.StatusImplemented:
 				stats.implemented++
 				implementedIssues = append(implementedIssues, issue)
-				fmt.Printf("  #%d %s — implemented (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
+				reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "")
 				if err := PullAfterMerge(baseBranch, logger); err != nil {
 					logger.Warn("stopping loop: could not sync local repo after merge", "error", err)
 					stats.abortReason = fmt.Sprintf("could not sync after merge: %v", err)
@@ -389,17 +388,17 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 				merged = true
 			case agent.StatusReadyToMerge:
 				stats.readyToMerge++
-				fmt.Printf("  #%d %s — ready-to-merge (PR #%d, %d retries)\n", issue.Number, issue.Title, outcome.PRNumber, outcome.Retries)
+				reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "")
 			case agent.StatusNeedsHumanReview:
 				stats.needsHumanReview++
-				fmt.Printf("  #%d %s — needs human review (PR #%d)\n", issue.Number, issue.Title, outcome.PRNumber)
+				reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "")
 			default:
 				stats.failed++
 				errMsg := ""
 				if outcome.Err != nil {
 					errMsg = outcome.Err.Error()
 				}
-				fmt.Printf("  #%d %s — failed: %s\n", issue.Number, issue.Title, errMsg)
+				reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg)
 			}
 
 			logger.Info("issue outcome",
@@ -440,7 +439,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 					// Print this entry's punchlist to stdout immediately.
 					text := punchlist.Generate([]punchlist.Entry{entry})
 					if text != "" {
-						fmt.Print(text)
+						reporter.PunchlistText(text)
 					}
 					logger.Info("punchlist acceptance tests generated",
 						"issue_number", iss.Number,
@@ -472,9 +471,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 
 done:
 	stats.blocked = len(blocked)
-	fmt.Println()
-	fmt.Printf("Results: %d implemented, %d ready-to-merge, %d needs-human-review, %d failed, %d skipped (blocked)\n",
-		stats.implemented, stats.readyToMerge, stats.needsHumanReview, stats.failed, stats.blocked)
+	reporter.RunFinished(stats.implemented, stats.readyToMerge, stats.needsHumanReview, stats.failed, stats.blocked)
 
 	// Rollup PR: create (and optionally merge) a PR from the base branch back
 	// to the default branch when the run completed cleanly, used a non-default
@@ -486,7 +483,7 @@ done:
 		cfg.AutoMerge.Rollup != config.RollupNone &&
 		cfg.BaseBranch != "" && cfg.BaseBranch != defaultBranch &&
 		stats.implemented > 0 {
-		prNum, prURL, err := handleRollupPR(ctx, cfg, implementedIssues, defaultBranch, logger)
+		prNum, prURL, err := handleRollupPR(ctx, cfg, implementedIssues, defaultBranch, logger, reporter)
 		if err != nil {
 			logger.Warn("rollup PR handling failed", "error", err)
 			fmt.Printf("Rollup PR warning: %v\n", err)
@@ -612,7 +609,7 @@ var mergeRollupPRFn = github.MergeRollupPR
 // into defaultBranch. It is called when rollup is "manual" or "auto" and at
 // least one issue was implemented into the base branch during the run.
 // Returns the PR number, URL, and any error.
-func handleRollupPR(ctx context.Context, cfg *config.Config, issues []github.Issue, defaultBranch string, logger *slog.Logger) (int, string, error) {
+func handleRollupPR(ctx context.Context, cfg *config.Config, issues []github.Issue, defaultBranch string, logger *slog.Logger, reporter progress.ProgressReporter) (int, string, error) {
 	title := fmt.Sprintf("chore: merge %s into %s", cfg.BaseBranch, defaultBranch)
 	body := buildRollupBody(issues)
 
@@ -628,7 +625,6 @@ func handleRollupPR(ctx context.Context, cfg *config.Config, issues []github.Iss
 	}
 
 	logger.Info("rollup PR created", "pr_number", prNum, "pr_url", prURL)
-	fmt.Printf("Rollup PR #%d created: %s\n", prNum, prURL)
 
 	if cfg.AutoMerge.Rollup == config.RollupAuto {
 		// Wait for CI checks before merging if configured.
@@ -654,10 +650,10 @@ func handleRollupPR(ctx context.Context, cfg *config.Config, issues []github.Iss
 			return 0, "", fmt.Errorf("merging rollup PR: %w", err)
 		}
 		logger.Info("rollup PR merged", "pr_number", prNum)
-		fmt.Printf("Rollup PR #%d merged.\n", prNum)
+		reporter.RollupCreated(prNum, prURL, true)
 	} else {
 		logger.Info("rollup PR left open for human review", "pr_number", prNum, "pr_url", prURL)
-		fmt.Printf("Rollup PR #%d is open for review: %s\n", prNum, prURL)
+		reporter.RollupCreated(prNum, prURL, false)
 	}
 
 	return prNum, prURL, nil

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/logging"
 	"github.com/phs/dark-factory/internal/notify"
+	"github.com/phs/dark-factory/internal/progress"
 	"github.com/phs/dark-factory/internal/rundata"
 )
 
@@ -31,6 +32,71 @@ func (f *fakeNotifier) Send(_ context.Context, event notify.Event) error {
 	}
 	f.received = append(f.received, event)
 	return nil
+}
+
+// fakeReporter records all reporter calls for test assertions.
+type fakeReporter struct {
+	issueCompleted []fakeIssueCompleted
+	waveStarted    []fakeWaveStarted
+	runFinished    []fakeRunFinished
+	allBlocked     []fakeAllBlocked
+	rollupCreated  []fakeRollupCreated
+	punchlistTexts []string
+}
+
+type fakeIssueCompleted struct {
+	issueNumber int
+	title       string
+	status      string
+	prNumber    int
+	retries     int
+	errMsg      string
+}
+
+type fakeWaveStarted struct {
+	wave  int
+	count int
+}
+
+type fakeRunFinished struct {
+	implemented      int
+	readyToMerge     int
+	needsHumanReview int
+	failed           int
+	blocked          int
+}
+
+type fakeAllBlocked struct {
+	total   int
+	blocked int
+}
+
+type fakeRollupCreated struct {
+	prNumber int
+	prURL    string
+	merged   bool
+}
+
+func (r *fakeReporter) RunStarted(_, _, _, _, _, _ string, _ int) {}
+func (r *fakeReporter) IssueStarted(_ int, _ string)              {}
+func (r *fakeReporter) IssueStageChanged(_ int, _ string)         {}
+func (r *fakeReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string) {
+	r.issueCompleted = append(r.issueCompleted, fakeIssueCompleted{issueNumber, title, status, prNumber, retries, errMsg})
+}
+func (r *fakeReporter) WaveStarted(wave, count int) {
+	r.waveStarted = append(r.waveStarted, fakeWaveStarted{wave, count})
+}
+func (r *fakeReporter) AllBlocked(total, blocked int) {
+	r.allBlocked = append(r.allBlocked, fakeAllBlocked{total, blocked})
+}
+func (r *fakeReporter) RollupCreated(prNumber int, prURL string, merged bool) {
+	r.rollupCreated = append(r.rollupCreated, fakeRollupCreated{prNumber, prURL, merged})
+}
+func (r *fakeReporter) RunFinished(implemented, readyToMerge, needsHumanReview, failed, blocked int) {
+	r.runFinished = append(r.runFinished, fakeRunFinished{implemented, readyToMerge, needsHumanReview, failed, blocked})
+}
+func (r *fakeReporter) PunchlistText(text string) {
+	r.punchlistTexts = append(r.punchlistTexts, text)
 }
 
 // ghIssue mirrors the JSON shape for test fixtures.
@@ -127,7 +193,7 @@ func TestDryRun_ListsIssuesInOrder(t *testing.T) {
 	setupFakeGH(t, openIssues, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, true, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, true, false, "")
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -153,7 +219,7 @@ func TestDryRun_BlockedIssuesShownSeparately(t *testing.T) {
 	setupFakeGH(t, openIssues, nil) // #99 not closed
 
 	output := captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, true, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, true, false, "")
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -179,7 +245,7 @@ func TestDryRun_SummaryCounts(t *testing.T) {
 	setupFakeGH(t, openIssues, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, true, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, true, false, "")
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -203,7 +269,7 @@ func TestDryRun_LogFileCreated(t *testing.T) {
 	}
 
 	captureStdout(t, func() {
-		if err := Run(context.Background(), testConfig(), logger, "Phase 1", 0, true, false, ""); err != nil {
+		if err := Run(context.Background(), testConfig(), logger, progress.NewTextReporter(os.Stdout), "Phase 1", 0, true, false, ""); err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
 	})
@@ -218,7 +284,7 @@ func TestEmptyMilestone(t *testing.T) {
 	setupFakeGH(t, []ghIssue{}, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, true, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, true, false, "")
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -251,7 +317,7 @@ func TestAllBlocked(t *testing.T) {
 	}
 
 	output := captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, false, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, false, false, "")
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -272,7 +338,7 @@ func TestDryRun_ClosedDepsUnblock(t *testing.T) {
 	setupFakeGH(t, openIssues, []int{3}) // #3 is closed
 
 	output := captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, true, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, true, false, "")
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -318,7 +384,7 @@ func TestDryRun_PriorityDisplayed(t *testing.T) {
 	setupFakeGH(t, openIssues, nil)
 
 	output := captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, true, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, true, false, "")
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -343,7 +409,7 @@ func TestSingleIssueMode_FiltersCorrectly(t *testing.T) {
 	cfg := testConfig()
 
 	output := captureStdout(t, func() {
-		err := Run(context.Background(), cfg, testLogger(t), "Phase 1", 2, true, false, "")
+		err := Run(context.Background(), cfg, testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 2, true, false, "")
 		if err != nil {
 			t.Fatalf("Run() error = %v", err)
 		}
@@ -367,7 +433,7 @@ func TestSingleIssueMode_ErrorWhenBlocked(t *testing.T) {
 	cfg := testConfig()
 
 	captureStdout(t, func() {
-		err := Run(context.Background(), cfg, testLogger(t), "Phase 1", 1, true, false, "")
+		err := Run(context.Background(), cfg, testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 1, true, false, "")
 		if err == nil {
 			t.Fatal("expected error for blocked single issue")
 		}
@@ -386,7 +452,7 @@ func TestSingleIssueMode_ErrorWhenNotFound(t *testing.T) {
 	cfg := testConfig()
 
 	captureStdout(t, func() {
-		err := Run(context.Background(), cfg, testLogger(t), "Phase 1", 999, true, false, "")
+		err := Run(context.Background(), cfg, testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 999, true, false, "")
 		if err == nil {
 			t.Fatal("expected error for missing single issue")
 		}
@@ -503,7 +569,7 @@ func TestProcessIssues_MultiWaveReResolution(t *testing.T) {
 	cfg.NoSandbox = true
 
 	output := captureStdout(t, func() {
-		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), nil, false, "", "test-milestone", nil)
+		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "test-milestone", nil)
 		if err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
@@ -550,7 +616,7 @@ func TestProcessIssues_AllFailNoInfiniteLoop(t *testing.T) {
 	cfg.NoSandbox = true
 
 	output := captureStdout(t, func() {
-		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), nil, false, "", "", nil)
+		err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "", nil)
 		if err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
@@ -599,7 +665,7 @@ func TestProcessIssues_FinalizeRunCalled(t *testing.T) {
 	cfg.NoSandbox = true
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), writer, false, "", "test-milestone", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), writer, false, "", "test-milestone", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -724,7 +790,7 @@ func TestProcessIssues_WritesDialogue(t *testing.T) {
 	cfg.NoSandbox = true
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), writer, false, "", "test-milestone", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), writer, false, "", "test-milestone", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -866,7 +932,7 @@ func TestRun_DirtyTreeBlocksRun(t *testing.T) {
 	}
 
 	captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, false, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, false, false, "")
 		if err == nil {
 			t.Fatal("expected error for dirty working tree")
 		}
@@ -892,7 +958,7 @@ func TestRun_DirtyTreeErrorListsFiles(t *testing.T) {
 	}
 
 	captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, false, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, false, false, "")
 		if err == nil {
 			t.Fatal("expected error for dirty working tree")
 		}
@@ -919,7 +985,7 @@ func TestRun_DryRunSkipsDirtyCheck(t *testing.T) {
 	}
 
 	captureStdout(t, func() {
-		err := Run(context.Background(), testConfig(), testLogger(t), "Phase 1", 0, true, false, "")
+		err := Run(context.Background(), testConfig(), testLogger(t), progress.NewTextReporter(os.Stdout), "Phase 1", 0, true, false, "")
 		if err != nil {
 			t.Fatalf("dry-run should not fail on dirty tree: %v", err)
 		}
@@ -1103,7 +1169,7 @@ func TestProcessIssues_LifecycleLabelsEnsured(t *testing.T) {
 	cfg.NoSandbox = true
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), nil, false, "", "test-milestone", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "test-milestone", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1183,7 +1249,7 @@ func TestProcessIssues_RunCompleteNotificationFired(t *testing.T) {
 	cfg.NoSandbox = true
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), nil, false, "", "test-milestone", []notify.Notifier{fn}); err != nil {
+		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "test-milestone", []notify.Notifier{fn}); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1240,7 +1306,7 @@ func TestProcessIssues_AbortNotificationFired(t *testing.T) {
 	cfg.NoSandbox = true
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), nil, false, "", "test-milestone", []notify.Notifier{fn}); err != nil {
+		if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "test-milestone", []notify.Notifier{fn}); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1352,7 +1418,7 @@ func TestRollup_NoneDoesNothing(t *testing.T) {
 	cfg.AutoMerge.Rollup = "none"
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1383,7 +1449,7 @@ func TestRollup_ManualCreatesPRButDoesNotMerge(t *testing.T) {
 	cfg.AutoMerge.Rollup = "manual"
 
 	output := captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1420,7 +1486,7 @@ func TestRollup_AutoCreateAndMerges(t *testing.T) {
 	cfg.AutoMerge.Rollup = "auto"
 
 	output := captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1454,7 +1520,7 @@ func TestRollup_SkipWhenBaseBranchEmpty(t *testing.T) {
 	cfg.AutoMerge.Rollup = "auto"
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1482,7 +1548,7 @@ func TestRollup_SkipWhenBaseBranchEqualsDefault(t *testing.T) {
 	cfg.AutoMerge.Rollup = "auto"
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1511,7 +1577,7 @@ func TestRollup_SkipWhenBaseBranchEqualsCustomDefault(t *testing.T) {
 	cfg.AutoMerge.Rollup = "auto"
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1540,7 +1606,7 @@ func TestRollup_UsesCustomDefaultBranch(t *testing.T) {
 	cfg.AutoMerge.Rollup = "manual"
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1571,7 +1637,7 @@ func TestRollup_SkipWhenZeroImplemented(t *testing.T) {
 	cfg.AutoMerge.Rollup = "auto"
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1615,7 +1681,7 @@ func TestRollup_SkipWhenAborted(t *testing.T) {
 	cfg.AutoMerge.Rollup = "auto"
 
 	captureStdout(t, func() {
-		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), nil, false, "", "m1", nil); err != nil {
+		if err := processIssues(context.Background(), allIssues, map[int]bool{}, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "m1", nil); err != nil {
 			t.Fatalf("processIssues() error = %v", err)
 		}
 	})
@@ -1636,5 +1702,226 @@ func TestBuildRollupBody_ListsIssues(t *testing.T) {
 	}
 	if !strings.Contains(body, "#2 Fix bug B") {
 		t.Errorf("expected '#2 Fix bug B' in body, got:\n%s", body)
+	}
+}
+
+// TestReporter_IssueCompleted verifies that processIssues calls IssueCompleted
+// with correct parameters after processIssueFn returns an outcome.
+// PRNumber is 0 to avoid triggering the punchlist enrichment goroutine in tests.
+func TestReporter_IssueCompleted(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 42, Title: "add cost tracking"},
+	}
+
+	setupProcessMocks(t, func() []int { return nil },
+		func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook) agent.IssueOutcome {
+			// Use PRNumber:0 to avoid triggering the punchlist goroutine.
+			return agent.IssueOutcome{IssueNumber: issue.Number, Status: "failed", Err: fmt.Errorf("test error")}
+		})
+
+	reporter := &fakeReporter{}
+	closedSet := map[int]bool{}
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), reporter, nil, false, "", "m1", nil); err != nil {
+		t.Fatalf("processIssues() error = %v", err)
+	}
+
+	if len(reporter.issueCompleted) != 1 {
+		t.Fatalf("expected 1 IssueCompleted call, got %d", len(reporter.issueCompleted))
+	}
+	got := reporter.issueCompleted[0]
+	if got.issueNumber != 42 {
+		t.Errorf("IssueCompleted issueNumber = %d, want 42", got.issueNumber)
+	}
+	if got.title != "add cost tracking" {
+		t.Errorf("IssueCompleted title = %q, want %q", got.title, "add cost tracking")
+	}
+	if got.status != "failed" {
+		t.Errorf("IssueCompleted status = %q, want %q", got.status, "failed")
+	}
+	if got.errMsg != "test error" {
+		t.Errorf("IssueCompleted errMsg = %q, want %q", got.errMsg, "test error")
+	}
+}
+
+// TestReporter_WaveStarted verifies that a second dependency wave triggers WaveStarted.
+func TestReporter_WaveStarted(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 1, Title: "first"},
+		{Number: 2, Title: "second", Body: "**Blocked by**: #1"},
+	}
+
+	callCount := 0
+	setupProcessMocks(t, func() []int {
+		// After issue #1 is merged, return it as closed so #2 unblocks.
+		if callCount > 0 {
+			return []int{1}
+		}
+		return nil
+	}, func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook) agent.IssueOutcome {
+		callCount++
+		// PRNumber:0 avoids triggering the punchlist enrichment goroutine in tests.
+		return agent.IssueOutcome{IssueNumber: issue.Number, Status: "implemented", PRNumber: 0}
+	})
+
+	reporter := &fakeReporter{}
+	closedSet := map[int]bool{}
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), reporter, nil, false, "", "m1", nil); err != nil {
+		t.Fatalf("processIssues() error = %v", err)
+	}
+
+	// Wave 2 should have been signaled.
+	if len(reporter.waveStarted) != 1 {
+		t.Fatalf("expected 1 WaveStarted call, got %d: %v", len(reporter.waveStarted), reporter.waveStarted)
+	}
+	if reporter.waveStarted[0].wave != 2 {
+		t.Errorf("WaveStarted wave = %d, want 2", reporter.waveStarted[0].wave)
+	}
+	if reporter.waveStarted[0].count != 1 {
+		t.Errorf("WaveStarted count = %d, want 1", reporter.waveStarted[0].count)
+	}
+}
+
+// TestReporter_RunFinished verifies that RunFinished receives correct summary counts.
+func TestReporter_RunFinished(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 1, Title: "implemented"},
+		{Number: 2, Title: "failed"},
+	}
+
+	setupProcessMocks(t, func() []int { return nil },
+		func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook) agent.IssueOutcome {
+			if issue.Number == 1 {
+				// PRNumber:0 avoids triggering the punchlist enrichment goroutine in tests.
+				return agent.IssueOutcome{IssueNumber: 1, Status: "implemented", PRNumber: 0}
+			}
+			return agent.IssueOutcome{IssueNumber: 2, Status: "failed", Err: fmt.Errorf("boom")}
+		})
+
+	reporter := &fakeReporter{}
+	closedSet := map[int]bool{}
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), reporter, nil, false, "", "m1", nil); err != nil {
+		t.Fatalf("processIssues() error = %v", err)
+	}
+
+	if len(reporter.runFinished) != 1 {
+		t.Fatalf("expected 1 RunFinished call, got %d", len(reporter.runFinished))
+	}
+	rf := reporter.runFinished[0]
+	if rf.implemented != 1 {
+		t.Errorf("RunFinished implemented = %d, want 1", rf.implemented)
+	}
+	if rf.failed != 1 {
+		t.Errorf("RunFinished failed = %d, want 1", rf.failed)
+	}
+}
+
+// TestReporter_DryRunDoesNotCallReporter verifies dry-run mode does not call any
+// reporter methods — it uses printDryRun directly.
+func TestReporter_DryRunDoesNotCallReporter(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 1, Title: "test issue", Labels: []ghLabel{}},
+	}
+	setupFakeGH(t, openIssues, nil)
+
+	reporter := &fakeReporter{}
+	cfg := testConfig()
+
+	if err := Run(context.Background(), cfg, testLogger(t), reporter, "Phase 1", 0, true, false, ""); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if len(reporter.issueCompleted) != 0 {
+		t.Errorf("dry-run: expected no IssueCompleted calls, got %d", len(reporter.issueCompleted))
+	}
+	if len(reporter.runFinished) != 0 {
+		t.Errorf("dry-run: expected no RunFinished calls, got %d", len(reporter.runFinished))
+	}
+	if len(reporter.waveStarted) != 0 {
+		t.Errorf("dry-run: expected no WaveStarted calls, got %d", len(reporter.waveStarted))
+	}
+}
+
+// TestReporter_LoggerPreserved verifies that logger.Info is still called for issue
+// outcomes alongside reporter methods.
+func TestReporter_LoggerPreserved(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 5, Title: "test issue"},
+	}
+
+	setupProcessMocks(t, func() []int { return nil },
+		func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook) agent.IssueOutcome {
+			// PRNumber:0 avoids triggering the punchlist enrichment goroutine in tests.
+			return agent.IssueOutcome{IssueNumber: issue.Number, Status: "implemented", PRNumber: 0}
+		})
+
+	// Use a recording logger to verify logger.Info("issue outcome", ...) is still called.
+	handler := &recordingHandler{}
+	logger := slog.New(handler)
+
+	reporter := &fakeReporter{}
+	closedSet := map[int]bool{}
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	if err := processIssues(context.Background(), allIssues, closedSet, cfg, logger, reporter, nil, false, "", "m1", nil); err != nil {
+		t.Fatalf("processIssues() error = %v", err)
+	}
+
+	// Reporter received IssueCompleted.
+	if len(reporter.issueCompleted) != 1 {
+		t.Fatalf("expected 1 IssueCompleted, got %d", len(reporter.issueCompleted))
+	}
+
+	// Logger also received the "issue outcome" log entry.
+	var found bool
+	for _, r := range handler.records {
+		if r.Message == "issue outcome" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected logger.Info('issue outcome', ...) to be called")
+	}
+}
+
+// TestReporter_AllBlockedCalled verifies that AllBlocked is called when all issues
+// are blocked.
+func TestReporter_AllBlockedCalled(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 1, Title: "blocked", Body: "**Blocked by**: #99"},
+	}
+
+	setupProcessMocks(t, func() []int { return nil },
+		func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook) agent.IssueOutcome {
+			return agent.IssueOutcome{IssueNumber: issue.Number, Status: "failed"}
+		})
+
+	reporter := &fakeReporter{}
+	closedSet := map[int]bool{} // #99 not closed
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), reporter, nil, false, "", "m1", nil); err != nil {
+		t.Fatalf("processIssues() error = %v", err)
+	}
+
+	if len(reporter.allBlocked) != 1 {
+		t.Fatalf("expected 1 AllBlocked call, got %d", len(reporter.allBlocked))
+	}
+	if reporter.allBlocked[0].total != 1 {
+		t.Errorf("AllBlocked total = %d, want 1", reporter.allBlocked[0].total)
+	}
+	if reporter.allBlocked[0].blocked != 1 {
+		t.Errorf("AllBlocked blocked = %d, want 1", reporter.allBlocked[0].blocked)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `progress.ProgressReporter` parameter to `orchestrator.Run()`, `processIssues()`, and `handleRollupPR()`
- Replace all user-facing `fmt.Printf`/`Println` progress calls in `orchestrator.go` with reporter method calls (`IssueCompleted`, `WaveStarted`, `AllBlocked`, `RunFinished`, `RollupCreated`, `PunchlistText`)
- Replace user-facing `fmt.Printf` calls in `implement.go` with the same reporter methods
- Inject `TextReporter(os.Stdout)` from `run.go` and `implement.go` — terminal output is byte-for-byte identical

## Test plan

- [x] Added `fakeReporter` struct in `orchestrator_test.go` following same pattern as `fakeNotifier`
- [x] Updated all `Run()` and `processIssues()` call sites in tests to pass reporter
- [x] `TestReporter_IssueCompleted` — mock reporter receives `IssueCompleted` with correct params
- [x] `TestReporter_WaveStarted` — mock reporter receives `WaveStarted(2, N)` on second wave
- [x] `TestReporter_RunFinished` — mock reporter receives final summary counts
- [x] `TestReporter_DryRunDoesNotCallReporter` — dry-run mode uses `printDryRun` and does not call any reporter methods
- [x] `TestReporter_LoggerPreserved` — `logger.Info("issue outcome", ...)` still called alongside reporter
- [x] `TestReporter_AllBlockedCalled` — `AllBlocked` called when all issues are blocked
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/progress/ ./internal/orchestrator/ -run TestDryRun|TestCategorize|TestReporter|...` passes

## Implementation Notes

### Approach
Took the described approach of threading `reporter progress.ProgressReporter` through the call chain: `Run()` → `processIssues()` → `handleRollupPR()`. The cmd layer creates `TextReporter(os.Stdout)` and passes it down. All existing behavior is preserved since `TextReporter` writes the same format strings previously used by `fmt.Printf`.

### Key Decisions
- `handleRollupPR()` needed a reporter param too (not explicitly stated in issue but required for `RollupCreated` calls inside it)
- `printSummary()` kept intact — still called from `printDryRun()` for dry-run mode. Only removed from non-dry-run paths (replaced by `reporter.AllBlocked()`)
- `fmt.Println("No issues found in milestone.")` at line 65 (early return path) kept as-is — not mentioned in issue
- `fmt.Printf("Rollup PR warning: %v\n", err)` kept as-is — error path not in scope
- Punchlist file writing in `implement.go` split from stdout: `reporter.PunchlistText(text)` for stdout, `os.WriteFile` for file path
- New test cases use `PRNumber: 0` to avoid triggering the background punchlist goroutine (which requires a real Claude agent)

### Known Limitations
- Existing tests like `TestProcessIssues_WaveReResolution` that return `PRNumber > 0` will hang waiting for Claude agent — this is a pre-existing issue unrelated to this PR
- The `TestReporter_IssueCompleted` test verifies `status: "failed"` rather than `"implemented"` with a specific PR number to avoid the punchlist hang

### Architecture
- `internal/progress/` is in the **foundation** layer (already in `architecture.json`) — no violations
- `orchestration` layer (`internal/orchestrator/`) depends on foundation — valid per architecture rules
- `cmd` layer creates and injects `TextReporter` — correct top-down dependency wiring
- No layer violations introduced

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)