### PR TITLE
feat(tui): TUI progress reporter implementation (#444)

### DIFF
--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -36,3 +36,21 @@ type RunFinishedMsg struct {
 	Failed           int
 	Blocked          int
 }
+
+// RunStartedMsg is sent when a run begins, carrying header metadata.
+type RunStartedMsg struct {
+	Repo         string
+	Milestone    string
+	Timestamp    string
+	BaseBranch   string
+	MergeFeature string
+	MergeRollup  string
+	IssueCount   int
+}
+
+// RollupCreatedMsg is sent when a rollup PR is created and optionally merged.
+type RollupCreatedMsg struct {
+	PRNumber int
+	PRURL    string
+	Merged   bool
+}

--- a/internal/tui/reporter.go
+++ b/internal/tui/reporter.go
@@ -1,0 +1,92 @@
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/phs/dark-factory/internal/progress"
+)
+
+// sender is a private interface over *tea.Program to allow unit testing without
+// a real terminal or event loop.
+type sender interface {
+	Send(msg tea.Msg)
+}
+
+// TUIReporter implements progress.ProgressReporter by dispatching Bubble Tea
+// messages to the running program. It is created in the cmd layer once the
+// tea.Program is initialised, and passed to the orchestrator as a ProgressReporter.
+type TUIReporter struct {
+	p sender
+}
+
+// Compile-time assertion that TUIReporter implements progress.ProgressReporter.
+var _ progress.ProgressReporter = (*TUIReporter)(nil)
+
+// NewTUIReporter returns a TUIReporter that sends messages to p.
+func NewTUIReporter(p *tea.Program) *TUIReporter {
+	return &TUIReporter{p: p}
+}
+
+// RunStarted sends RunStartedMsg with run header metadata.
+func (r *TUIReporter) RunStarted(repo, milestone, timestamp, baseBranch, mergeFeature, mergeRollup string, issueCount int) {
+	r.p.Send(RunStartedMsg{
+		Repo:         repo,
+		Milestone:    milestone,
+		Timestamp:    timestamp,
+		BaseBranch:   baseBranch,
+		MergeFeature: mergeFeature,
+		MergeRollup:  mergeRollup,
+		IssueCount:   issueCount,
+	})
+}
+
+// IssueStarted sends IssueStartedMsg when the orchestrator begins an issue.
+func (r *TUIReporter) IssueStarted(issueNumber int, title string) {
+	r.p.Send(IssueStartedMsg{Number: issueNumber, Title: title})
+}
+
+// IssueStageChanged sends IssueStageChangedMsg on a stage transition.
+func (r *TUIReporter) IssueStageChanged(issueNumber int, stage string) {
+	r.p.Send(IssueStageChangedMsg{Number: issueNumber, Stage: stage})
+}
+
+// IssueCompleted sends IssueCompletedMsg with the terminal outcome for an issue.
+func (r *TUIReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string) {
+	r.p.Send(IssueCompletedMsg{
+		Number:   issueNumber,
+		Title:    title,
+		Status:   status,
+		PRNumber: prNumber,
+		Retries:  retries,
+		ErrMsg:   errMsg,
+	})
+}
+
+// WaveStarted sends WaveStartedMsg when a new dependency wave begins.
+func (r *TUIReporter) WaveStarted(wave, count int) {
+	r.p.Send(WaveStartedMsg{Wave: wave, Count: count})
+}
+
+// AllBlocked sends RunFinishedMsg with all issues counted as blocked.
+func (r *TUIReporter) AllBlocked(total, blocked int) {
+	r.p.Send(RunFinishedMsg{Blocked: total})
+}
+
+// RollupCreated sends RollupCreatedMsg with PR details and merge status.
+func (r *TUIReporter) RollupCreated(prNumber int, prURL string, merged bool) {
+	r.p.Send(RollupCreatedMsg{PRNumber: prNumber, PRURL: prURL, Merged: merged})
+}
+
+// RunFinished sends RunFinishedMsg with the final aggregate counts.
+func (r *TUIReporter) RunFinished(implemented, readyToMerge, needsHumanReview, failed, blocked int) {
+	r.p.Send(RunFinishedMsg{
+		Implemented:      implemented,
+		ReadyToMerge:     readyToMerge,
+		NeedsHumanReview: needsHumanReview,
+		Failed:           failed,
+		Blocked:          blocked,
+	})
+}
+
+// PunchlistText is a no-op in TUI mode. The punchlist is written to a file;
+// the TUI does not display it inline.
+func (r *TUIReporter) PunchlistText(text string) {}

--- a/internal/tui/reporter_test.go
+++ b/internal/tui/reporter_test.go
@@ -1,0 +1,215 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// mockSender records every message passed to Send so tests can assert on them.
+type mockSender struct {
+	msgs []tea.Msg
+}
+
+func (m *mockSender) Send(msg tea.Msg) {
+	m.msgs = append(m.msgs, msg)
+}
+
+func newTestReporter() (*TUIReporter, *mockSender) {
+	s := &mockSender{}
+	return &TUIReporter{p: s}, s
+}
+
+func TestIssueStartedSendsMessage(t *testing.T) {
+	r, s := newTestReporter()
+	r.IssueStarted(42, "add endpoint")
+
+	if len(s.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(s.msgs))
+	}
+	msg, ok := s.msgs[0].(IssueStartedMsg)
+	if !ok {
+		t.Fatalf("expected IssueStartedMsg, got %T", s.msgs[0])
+	}
+	if msg.Number != 42 {
+		t.Errorf("Number: got %d, want 42", msg.Number)
+	}
+	if msg.Title != "add endpoint" {
+		t.Errorf("Title: got %q, want %q", msg.Title, "add endpoint")
+	}
+}
+
+func TestIssueStageChangedSendsMessage(t *testing.T) {
+	r, s := newTestReporter()
+	r.IssueStageChanged(7, "reviewing")
+
+	if len(s.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(s.msgs))
+	}
+	msg, ok := s.msgs[0].(IssueStageChangedMsg)
+	if !ok {
+		t.Fatalf("expected IssueStageChangedMsg, got %T", s.msgs[0])
+	}
+	if msg.Number != 7 {
+		t.Errorf("Number: got %d, want 7", msg.Number)
+	}
+	if msg.Stage != "reviewing" {
+		t.Errorf("Stage: got %q, want %q", msg.Stage, "reviewing")
+	}
+}
+
+func TestIssueCompletedSendsMessage(t *testing.T) {
+	r, s := newTestReporter()
+	r.IssueCompleted(42, "add endpoint", "implemented", 87, 0, "")
+
+	if len(s.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(s.msgs))
+	}
+	msg, ok := s.msgs[0].(IssueCompletedMsg)
+	if !ok {
+		t.Fatalf("expected IssueCompletedMsg, got %T", s.msgs[0])
+	}
+	if msg.Number != 42 {
+		t.Errorf("Number: got %d, want 42", msg.Number)
+	}
+	if msg.Title != "add endpoint" {
+		t.Errorf("Title: got %q, want %q", msg.Title, "add endpoint")
+	}
+	if msg.Status != "implemented" {
+		t.Errorf("Status: got %q, want %q", msg.Status, "implemented")
+	}
+	if msg.PRNumber != 87 {
+		t.Errorf("PRNumber: got %d, want 87", msg.PRNumber)
+	}
+	if msg.Retries != 0 {
+		t.Errorf("Retries: got %d, want 0", msg.Retries)
+	}
+	if msg.ErrMsg != "" {
+		t.Errorf("ErrMsg: got %q, want %q", msg.ErrMsg, "")
+	}
+}
+
+func TestWaveStartedSendsMessage(t *testing.T) {
+	r, s := newTestReporter()
+	r.WaveStarted(2, 5)
+
+	if len(s.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(s.msgs))
+	}
+	msg, ok := s.msgs[0].(WaveStartedMsg)
+	if !ok {
+		t.Fatalf("expected WaveStartedMsg, got %T", s.msgs[0])
+	}
+	if msg.Wave != 2 {
+		t.Errorf("Wave: got %d, want 2", msg.Wave)
+	}
+	if msg.Count != 5 {
+		t.Errorf("Count: got %d, want 5", msg.Count)
+	}
+}
+
+func TestRunFinishedSendsMessage(t *testing.T) {
+	r, s := newTestReporter()
+	r.RunFinished(3, 1, 0, 1, 2)
+
+	if len(s.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(s.msgs))
+	}
+	msg, ok := s.msgs[0].(RunFinishedMsg)
+	if !ok {
+		t.Fatalf("expected RunFinishedMsg, got %T", s.msgs[0])
+	}
+	if msg.Implemented != 3 {
+		t.Errorf("Implemented: got %d, want 3", msg.Implemented)
+	}
+	if msg.ReadyToMerge != 1 {
+		t.Errorf("ReadyToMerge: got %d, want 1", msg.ReadyToMerge)
+	}
+	if msg.NeedsHumanReview != 0 {
+		t.Errorf("NeedsHumanReview: got %d, want 0", msg.NeedsHumanReview)
+	}
+	if msg.Failed != 1 {
+		t.Errorf("Failed: got %d, want 1", msg.Failed)
+	}
+	if msg.Blocked != 2 {
+		t.Errorf("Blocked: got %d, want 2", msg.Blocked)
+	}
+}
+
+func TestAllBlockedSendsRunFinishedMsg(t *testing.T) {
+	r, s := newTestReporter()
+	r.AllBlocked(10, 10)
+
+	if len(s.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(s.msgs))
+	}
+	msg, ok := s.msgs[0].(RunFinishedMsg)
+	if !ok {
+		t.Fatalf("expected RunFinishedMsg, got %T", s.msgs[0])
+	}
+	if msg.Blocked != 10 {
+		t.Errorf("Blocked: got %d, want 10", msg.Blocked)
+	}
+	if msg.Implemented != 0 || msg.ReadyToMerge != 0 || msg.NeedsHumanReview != 0 || msg.Failed != 0 {
+		t.Errorf("expected all non-Blocked counts to be 0, got %+v", msg)
+	}
+}
+
+func TestRunStartedSendsMessage(t *testing.T) {
+	r, s := newTestReporter()
+	r.RunStarted("owner/repo", "v1.0", "2026-03-14T10:00:00Z", "main", "feat", "rollup", 5)
+
+	if len(s.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(s.msgs))
+	}
+	msg, ok := s.msgs[0].(RunStartedMsg)
+	if !ok {
+		t.Fatalf("expected RunStartedMsg, got %T", s.msgs[0])
+	}
+	if msg.Repo != "owner/repo" {
+		t.Errorf("Repo: got %q, want %q", msg.Repo, "owner/repo")
+	}
+	if msg.Milestone != "v1.0" {
+		t.Errorf("Milestone: got %q, want %q", msg.Milestone, "v1.0")
+	}
+	if msg.IssueCount != 5 {
+		t.Errorf("IssueCount: got %d, want 5", msg.IssueCount)
+	}
+	if msg.MergeFeature != "feat" {
+		t.Errorf("MergeFeature: got %q, want %q", msg.MergeFeature, "feat")
+	}
+	if msg.MergeRollup != "rollup" {
+		t.Errorf("MergeRollup: got %q, want %q", msg.MergeRollup, "rollup")
+	}
+}
+
+func TestRollupCreatedSendsMessage(t *testing.T) {
+	r, s := newTestReporter()
+	r.RollupCreated(99, "https://github.com/owner/repo/pull/99", true)
+
+	if len(s.msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(s.msgs))
+	}
+	msg, ok := s.msgs[0].(RollupCreatedMsg)
+	if !ok {
+		t.Fatalf("expected RollupCreatedMsg, got %T", s.msgs[0])
+	}
+	if msg.PRNumber != 99 {
+		t.Errorf("PRNumber: got %d, want 99", msg.PRNumber)
+	}
+	if msg.PRURL != "https://github.com/owner/repo/pull/99" {
+		t.Errorf("PRURL: got %q", msg.PRURL)
+	}
+	if !msg.Merged {
+		t.Errorf("Merged: got false, want true")
+	}
+}
+
+func TestPunchlistTextIsNoOp(t *testing.T) {
+	r, s := newTestReporter()
+	r.PunchlistText("some punchlist content")
+
+	if len(s.msgs) != 0 {
+		t.Errorf("PunchlistText should send no messages, got %d", len(s.msgs))
+	}
+}


### PR DESCRIPTION
Closes #444

## Implementation Notes

### Approach
Implemented `TUIReporter` as a thin adapter between the `progress.ProgressReporter` interface and the Bubble Tea message loop. Each reporter method constructs the corresponding message struct and calls `p.Send()`. The struct holds a private `sender` interface rather than `*tea.Program` directly, enabling unit testing without a real terminal or event loop, while the public constructor `NewTUIReporter(p *tea.Program)` satisfies the issue spec exactly.

### Key Decisions
- **`sender` interface**: Introduced a private `type sender interface { Send(msg tea.Msg) }` so tests can inject a `mockSender` without needing a real `tea.Program`. The public API still accepts `*tea.Program` as specified.
- **`RunStartedMsg` and `RollupCreatedMsg` added to `messages.go`**: These two types were absent from the `#443` spec but required by `#444`. Their fields mirror the `ProgressReporter` method signatures directly.
- **`AllBlocked` mapping**: Sends `RunFinishedMsg{Blocked: total}` with all other counts zero, per the issue spec ("all counts as blocked").
- **`PunchlistText` no-op**: Empty method body with a comment explaining why — punchlist goes to file, not the terminal UI.
- **Compile-time interface assertion**: `var _ progress.ProgressReporter = (*TUIReporter)(nil)` catches any drift from the interface.

### Known Limitations
- `RunStartedMsg` is dispatched by `RunStarted()` but `model.go`'s `Update()` does not yet handle it (no `case RunStartedMsg:` switch arm). That is intentional — the model wires up these messages in a separate issue. The reporter's job is only to send.
- Same applies to `RollupCreatedMsg`: the model has no handler yet.

### Architecture
- **Layer touched**: `presentation` (`internal/tui/`)
- **New dependency**: `internal/progress` (foundation layer) — allowed per `presentation → may_depend_on: [domain, foundation]`
- **No imports from**: orchestration, service, infrastructure, content — constraint satisfied
- `internal/tui/reporter.go` imports only `github.com/charmbracelet/bubbletea` (external) and `internal/progress` (foundation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)