### PR TITLE
feat(tui): add issue table component (#443)

### DIFF
--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -1,0 +1,38 @@
+package tui
+
+// IssueStartedMsg is sent when the orchestrator begins processing an issue.
+type IssueStartedMsg struct {
+	Number int
+	Title  string
+}
+
+// IssueStageChangedMsg is sent when an in-progress issue transitions to a new stage.
+type IssueStageChangedMsg struct {
+	Number int
+	Stage  string
+}
+
+// IssueCompletedMsg is sent when an issue reaches a terminal state.
+type IssueCompletedMsg struct {
+	Number   int
+	Title    string
+	Status   string
+	PRNumber int
+	Retries  int
+	ErrMsg   string
+}
+
+// WaveStartedMsg is sent when a new dependency re-resolution wave begins.
+type WaveStartedMsg struct {
+	Wave  int
+	Count int
+}
+
+// RunFinishedMsg is sent when the full run completes with final aggregate counts.
+type RunFinishedMsg struct {
+	Implemented      int
+	ReadyToMerge     int
+	NeedsHumanReview int
+	Failed           int
+	Blocked          int
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -14,13 +15,13 @@ type autoMerge struct {
 // Model is the root Bubble Tea model for the dark-factory TUI.
 //
 // It holds run metadata displayed in the header chrome, aggregate issue counts
-// displayed in the summary bar, and terminal dimensions for layout calculations.
-// Dynamic issue-table content is added in a subsequent issue (#443).
+// displayed in the summary bar, an issue table with per-row state, and
+// terminal dimensions for layout calculations.
 type Model struct {
 	// Run metadata — populated via Update messages.
-	repo      string
-	milestone string
-	timestamp string
+	repo       string
+	milestone  string
+	timestamp  string
 	baseBranch string
 	autoMerge  *autoMerge
 
@@ -31,6 +32,13 @@ type Model struct {
 	failed    int
 	totalCost float64
 
+	// Issue table state.
+	issues     []issueRow
+	issueIndex map[int]int // issue number → index in issues slice
+
+	// Spinner for in-progress rows.
+	spinner spinner.Model
+
 	// Terminal dimensions.
 	width  int
 	height int
@@ -39,29 +47,69 @@ type Model struct {
 // Compile-time assertion that Model implements tea.Model.
 var _ tea.Model = Model{}
 
-// Init implements tea.Model. No initial command is needed.
+// Init implements tea.Model. Returns the spinner tick command so animation
+// starts immediately.
 func (m Model) Init() tea.Cmd {
-	return nil
+	return m.spinner.Tick
 }
 
-// Update implements tea.Model. Handles window-size messages and will handle
-// progress messages once they are defined in issue #443.
+// Update implements tea.Model. Handles window-size messages, spinner ticks,
+// and all progress message types.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case IssueStartedMsg:
+		if m.issueIndex == nil {
+			m.issueIndex = make(map[int]int)
+		}
+		m.issueIndex[msg.Number] = len(m.issues)
+		m.issues = append(m.issues, issueRow{
+			number: msg.Number,
+			title:  msg.Title,
+		})
+
+	case IssueStageChangedMsg:
+		if idx, ok := m.issueIndex[msg.Number]; ok {
+			m.issues[idx].stage = msg.Stage
+		}
+
+	case IssueCompletedMsg:
+		if idx, ok := m.issueIndex[msg.Number]; ok {
+			m.issues[idx].status = msg.Status
+			m.issues[idx].prNumber = msg.PRNumber
+			m.issues[idx].retries = msg.Retries
+			m.issues[idx].errMsg = msg.ErrMsg
+		}
+
+	case WaveStartedMsg:
+		// Wave metadata is informational; no per-row state changes here.
+
+	case RunFinishedMsg:
+		// Final counts could update summary bar fields if needed; currently
+		// the summary bar is maintained via individual issue events.
 	}
+
 	return m, nil
 }
 
-// View implements tea.Model. Composes the header, a placeholder for the issue
-// table (added in #443), and the summary bar.
+// View implements tea.Model. Composes the header, issue table, and summary bar.
 func (m Model) View() string {
 	header := renderHeader(m)
+	table := renderTable(m.issues, m.spinner, m.width)
 	summary := renderSummary(m)
-	// Issue table placeholder — replaced in #443.
-	return header + "\n\n" + summary + "\n"
+
+	if table == "" {
+		return header + "\n\n" + summary + "\n"
+	}
+	return header + "\n\n" + table + "\n\n" + summary + "\n"
 }
 
 // New returns a Model pre-populated with run metadata.
@@ -69,11 +117,15 @@ func (m Model) View() string {
 // mergeFeature and mergeRollup may be empty strings when auto-merge is not
 // configured. baseBranch may be empty when using the repository default.
 func New(repo, milestone, timestamp, baseBranch, mergeFeature, mergeRollup string) Model {
+	spin := spinner.New()
+	spin.Spinner = spinner.Dot
+
 	m := Model{
 		repo:       repo,
 		milestone:  milestone,
 		timestamp:  timestamp,
 		baseBranch: baseBranch,
+		spinner:    spin,
 	}
 	if mergeFeature != "" || mergeRollup != "" {
 		m.autoMerge = &autoMerge{

--- a/internal/tui/table.go
+++ b/internal/tui/table.go
@@ -1,0 +1,124 @@
+package tui
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// issueRow holds all display state for a single issue in the table.
+type issueRow struct {
+	number   int
+	title    string
+	status   string
+	stage    string
+	prNumber int
+	retries  int
+	errMsg   string
+}
+
+// Status marker constants.
+const (
+	markerQueued    = "○"
+	markerCompleted = "■"
+	markerReview    = "●"
+	markerFailed    = "✕"
+)
+
+// Lipgloss styles for status markers.
+var (
+	markerQueuedStyle    = lipgloss.NewStyle().Foreground(colorMuted)
+	markerCompletedStyle = lipgloss.NewStyle().Foreground(colorGreen)
+	markerReviewStyle    = lipgloss.NewStyle().Foreground(colorYellow)
+	markerFailedStyle    = lipgloss.NewStyle().Foreground(colorRed)
+	rowNumberStyle       = lipgloss.NewStyle().Foreground(colorMuted)
+	rowTitleStyle        = lipgloss.NewStyle().Foreground(colorBright)
+	rowStageStyle        = lipgloss.NewStyle().Foreground(colorMuted)
+	rowErrStyle          = lipgloss.NewStyle().Foreground(colorRed)
+)
+
+// renderTable composes all issue rows into a single styled string.
+//
+// The spin argument supplies the current spinner frame used for in-progress
+// rows (status == "" with a stage set). width controls title truncation.
+func renderTable(rows []issueRow, spin spinner.Model, width int) string {
+	if len(rows) == 0 {
+		return ""
+	}
+
+	var out string
+	for i, row := range rows {
+		out += renderRow(row, spin, width)
+		if i < len(rows)-1 {
+			out += "\n"
+		}
+	}
+	return out
+}
+
+// renderRow renders a single issue row.
+func renderRow(row issueRow, spin spinner.Model, width int) string {
+	marker := markerFor(row, spin)
+	num := rowNumberStyle.Render(fmt.Sprintf("#%d", row.number))
+
+	// Reserve space for: marker(1) + space(1) + "#NNN"(≤6) + space(1) + stage(≤10) + space(1) = ~20
+	// Approximate title column width from terminal width.
+	titleWidth := width - 22
+	if titleWidth < 10 {
+		titleWidth = 10
+	}
+	title := rowTitleStyle.Render(truncate(row.title, titleWidth))
+
+	var stagePart string
+	if row.stage != "" {
+		stagePart = " " + rowStageStyle.Render(row.stage)
+	}
+
+	line := marker + " " + num + " " + title + stagePart
+
+	if row.errMsg != "" {
+		line += " " + rowErrStyle.Render(row.errMsg)
+	}
+
+	return line
+}
+
+// markerFor returns the styled status marker for a row.
+//
+// State machine:
+//   - terminal status "implemented"/"merged" → green ■
+//   - terminal status "ready-to-merge"       → yellow ●
+//   - terminal status "needs-human-review"   → yellow ●
+//   - terminal status "failed"               → red ✕
+//   - in-progress (no status, stage set)     → spinner frame
+//   - queued (no status, no stage)           → dim ○
+func markerFor(row issueRow, spin spinner.Model) string {
+	switch row.status {
+	case "implemented", "merged":
+		return markerCompletedStyle.Render(markerCompleted)
+	case "ready-to-merge", "needs-human-review":
+		return markerReviewStyle.Render(markerReview)
+	case "failed":
+		return markerFailedStyle.Render(markerFailed)
+	default:
+		// No terminal status: distinguish in-progress (stage set) from queued.
+		if row.stage != "" {
+			return spin.View()
+		}
+		return markerQueuedStyle.Render(markerQueued)
+	}
+}
+
+// truncate shortens s to at most maxWidth runes, replacing the last rune with
+// "…" if truncation occurs.
+func truncate(s string, maxWidth int) string {
+	runes := []rune(s)
+	if len(runes) <= maxWidth {
+		return s
+	}
+	if maxWidth <= 0 {
+		return "…"
+	}
+	return string(runes[:maxWidth-1]) + "…"
+}

--- a/internal/tui/table_test.go
+++ b/internal/tui/table_test.go
@@ -1,0 +1,312 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+)
+
+// newTestSpinner returns a spinner.Model suitable for testing (no animation needed).
+func newTestSpinner() spinner.Model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	return s
+}
+
+// --- truncate tests ---
+
+func TestTruncateShortString(t *testing.T) {
+	t.Helper()
+	got := truncate("hello", 10)
+	if got != "hello" {
+		t.Errorf("truncate short: got %q, want %q", got, "hello")
+	}
+}
+
+func TestTruncateExactLength(t *testing.T) {
+	got := truncate("hello", 5)
+	if got != "hello" {
+		t.Errorf("truncate exact: got %q, want %q", got, "hello")
+	}
+}
+
+func TestTruncateLongTitle(t *testing.T) {
+	// 120-character title, 80-column terminal.
+	// titleWidth = 80 - 22 = 58 runes, so truncation applies.
+	title := strings.Repeat("a", 120)
+	width := 80
+	titleWidth := width - 22
+
+	got := truncate(title, titleWidth)
+	runes := []rune(got)
+
+	if len(runes) > titleWidth {
+		t.Errorf("truncate long: result has %d runes, want ≤%d", len(runes), titleWidth)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncate long: result %q does not end with ellipsis", got)
+	}
+}
+
+func TestTruncateZeroWidth(t *testing.T) {
+	got := truncate("hello", 0)
+	if got != "…" {
+		t.Errorf("truncate zero width: got %q, want %q", got, "…")
+	}
+}
+
+// --- markerFor tests ---
+
+func TestMarkerQueued(t *testing.T) {
+	row := issueRow{number: 1, title: "fix bug"}
+	spin := newTestSpinner()
+	got := stripANSI(markerFor(row, spin))
+	if got != markerQueued {
+		t.Errorf("markerFor queued: got %q, want %q", got, markerQueued)
+	}
+}
+
+func TestMarkerInProgress(t *testing.T) {
+	row := issueRow{number: 1, title: "fix bug", stage: "implement"}
+	spin := newTestSpinner()
+	// The spinner view is not the queued marker.
+	got := stripANSI(markerFor(row, spin))
+	if got == markerQueued {
+		t.Errorf("markerFor in-progress: should not be queued marker %q", markerQueued)
+	}
+}
+
+func TestMarkerCompleted(t *testing.T) {
+	row := issueRow{number: 1, title: "fix bug", status: "implemented", stage: "merged"}
+	spin := newTestSpinner()
+	got := stripANSI(markerFor(row, spin))
+	if got != markerCompleted {
+		t.Errorf("markerFor completed: got %q, want %q", got, markerCompleted)
+	}
+}
+
+func TestMarkerReadyToMerge(t *testing.T) {
+	row := issueRow{number: 1, title: "fix bug", status: "ready-to-merge", stage: "review"}
+	spin := newTestSpinner()
+	got := stripANSI(markerFor(row, spin))
+	if got != markerReview {
+		t.Errorf("markerFor ready-to-merge: got %q, want %q", got, markerReview)
+	}
+}
+
+func TestMarkerNeedsHumanReview(t *testing.T) {
+	row := issueRow{number: 1, title: "fix bug", status: "needs-human-review"}
+	spin := newTestSpinner()
+	got := stripANSI(markerFor(row, spin))
+	if got != markerReview {
+		t.Errorf("markerFor needs-human-review: got %q, want %q", got, markerReview)
+	}
+}
+
+func TestMarkerFailed(t *testing.T) {
+	row := issueRow{number: 1, title: "fix bug", status: "failed", stage: "failed"}
+	spin := newTestSpinner()
+	got := stripANSI(markerFor(row, spin))
+	if got != markerFailed {
+		t.Errorf("markerFor failed: got %q, want %q", got, markerFailed)
+	}
+}
+
+// --- renderTable tests ---
+
+func TestRenderTableEmpty(t *testing.T) {
+	spin := newTestSpinner()
+	got := renderTable(nil, spin, 80)
+	if got != "" {
+		t.Errorf("renderTable empty: got %q, want empty string", got)
+	}
+}
+
+func TestRenderTableQueuedRow(t *testing.T) {
+	rows := []issueRow{
+		{number: 42, title: "fix the bug"},
+	}
+	spin := newTestSpinner()
+	got := stripANSI(renderTable(rows, spin, 80))
+
+	if !strings.Contains(got, markerQueued) {
+		t.Errorf("renderTable queued: marker %q not found in %q", markerQueued, got)
+	}
+	if !strings.Contains(got, "#42") {
+		t.Errorf("renderTable queued: issue number not found in %q", got)
+	}
+	if !strings.Contains(got, "fix the bug") {
+		t.Errorf("renderTable queued: title not found in %q", got)
+	}
+}
+
+func TestRenderTableInProgressRowShowsStage(t *testing.T) {
+	rows := []issueRow{
+		{number: 42, title: "fix the bug", stage: "implement"},
+	}
+	spin := newTestSpinner()
+	got := stripANSI(renderTable(rows, spin, 80))
+
+	// In-progress: should contain the stage label.
+	if !strings.Contains(got, "implement") {
+		t.Errorf("renderTable in-progress: stage label not found in %q", got)
+	}
+	// Should not show queued marker.
+	if strings.Contains(got, markerQueued) {
+		t.Errorf("renderTable in-progress: queued marker %q should not appear in %q", markerQueued, got)
+	}
+}
+
+func TestRenderTableCompletedRow(t *testing.T) {
+	rows := []issueRow{
+		{number: 42, title: "fix the bug", status: "implemented", stage: "merged"},
+	}
+	spin := newTestSpinner()
+	got := stripANSI(renderTable(rows, spin, 80))
+
+	if !strings.Contains(got, markerCompleted) {
+		t.Errorf("renderTable completed: marker %q not found in %q", markerCompleted, got)
+	}
+}
+
+func TestRenderTableFailedRow(t *testing.T) {
+	rows := []issueRow{
+		{number: 42, title: "fix the bug", status: "failed", stage: "failed", errMsg: "timeout"},
+	}
+	spin := newTestSpinner()
+	got := stripANSI(renderTable(rows, spin, 80))
+
+	if !strings.Contains(got, markerFailed) {
+		t.Errorf("renderTable failed: marker %q not found in %q", markerFailed, got)
+	}
+	if !strings.Contains(got, "timeout") {
+		t.Errorf("renderTable failed: errMsg not found in %q", got)
+	}
+}
+
+func TestRenderTableTitleTruncation(t *testing.T) {
+	title := strings.Repeat("x", 120)
+	rows := []issueRow{
+		{number: 1, title: title},
+	}
+	spin := newTestSpinner()
+	got := stripANSI(renderTable(rows, spin, 80))
+
+	if !strings.Contains(got, "…") {
+		t.Errorf("renderTable truncation: expected ellipsis in %q", got)
+	}
+	if strings.Contains(got, strings.Repeat("x", 120)) {
+		t.Errorf("renderTable truncation: full 120-char title should be truncated")
+	}
+}
+
+// --- Model Update message handler tests ---
+
+func TestModelIssueStartedMsg(t *testing.T) {
+	m := New("repo", "ms", "ts", "", "", "")
+	next, _ := m.Update(IssueStartedMsg{Number: 42, Title: "fix the bug"})
+	updated := next.(Model)
+
+	if len(updated.issues) != 1 {
+		t.Fatalf("IssueStartedMsg: expected 1 issue, got %d", len(updated.issues))
+	}
+	if updated.issues[0].number != 42 {
+		t.Errorf("IssueStartedMsg: issue number: got %d, want 42", updated.issues[0].number)
+	}
+	if updated.issues[0].title != "fix the bug" {
+		t.Errorf("IssueStartedMsg: title: got %q, want %q", updated.issues[0].title, "fix the bug")
+	}
+	if updated.issueIndex[42] != 0 {
+		t.Errorf("IssueStartedMsg: issueIndex[42]: got %d, want 0", updated.issueIndex[42])
+	}
+}
+
+func TestModelIssueStageChangedMsg(t *testing.T) {
+	m := New("repo", "ms", "ts", "", "", "")
+
+	// First start an issue.
+	next, _ := m.Update(IssueStartedMsg{Number: 42, Title: "fix the bug"})
+	m = next.(Model)
+
+	// Then change its stage.
+	next, _ = m.Update(IssueStageChangedMsg{Number: 42, Stage: "verify"})
+	updated := next.(Model)
+
+	idx := updated.issueIndex[42]
+	if updated.issues[idx].stage != "verify" {
+		t.Errorf("IssueStageChangedMsg: stage: got %q, want %q", updated.issues[idx].stage, "verify")
+	}
+}
+
+func TestModelIssueCompletedMsg(t *testing.T) {
+	m := New("repo", "ms", "ts", "", "", "")
+
+	next, _ := m.Update(IssueStartedMsg{Number: 42, Title: "fix the bug"})
+	m = next.(Model)
+	next, _ = m.Update(IssueStageChangedMsg{Number: 42, Stage: "implement"})
+	m = next.(Model)
+	next, _ = m.Update(IssueCompletedMsg{
+		Number:   42,
+		Title:    "fix the bug",
+		Status:   "implemented",
+		PRNumber: 100,
+		Retries:  1,
+		ErrMsg:   "",
+	})
+	updated := next.(Model)
+
+	idx := updated.issueIndex[42]
+	if updated.issues[idx].status != "implemented" {
+		t.Errorf("IssueCompletedMsg: status: got %q, want %q", updated.issues[idx].status, "implemented")
+	}
+	if updated.issues[idx].prNumber != 100 {
+		t.Errorf("IssueCompletedMsg: prNumber: got %d, want 100", updated.issues[idx].prNumber)
+	}
+}
+
+func TestModelStageChangedUnknownIssue(t *testing.T) {
+	// Should not panic or add rows for unknown issue numbers.
+	m := New("repo", "ms", "ts", "", "", "")
+	next, _ := m.Update(IssueStageChangedMsg{Number: 999, Stage: "verify"})
+	updated := next.(Model)
+	if len(updated.issues) != 0 {
+		t.Errorf("IssueStageChangedMsg unknown: expected 0 issues, got %d", len(updated.issues))
+	}
+}
+
+func TestModelMultipleIssues(t *testing.T) {
+	m := New("repo", "ms", "ts", "", "", "")
+
+	next, _ := m.Update(IssueStartedMsg{Number: 10, Title: "issue ten"})
+	m = next.(Model)
+	next, _ = m.Update(IssueStartedMsg{Number: 20, Title: "issue twenty"})
+	m = next.(Model)
+
+	if len(m.issues) != 2 {
+		t.Fatalf("multiple issues: expected 2, got %d", len(m.issues))
+	}
+	if m.issueIndex[10] != 0 {
+		t.Errorf("issueIndex[10]: got %d, want 0", m.issueIndex[10])
+	}
+	if m.issueIndex[20] != 1 {
+		t.Errorf("issueIndex[20]: got %d, want 1", m.issueIndex[20])
+	}
+}
+
+// --- Model View table integration ---
+
+func TestModelViewContainsTable(t *testing.T) {
+	m := New("repo", "ms", "ts", "", "", "")
+	next, _ := m.Update(IssueStartedMsg{Number: 42, Title: "fix the bug"})
+	m = next.(Model)
+	m.width = 80
+
+	got := stripANSI(m.View())
+	if !strings.Contains(got, "#42") {
+		t.Errorf("View with issue: #42 not found in %q", got)
+	}
+	if !strings.Contains(got, "fix the bug") {
+		t.Errorf("View with issue: title not found in %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/tui/messages.go` with all Bubble Tea message types for progress events (`IssueStartedMsg`, `IssueStageChangedMsg`, `IssueCompletedMsg`, `WaveStartedMsg`, `RunFinishedMsg`)
- Adds `internal/tui/table.go` with `issueRow` struct, `renderTable()` with Lip Gloss styled status markers, Bubbles spinner for in-progress animation, and `truncate()` for terminal-width-aware title truncation
- Extends `internal/tui/model.go` with `issues []issueRow`, `issueIndex map[int]int`, `spinner.Model`, message handlers in `Update()`, and table composition in `View()`

## Test plan

- [x] All existing model tests pass (`TestRenderHeader*`, `TestRenderSummary*`, `TestModelUpdate*`, `TestNew*`)
- [x] Queued row: renders `○` marker
- [x] In-progress row: stage `"implement"` renders spinner (not queued marker), stage label visible
- [x] Completed row: status `"implemented"` renders `■` marker
- [x] Failed row: status `"failed"` renders `✕` marker with errMsg
- [x] Stage update: `IssueStageChangedMsg{Number: 42, Stage: "verify"}` changes stage correctly
- [x] Title truncation: 120-char title in 80-col terminal truncated with `…`
- [x] `go build ./...` clean

## Implementation Notes

### Approach
Describe what approach you took and why.

Implemented the three deliverables in dependency order: message types first (standalone), then table rendering, then model extension. The `issueIndex map[int]int` provides O(1) row lookup for stage and completion updates arriving by issue number.

### Key Decisions
List any non-obvious decisions or trade-offs made during implementation.

- **Spinner always ticking**: `Init()` returns `spinner.Tick` unconditionally so the spinner is always animating. This is simpler and harmless — the spinner view is only surfaced in `renderRow` when a row has an active stage.
- **`issueIndex` lazy init**: initialized on first `IssueStartedMsg` rather than in `New()` to keep the zero-value `Model{}` valid (as required by existing tests that use `Model{}` directly).
- **Title truncation uses rune counting**: `[]rune(s)` rather than byte indexing to handle non-ASCII characters correctly.
- **`WaveStartedMsg` and `RunFinishedMsg`** are handled in the switch (no-op for now) to satisfy the interface contract and prevent fall-through; a future issue can populate wave labels or update aggregate counts.

### Known Limitations
Note anything incomplete, deferred, or that the reviewer should be aware of.

- The summary bar counts (`merged`, `inReview`, `queued`, `failed`) are not updated by the new message handlers — they were already in the model from #442 and are presumably updated by a separate reporter adapter (issue #444). `RunFinishedMsg` could populate them but deferred to keep scope tight.
- `tui.go` still carries a blank `_ "github.com/charmbracelet/bubbles/list"` import from #442's scaffolding. Not removed here since it's out of scope for this issue.

### Architecture
Describe which layers were touched and how dependencies were respected (per architecture rules above).

- `internal/tui/` is the **presentation** layer (registered in `docs/architecture.json`).
- Only external charm packages (`bubbletea`, `lipgloss`, `bubbles/spinner`) are imported — no internal layer imports, fully respecting the presentation layer's `must_not_depend_on` constraints.

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)