### PR TITLE
feat(agent): emit IssueStageChanged calls in ProcessIssue

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -119,6 +119,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	// Optional recon step: gather context before implementation.
 	reconBrief := ""
 	if prompts.Recon != "" {
+		if reporter != nil {
+			reporter.IssueStageChanged(issue.Number, "recon")
+		}
 		reconResult, reconErr := Recon(ctx, issue, cfg, prompts, authEnv, logger)
 		var reconWriteHook func(rundata.StepResult) error
 		if hook != nil {
@@ -129,6 +132,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		reconBrief = handleNonBlockingResult(reconResult, reconErr, "recon agent", logger, reconWriteHook)
 	}
 
+	if reporter != nil {
+		reporter.IssueStageChanged(issue.Number, "implement")
+	}
 	implResult, err := Implement(ctx, issue, cfg, prompts, authEnv, logger, reconBrief)
 	if err != nil {
 		outcome.Status = StatusFailed
@@ -208,6 +214,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	fixCycles := 0
 
 	// Step 3.5: Verify. Runs between guard rails and quality review.
+	if reporter != nil {
+		reporter.IssueStageChanged(issue.Number, "verify")
+	}
 	if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles); verifyErr != nil {
 		outcome.Status = StatusFailed
 		outcome.Err = verifyErr
@@ -216,7 +225,10 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 
 	// Step 4: Quality review gate (if prompt is configured).
 	if prompts.QualityReviewer != "" {
-		passed, err := runQualityReviewCycle(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles)
+		if reporter != nil {
+			reporter.IssueStageChanged(issue.Number, "review")
+		}
+		passed, err := runQualityReviewCycle(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles, reporter)
 		if err != nil {
 			outcome.Status = StatusFailed
 			outcome.Err = err
@@ -239,8 +251,11 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	}
 
 	// Step 5: Review/retry loop.
+	if reporter != nil {
+		reporter.IssueStageChanged(issue.Number, "review")
+	}
 	outcome.Status, _, outcome.Retries, outcome.Err = runFunctionalReviewCycle(
-		ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles, hasSpec,
+		ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles, hasSpec, reporter,
 	)
 	return outcome
 }
@@ -531,6 +546,7 @@ func runQualityReviewCycle(
 	hook RunDataHook,
 	sessionID *string,
 	fixCycles *int,
+	reporter progress.ProgressReporter,
 ) (bool, error) {
 	qualityMaxAttempts := cfg.MaxRetries + 1
 	for qAttempt := 0; qAttempt < qualityMaxAttempts; qAttempt++ {
@@ -579,6 +595,9 @@ func runQualityReviewCycle(
 				qualityHandoff = assembleHandoffContext(cfg.Repo, prNum, logger)
 			}
 
+			if reporter != nil {
+				reporter.IssueStageChanged(issue.Number, "implement")
+			}
 			retryResult, err := Retry(ctx, issue, prNum, "", "", qualityHandoff, cfg, prompts, authEnv, logger)
 			if err != nil {
 				return false, fmt.Errorf("retry agent (quality): %w", err)
@@ -631,6 +650,7 @@ func runFunctionalReviewCycle(
 	sessionID *string,
 	fixCycles *int,
 	hasSpec bool,
+	reporter progress.ProgressReporter,
 ) (status OutcomeStatus, prMerged bool, retries int, err error) {
 	if hook != nil {
 		if err := hook.WriteIssueStatus(issue.Number, rundata.IssueStatus{Status: "in_review"}); err != nil {
@@ -887,6 +907,9 @@ func runFunctionalReviewCycle(
 				handoff = assembleHandoffContext(cfg.Repo, prNum, logger)
 			}
 
+			if reporter != nil {
+				reporter.IssueStageChanged(issue.Number, "implement")
+			}
 			retryResult, err := Retry(ctx, issue, prNum, *sessionID, "", handoff, cfg, prompts, authEnv, logger)
 			if err != nil {
 				return StatusFailed, false, 0, fmt.Errorf("retry agent: %w", err)

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -4511,6 +4511,7 @@ func TestRunQualityReviewCycle_ApprovedFirstTry(t *testing.T) {
 		nil,
 		&sessionID,
 		&fixCycles,
+		nil,
 	)
 
 	if !passed {
@@ -4562,6 +4563,7 @@ func TestRunQualityReviewCycle_ApprovedAfterRetry(t *testing.T) {
 		nil,
 		&sessionID,
 		&fixCycles,
+		nil,
 	)
 
 	if !passed {
@@ -4611,6 +4613,7 @@ func TestRunQualityReviewCycle_ExhaustsRetries(t *testing.T) {
 		nil,
 		&sessionID,
 		&fixCycles,
+		nil,
 	)
 
 	if passed {
@@ -4673,6 +4676,7 @@ func TestRunQualityReviewCycle_DriftDuringQuality(t *testing.T) {
 		nil,
 		&sessionID,
 		&fixCycles,
+		nil,
 	)
 
 	if passed {
@@ -4683,5 +4687,151 @@ func TestRunQualityReviewCycle_DriftDuringQuality(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "protected path drift") {
 		t.Errorf("err = %q, want to contain %q", err.Error(), "protected path drift")
+	}
+}
+
+// mockReporter records IssueStageChanged calls for assertion in stage-emission tests.
+// All other ProgressReporter methods are no-ops.
+type mockReporter struct {
+	stageChanges []struct {
+		number int
+		stage  string
+	}
+}
+
+func (r *mockReporter) IssueStageChanged(number int, stage string) {
+	r.stageChanges = append(r.stageChanges, struct {
+		number int
+		stage  string
+	}{number, stage})
+}
+func (r *mockReporter) RunStarted(_, _, _, _, _, _ string, _ int) {}
+func (r *mockReporter) IssueStarted(_ int, _ string)              {}
+func (r *mockReporter) IssueCompleted(_ int, _ string, _ string, _, _ int, _ string) {
+}
+func (r *mockReporter) WaveStarted(_, _ int)              {}
+func (r *mockReporter) AllBlocked(_, _ int)               {}
+func (r *mockReporter) RollupCreated(_ int, _ string, _ bool) {}
+func (r *mockReporter) RunFinished(_, _, _, _, _ int)     {}
+func (r *mockReporter) PunchlistText(_ string)            {}
+
+func (r *mockReporter) hasStageChange(number int, stage string) bool {
+	for _, sc := range r.stageChanges {
+		if sc.number == number && sc.stage == stage {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *mockReporter) countStageChanges(stage string) int {
+	count := 0
+	for _, sc := range r.stageChanges {
+		if sc.stage == stage {
+			count++
+		}
+	}
+	return count
+}
+
+func TestProcessIssue_ImplementStageEmitted(t *testing.T) {
+	setupLoopTest(t, []string{
+		"implementer output",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	reporter := &mockReporter{}
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil, reporter)
+
+	if !reporter.hasStageChange(loopIssue().Number, "implement") {
+		t.Errorf("IssueStageChanged(%d, %q) was not called", loopIssue().Number, "implement")
+	}
+}
+
+func TestProcessIssue_VerifyStageEmitted(t *testing.T) {
+	setupLoopTest(t, []string{
+		"implementer output",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	reporter := &mockReporter{}
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil, reporter)
+
+	if !reporter.hasStageChange(loopIssue().Number, "verify") {
+		t.Errorf("IssueStageChanged(%d, %q) was not called", loopIssue().Number, "verify")
+	}
+}
+
+func TestProcessIssue_ReviewStageEmitted(t *testing.T) {
+	setupLoopTest(t, []string{
+		"implementer output",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	reporter := &mockReporter{}
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil, reporter)
+
+	if !reporter.hasStageChange(loopIssue().Number, "review") {
+		t.Errorf("IssueStageChanged(%d, %q) was not called", loopIssue().Number, "review")
+	}
+}
+
+func TestProcessIssue_ReconStageEmitted(t *testing.T) {
+	setupLoopTest(t, []string{
+		"recon output",
+		"implementer output",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	prompts := testPrompts(t)
+	prompts.Recon = "recon prompt"
+
+	reporter := &mockReporter{}
+	ProcessIssue(context.Background(), loopIssue(), loopConfig(), prompts, nil, testLogger(t), nil, reporter)
+
+	if !reporter.hasStageChange(loopIssue().Number, "recon") {
+		t.Errorf("IssueStageChanged(%d, %q) was not called when recon is configured", loopIssue().Number, "recon")
+	}
+}
+
+func TestProcessIssue_NilReporterSafe(t *testing.T) {
+	setupLoopTest(t, []string{
+		"implementer output",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	// Should not panic with nil reporter.
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil, nil)
+	if outcome.Status != StatusImplemented {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, StatusImplemented, outcome.Err)
+	}
+}
+
+func TestProcessIssue_RetryReentersImplementStage(t *testing.T) {
+	// Agent outputs: implementer, quality(APPROVED), reviewer(CHANGES), retry, reviewer(APPROVED)
+	setupLoopTest(t, []string{
+		"implementer output",
+		"AGENT_RESULT=APPROVED",
+		"AGENT_RESULT=CHANGES_REQUESTED",
+		"retry output",
+		"AGENT_RESULT=APPROVED",
+	}, loopGuardFn)
+
+	reporter := &mockReporter{}
+	outcome := ProcessIssue(context.Background(), loopIssue(), loopConfig(), testPrompts(t), nil, testLogger(t), nil, reporter)
+
+	if outcome.Status != StatusImplemented {
+		t.Errorf("Status = %q, want %q (err: %v)", outcome.Status, StatusImplemented, outcome.Err)
+	}
+
+	// "implement" should be emitted at least twice: once for initial implement, once for retry.
+	count := reporter.countStageChanges("implement")
+	if count < 2 {
+		t.Errorf("IssueStageChanged(_, %q) called %d time(s), want at least 2 (initial + retry)", "implement", count)
 	}
 }


### PR DESCRIPTION
## Summary

- Calls `reporter.IssueStageChanged()` at each major step in `ProcessIssue`: recon, implement, verify, review
- Threads reporter into `runQualityReviewCycle` and `runFunctionalReviewCycle` to emit `"implement"` before each retry
- Guards all calls with `if reporter != nil` for nil-safety (existing tests pass nil)
- Adds 6 new tests covering all acceptance criteria from issue #470

## Test plan

- [x] `TestProcessIssue_ImplementStageEmitted` — mock reporter receives `IssueStageChanged(5, "implement")` before implement runs
- [x] `TestProcessIssue_VerifyStageEmitted` — mock reporter receives `IssueStageChanged(5, "verify")` before verify runs
- [x] `TestProcessIssue_ReviewStageEmitted` — mock reporter receives `IssueStageChanged(5, "review")` before review runs
- [x] `TestProcessIssue_ReconStageEmitted` — mock reporter receives `IssueStageChanged(5, "recon")` when recon is configured
- [x] `TestProcessIssue_NilReporterSafe` — nil reporter completes without panic
- [x] `TestProcessIssue_RetryReentersImplementStage` — retry emits `IssueStageChanged(5, "implement")` again
- [x] All existing tests pass unchanged (nil reporter path)

## Implementation Notes

### Approach
Added `reporter progress.ProgressReporter` parameter to the two private helper functions (`runQualityReviewCycle` and `runFunctionalReviewCycle`) that contain `Retry(...)` calls. All emission points guard with `if reporter != nil`. Existing tests pass `nil` and remain unchanged except for the updated call sites with the new argument.

### Key Decisions
- **Reporter threaded, not closed over**: Added as an explicit parameter to helpers rather than using a closure, keeping with the project's explicit-over-implicit convention.
- **Both quality and functional retry emit "implement"**: Ensures the TUI reflects re-entering the implement stage regardless of which review cycle triggers the retry.
- **Verify always emits**: `runVerifyPhase` is always called at line 211, so `"verify"` stage is emitted unconditionally before it. This matches the issue spec.
- **Recon stage emitted inside `if prompts.Recon != ""`**: Only fires when recon is actually configured, as required.

### Known Limitations
- The re-run of `runVerifyPhase` inside `runQualityReviewCycle` (after quality-gate retry) does not re-emit `"verify"`. This is consistent with the issue spec which does not require re-emission on re-entry within cycles.

### Architecture
Only `internal/agent/` (orchestration layer) was touched. It consumes `progress.ProgressReporter` from `internal/progress/` (foundation layer) — an already-valid dependency per `docs/architecture.json`. No new imports were added; the package already imported `internal/progress`.

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)