### PR TITLE
feat(analysis): add duration trends by step metric (#466)

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -15,6 +15,13 @@ type Report struct {
 	RetryStats      RetryStats      `json:"retry_stats"`
 	VerifyStats     map[string]int  `json:"verify_stats"`
 	CostStats       CostStats       `json:"cost_stats"`
+	DurationStats   DurationStats   `json:"duration_stats"`
+}
+
+// DurationStats holds aggregate step duration statistics.
+type DurationStats struct {
+	AvgImplementSeconds float64 `json:"avg_implement_seconds"` // average across all issues
+	AvgReviewSeconds    float64 `json:"avg_review_seconds"`    // average across all issues
 }
 
 // FlagFrequency records how often a quality flag code appears across all issues.
@@ -61,6 +68,7 @@ func Aggregate(runs []rundata.RunDetail) Report {
 	var maxRetries int
 	var totalCost float64
 	var retriedSucceeded int
+	var totalImplementDuration, totalReviewDuration float64
 
 	for _, run := range runs {
 		for _, issue := range run.Issues {
@@ -101,6 +109,10 @@ func Aggregate(runs []rundata.RunDetail) Report {
 			// Cost statistics from all step results.
 			totalCost += accumulateIssueCosts(report.CostStats.CostByStep, issue)
 
+			// Duration statistics from implement and quality-review steps.
+			totalImplementDuration += issue.Implement.DurationSeconds
+			totalReviewDuration += issue.QualityReview.DurationSeconds
+
 			// Verify step failure counts by check name.
 			for _, vr := range issue.VerifyResults {
 				for _, check := range vr.Checks {
@@ -128,6 +140,12 @@ func Aggregate(runs []rundata.RunDetail) Report {
 		report.CostStats.AvgPerIssueUSD = totalCost / float64(report.IssueCount)
 	}
 	report.CostStats.AvgPerRunUSD = totalCost / float64(report.RunCount)
+
+	// Populate duration stats.
+	if report.IssueCount > 0 {
+		report.DurationStats.AvgImplementSeconds = totalImplementDuration / float64(report.IssueCount)
+		report.DurationStats.AvgReviewSeconds = totalReviewDuration / float64(report.IssueCount)
+	}
 
 	// Build flag frequencies sorted by count descending, then code ascending for stability.
 	report.FlagFrequencies = buildFlagFrequencies(flagCounts, report.IssueCount)

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -525,6 +525,61 @@ func TestAggregateCostByStepMultipleSteps(t *testing.T) {
 	}
 }
 
+func TestAggregateDurationStats(t *testing.T) {
+	// Two issues with known durations across two runs.
+	// Issue 1: implement 300s, review 120s
+	// Issue 2: implement 600s, review 0s (missing)
+	// Total implement: 900s, total review: 120s, issue count: 2
+	// AvgImplementSeconds = 450.0, AvgReviewSeconds = 60.0
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Implement:     rundata.StepResult{DurationSeconds: 300.0},
+					QualityReview: rundata.StepResult{DurationSeconds: 120.0},
+				},
+			},
+		},
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Implement: rundata.StepResult{DurationSeconds: 600.0},
+					// QualityReview has no duration — defaults to 0.0
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if !nearlyEqual(got.DurationStats.AvgImplementSeconds, 450.0, 0.001) {
+		t.Errorf("DurationStats.AvgImplementSeconds = %f, want 450.0", got.DurationStats.AvgImplementSeconds)
+	}
+	if !nearlyEqual(got.DurationStats.AvgReviewSeconds, 60.0, 0.001) {
+		t.Errorf("DurationStats.AvgReviewSeconds = %f, want 60.0", got.DurationStats.AvgReviewSeconds)
+	}
+}
+
+func TestAggregateDurationStatsNoData(t *testing.T) {
+	// No duration data — both averages are 0.0, not NaN.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{}, // no step data
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if got.DurationStats.AvgImplementSeconds != 0.0 {
+		t.Errorf("DurationStats.AvgImplementSeconds = %f, want 0.0", got.DurationStats.AvgImplementSeconds)
+	}
+	if got.DurationStats.AvgReviewSeconds != 0.0 {
+		t.Errorf("DurationStats.AvgReviewSeconds = %f, want 0.0", got.DurationStats.AvgReviewSeconds)
+	}
+}
+
 func TestAggregateCostByStepRecon(t *testing.T) {
 	// Recon cost should be tracked and included in total.
 	runs := []rundata.RunDetail{

--- a/internal/analysis/trends.go
+++ b/internal/analysis/trends.go
@@ -10,14 +10,16 @@ import (
 // TrendPoint represents one data point in a time series, corresponding
 // to a single run.
 type TrendPoint struct {
-	Timestamp          time.Time `json:"timestamp"`
-	Repo               string    `json:"repo"`
-	Milestone          string    `json:"milestone"`
-	IssueCount         int       `json:"issue_count"`
-	SuccessRate        float64   `json:"success_rate"` // 0.0–1.0
-	AvgRetries         float64   `json:"avg_retries"`
-	TotalCostUSD       float64   `json:"total_cost_usd"`
-	AvgCostPerIssueUSD float64   `json:"avg_cost_per_issue_usd"`
+	Timestamp            time.Time `json:"timestamp"`
+	Repo                 string    `json:"repo"`
+	Milestone            string    `json:"milestone"`
+	IssueCount           int       `json:"issue_count"`
+	SuccessRate          float64   `json:"success_rate"` // 0.0–1.0
+	AvgRetries           float64   `json:"avg_retries"`
+	TotalCostUSD         float64   `json:"total_cost_usd"`
+	AvgCostPerIssueUSD   float64   `json:"avg_cost_per_issue_usd"`
+	AvgImplementDuration float64   `json:"avg_implement_duration"` // seconds
+	AvgReviewDuration    float64   `json:"avg_review_duration"`    // seconds
 }
 
 // ComputeTrends returns one TrendPoint per run, sorted chronologically
@@ -35,7 +37,7 @@ func ComputeTrends(runs []rundata.RunDetail) []TrendPoint {
 
 		issueCount := len(run.Issues)
 		var implemented, totalRetries int
-		var totalCost float64
+		var totalCost, totalImplementDuration, totalReviewDuration float64
 
 		for _, issue := range run.Issues {
 			if issue.Outcome.Status == "implemented" {
@@ -52,24 +54,31 @@ func ComputeTrends(runs []rundata.RunDetail) []TrendPoint {
 				totalCost += retry.QualityReview.CostUSD
 				totalCost += retry.FunctionalReview.CostUSD
 			}
+
+			totalImplementDuration += issue.Implement.DurationSeconds
+			totalReviewDuration += issue.QualityReview.DurationSeconds
 		}
 
-		var successRate, avgRetries, avgCostPerIssue float64
+		var successRate, avgRetries, avgCostPerIssue, avgImplementDuration, avgReviewDuration float64
 		if issueCount > 0 {
 			successRate = float64(implemented) / float64(issueCount)
 			avgRetries = float64(totalRetries) / float64(issueCount)
 			avgCostPerIssue = totalCost / float64(issueCount)
+			avgImplementDuration = totalImplementDuration / float64(issueCount)
+			avgReviewDuration = totalReviewDuration / float64(issueCount)
 		}
 
 		points = append(points, TrendPoint{
-			Timestamp:          run.StartedAt,
-			Repo:               run.Repo,
-			Milestone:          run.Milestone,
-			IssueCount:         issueCount,
-			SuccessRate:        successRate,
-			AvgRetries:         avgRetries,
-			TotalCostUSD:       totalCost,
-			AvgCostPerIssueUSD: avgCostPerIssue,
+			Timestamp:            run.StartedAt,
+			Repo:                 run.Repo,
+			Milestone:            run.Milestone,
+			IssueCount:           issueCount,
+			SuccessRate:          successRate,
+			AvgRetries:           avgRetries,
+			TotalCostUSD:         totalCost,
+			AvgCostPerIssueUSD:   avgCostPerIssue,
+			AvgImplementDuration: avgImplementDuration,
+			AvgReviewDuration:    avgReviewDuration,
 		})
 	}
 

--- a/internal/analysis/trends_test.go
+++ b/internal/analysis/trends_test.go
@@ -170,6 +170,136 @@ func TestComputeTrendsAllUnfinishedReturnsNil(t *testing.T) {
 	}
 }
 
+func TestComputeTrendsDurationSingleRun(t *testing.T) {
+	// One run with implement at 300s, review at 120s — trend point shows 300.0 and 120.0.
+	finishedAt := time.Now()
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{FinishedAt: &finishedAt},
+			Issues: []rundata.IssueDetail{
+				{
+					Implement:     rundata.StepResult{DurationSeconds: 300.0},
+					QualityReview: rundata.StepResult{DurationSeconds: 120.0},
+				},
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 1 {
+		t.Fatalf("len(ComputeTrends) = %d, want 1", len(got))
+	}
+	if !nearlyEqual(got[0].AvgImplementDuration, 300.0, 0.001) {
+		t.Errorf("AvgImplementDuration = %f, want 300.0", got[0].AvgImplementDuration)
+	}
+	if !nearlyEqual(got[0].AvgReviewDuration, 120.0, 0.001) {
+		t.Errorf("AvgReviewDuration = %f, want 120.0", got[0].AvgReviewDuration)
+	}
+}
+
+func TestComputeTrendsDurationMultipleRuns(t *testing.T) {
+	// Two runs with different durations — trends show values per run in chronological order.
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{StartedAt: t2, FinishedAt: ptr(t2)},
+			Issues: []rundata.IssueDetail{
+				{
+					Implement:     rundata.StepResult{DurationSeconds: 600.0},
+					QualityReview: rundata.StepResult{DurationSeconds: 240.0},
+				},
+			},
+		},
+		{
+			RunMeta: rundata.RunMeta{StartedAt: t1, FinishedAt: ptr(t1)},
+			Issues: []rundata.IssueDetail{
+				{
+					Implement:     rundata.StepResult{DurationSeconds: 300.0},
+					QualityReview: rundata.StepResult{DurationSeconds: 120.0},
+				},
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 2 {
+		t.Fatalf("len(ComputeTrends) = %d, want 2", len(got))
+	}
+	// Sorted chronologically: t1 first.
+	if !nearlyEqual(got[0].AvgImplementDuration, 300.0, 0.001) {
+		t.Errorf("got[0].AvgImplementDuration = %f, want 300.0", got[0].AvgImplementDuration)
+	}
+	if !nearlyEqual(got[0].AvgReviewDuration, 120.0, 0.001) {
+		t.Errorf("got[0].AvgReviewDuration = %f, want 120.0", got[0].AvgReviewDuration)
+	}
+	if !nearlyEqual(got[1].AvgImplementDuration, 600.0, 0.001) {
+		t.Errorf("got[1].AvgImplementDuration = %f, want 600.0", got[1].AvgImplementDuration)
+	}
+	if !nearlyEqual(got[1].AvgReviewDuration, 240.0, 0.001) {
+		t.Errorf("got[1].AvgReviewDuration = %f, want 240.0", got[1].AvgReviewDuration)
+	}
+}
+
+func TestComputeTrendsDurationNoStepData(t *testing.T) {
+	// Missing duration data produces 0.0 (not NaN or error).
+	finishedAt := time.Now()
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{FinishedAt: &finishedAt},
+			Issues: []rundata.IssueDetail{
+				{}, // no step data — DurationSeconds defaults to 0.0
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 1 {
+		t.Fatalf("len(ComputeTrends) = %d, want 1", len(got))
+	}
+	if got[0].AvgImplementDuration != 0.0 {
+		t.Errorf("AvgImplementDuration = %f, want 0.0", got[0].AvgImplementDuration)
+	}
+	if got[0].AvgReviewDuration != 0.0 {
+		t.Errorf("AvgReviewDuration = %f, want 0.0", got[0].AvgReviewDuration)
+	}
+}
+
+func TestComputeTrendsDurationMultipleIssuesAverage(t *testing.T) {
+	// Two issues with different durations — result is the average.
+	finishedAt := time.Now()
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{FinishedAt: &finishedAt},
+			Issues: []rundata.IssueDetail{
+				{
+					Implement:     rundata.StepResult{DurationSeconds: 200.0},
+					QualityReview: rundata.StepResult{DurationSeconds: 80.0},
+				},
+				{
+					Implement:     rundata.StepResult{DurationSeconds: 400.0},
+					QualityReview: rundata.StepResult{DurationSeconds: 160.0},
+				},
+			},
+		},
+	}
+
+	got := ComputeTrends(runs)
+
+	if len(got) != 1 {
+		t.Fatalf("len(ComputeTrends) = %d, want 1", len(got))
+	}
+	if !nearlyEqual(got[0].AvgImplementDuration, 300.0, 0.001) {
+		t.Errorf("AvgImplementDuration = %f, want 300.0 (average of 200 and 400)", got[0].AvgImplementDuration)
+	}
+	if !nearlyEqual(got[0].AvgReviewDuration, 120.0, 0.001) {
+		t.Errorf("AvgReviewDuration = %f, want 120.0 (average of 80 and 160)", got[0].AvgReviewDuration)
+	}
+}
+
 func TestComputeTrendsMetaFields(t *testing.T) {
 	finishedAt := time.Now()
 	ts := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)

--- a/internal/cmd/analyze.go
+++ b/internal/cmd/analyze.go
@@ -342,6 +342,11 @@ func printAnalyzeReport(w io.Writer, report analysis.Report, gaps []analysis.Pro
 		_ = tw.Flush()
 	}
 
+	// Duration stats.
+	fmt.Fprintf(w, "\nDuration Stats\n")
+	fmt.Fprintf(w, "  Avg implement duration: %s\n", formatDuration(report.DurationStats.AvgImplementSeconds))
+	fmt.Fprintf(w, "  Avg review duration:    %s\n", formatDuration(report.DurationStats.AvgReviewSeconds))
+
 	// Prompt gaps.
 	fmt.Fprintf(w, "\nPrompt Gaps\n")
 	if len(gaps) == 0 {
@@ -353,4 +358,16 @@ func printAnalyzeReport(w io.Writer, report analysis.Report, gaps []analysis.Pro
 			fmt.Fprintf(w, "    fail rate without: %.1f%% (%d samples)\n", g.FailRateWithout*100, g.SamplesWithout)
 		}
 	}
+}
+
+// formatDuration formats a duration in seconds as a human-readable string (e.g. "5m00s").
+func formatDuration(seconds float64) string {
+	total := int(seconds)
+	h := total / 3600
+	m := (total % 3600) / 60
+	s := total % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh%02dm%02ds", h, m, s)
+	}
+	return fmt.Sprintf("%dm%02ds", m, s)
 }

--- a/internal/cmd/analyze_test.go
+++ b/internal/cmd/analyze_test.go
@@ -44,6 +44,28 @@ func writeRunDir(t *testing.T, base, owner, repo string, meta rundata.RunMeta, o
 	}
 }
 
+// issueWithSteps bundles an issue outcome with its step result files.
+type issueWithSteps struct {
+	Outcome       rundata.Outcome
+	Implement     rundata.StepResult
+	QualityReview rundata.StepResult
+}
+
+// writeRunDirWithSteps creates a run directory with run.json, per-issue outcome files,
+// and per-issue step result files (implement.json, quality-review.json).
+func writeRunDirWithSteps(t *testing.T, base, owner, repo string, meta rundata.RunMeta, issues []issueWithSteps) {
+	t.Helper()
+	timestamp := meta.StartedAt.UTC().Format("20060102-150405")
+	runDir := filepath.Join(base, owner, repo, timestamp)
+	writeJSONFile(t, filepath.Join(runDir, "run.json"), meta)
+	for _, iss := range issues {
+		issueDir := filepath.Join(runDir, "issues", fmt.Sprintf("%d", iss.Outcome.IssueNumber))
+		writeJSONFile(t, filepath.Join(issueDir, "outcome.json"), iss.Outcome)
+		writeJSONFile(t, filepath.Join(issueDir, "implement.json"), iss.Implement)
+		writeJSONFile(t, filepath.Join(issueDir, "quality-review.json"), iss.QualityReview)
+	}
+}
+
 // analyzeWithReader calls runAnalyze with a reader rooted at base and returns stdout.
 func analyzeWithReader(t *testing.T, base, repo, milestone, sinceStr, untilStr string, jsonOut bool) (string, error) {
 	t.Helper()
@@ -153,6 +175,7 @@ func TestAnalyzeFullReport(t *testing.T) {
 		"Flag Frequencies",
 		"Retry Stats",
 		"Cost Stats",
+		"Duration Stats",
 		"Prompt Gaps",
 	} {
 		if !strings.Contains(out, want) {
@@ -628,5 +651,87 @@ func TestAnalyzeDB_CostFromSteps(t *testing.T) {
 
 	if result.Report.CostStats.TotalUSD != 0.42 {
 		t.Errorf("TotalUSD = %v, want 0.42", result.Report.CostStats.TotalUSD)
+	}
+}
+
+// TestAnalyzeDurationOutput: Duration Stats section appears in CLI output with correct format.
+func TestAnalyzeDurationOutput(t *testing.T) {
+	base := t.TempDir()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	meta := rundata.RunMeta{
+		Repo:         "owner/repo",
+		Milestone:    "Phase 1",
+		IssueNumbers: []int{1},
+		StartedAt:    ts,
+	}
+	writeRunDirWithSteps(t, base, "owner", "repo", meta, []issueWithSteps{
+		{
+			Outcome:       rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+			Implement:     rundata.StepResult{DurationSeconds: 300.0},
+			QualityReview: rundata.StepResult{DurationSeconds: 120.0},
+		},
+	})
+
+	out, err := analyzeWithReader(t, base, "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "Duration Stats") {
+		t.Errorf("output missing 'Duration Stats' section\nfull output:\n%s", out)
+	}
+	if !strings.Contains(out, "Avg implement duration: 5m00s") {
+		t.Errorf("output missing 'Avg implement duration: 5m00s'\nfull output:\n%s", out)
+	}
+	if !strings.Contains(out, "Avg review duration:    2m00s") {
+		t.Errorf("output missing 'Avg review duration:    2m00s'\nfull output:\n%s", out)
+	}
+}
+
+// TestAnalyzeDB_DurationFromSteps: step duration records flow through to report.
+func TestAnalyzeDB_DurationFromSteps(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	if err := stats.WriteRun(ctx, db, stats.RunRecord{
+		ID: "run-1", Repo: "org/repo", Milestone: "m1", StartedAt: ts,
+	}); err != nil {
+		t.Fatalf("WriteRun: %v", err)
+	}
+	if err := stats.WriteIssueOutcome(ctx, db, stats.IssueOutcomeRecord{
+		RunID: "run-1", IssueNumber: 1, Status: "implemented",
+	}); err != nil {
+		t.Fatalf("WriteIssueOutcome: %v", err)
+	}
+	if err := stats.WriteStepResult(ctx, db, stats.StepResultRecord{
+		RunID: "run-1", IssueNumber: 1, StepName: "implement", DurationSeconds: 300.0,
+	}); err != nil {
+		t.Fatalf("WriteStepResult (implement): %v", err)
+	}
+	if err := stats.WriteStepResult(ctx, db, stats.StepResultRecord{
+		RunID: "run-1", IssueNumber: 1, StepName: "quality-review", DurationSeconds: 120.0,
+	}); err != nil {
+		t.Fatalf("WriteStepResult (quality-review): %v", err)
+	}
+
+	out, err := analyzeWithDB(t, db, "", "", "", "", true)
+	if err != nil {
+		t.Fatalf("analyzeWithDB: %v", err)
+	}
+
+	var result struct {
+		Report analysis.Report `json:"report"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput:\n%s", err, out)
+	}
+
+	if result.Report.DurationStats.AvgImplementSeconds != 300.0 {
+		t.Errorf("DurationStats.AvgImplementSeconds = %v, want 300.0", result.Report.DurationStats.AvgImplementSeconds)
+	}
+	if result.Report.DurationStats.AvgReviewSeconds != 120.0 {
+		t.Errorf("DurationStats.AvgReviewSeconds = %v, want 120.0", result.Report.DurationStats.AvgReviewSeconds)
 	}
 }

--- a/internal/dashboard/templates/analysis.html
+++ b/internal/dashboard/templates/analysis.html
@@ -378,6 +378,15 @@
   <div style="position:relative;height:300px;"><canvas id="chart-cost"></canvas></div>
 </div>
 
+<!-- Duration Trends Chart -->
+<div class="card animate-in animate-in-3">
+  <div class="card__header">
+    <span class="card__title">Duration Trends Over Time</span>
+    <span class="text-muted">Average implement and review step duration per run (seconds)</span>
+  </div>
+  <div style="position:relative;height:300px;"><canvas id="chart-duration"></canvas></div>
+</div>
+
 <script>
 (function initCharts() {
   if (typeof Chart === 'undefined') {
@@ -456,6 +465,77 @@
   makeChart('chart-cost', 'Avg Cost / Issue (USD)',
     function(p) { return +p.avg_cost_per_issue_usd.toFixed(4); }, '#60a5fa',
     { ticks: { color: '#94a3b8', callback: function(v) { return '$' + v; } } });
+
+  // Duration chart: two datasets (implement + review) on one canvas.
+  (function() {
+    var canvas = document.getElementById('chart-duration');
+    if (!canvas) return;
+    var ctx = canvas.getContext('2d');
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            label: 'Implement',
+            data: points.map(function(p) { return +(p.avg_implement_duration || 0).toFixed(1); }),
+            borderColor: '#a78bfa',
+            backgroundColor: '#a78bfa20',
+            fill: true,
+            pointRadius: 5,
+            pointHoverRadius: 7,
+            pointBackgroundColor: '#a78bfa',
+            borderWidth: 2,
+            tension: 0.3
+          },
+          {
+            label: 'Review',
+            data: points.map(function(p) { return +(p.avg_review_duration || 0).toFixed(1); }),
+            borderColor: '#fb7185',
+            backgroundColor: '#fb718520',
+            fill: true,
+            pointRadius: 5,
+            pointHoverRadius: 7,
+            pointBackgroundColor: '#fb7185',
+            borderWidth: 2,
+            tension: 0.3
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: true, labels: { color: '#e2e8f0' } },
+          tooltip: {
+            backgroundColor: '#1e293b',
+            borderColor: '#334155',
+            borderWidth: 1,
+            titleColor: '#e2e8f0',
+            bodyColor: '#e2e8f0',
+            padding: 10,
+            callbacks: {
+              title: function(items) {
+                var p = points[items[0].dataIndex];
+                return (p.repo || '') + (p.milestone ? ' \u2014 ' + p.milestone : '');
+              }
+            }
+          }
+        },
+        scales: {
+          x: {
+            ticks: { color: '#94a3b8', maxRotation: 45, maxTicksLimit: 10, font: { size: 11 } },
+            grid: { color: '#1e293b' }
+          },
+          y: {
+            beginAtZero: true,
+            ticks: { color: '#94a3b8', callback: function(v) { return v + 's'; } },
+            grid: { color: '#1e293b' }
+          }
+        }
+      }
+    });
+  })();
 })();
 </script>
 


### PR DESCRIPTION
## Summary

- Add `AvgImplementDuration` and `AvgReviewDuration` to `TrendPoint` for per-run duration trend data
- Add `DurationStats` aggregate struct to `Report` for CLI summary averages
- Add "Duration Stats" section to `godark analyze` CLI output with human-readable durations (e.g. `5m00s`)
- Add "Duration Trends Over Time" chart to the analysis dashboard with two datasets (implement + review)

## Implementation Notes

### Approach
Added duration tracking at two levels: per-run trend points (in `ComputeTrends`) and aggregate across all runs (in `Aggregate`). The CLI reads from `DurationStats` on `Report`, which flows through the existing `printAnalyzeReport`/`printAnalyzeJSON` paths automatically.

### Key Decisions
- **Two separate levels**: `TrendPoint.AvgImplementDuration` for dashboard trends (per run); `Report.DurationStats` for CLI aggregate (across runs). These serve different consumers.
- **`DurationStats` in `Report` (not computed from `TrendPoint`)**: Cleanest path — avoids requiring `ComputeTrends` to be called from `runAnalyze`; keeps `Aggregate` self-contained.
- **`formatDuration` helper**: Custom formatter produces `5m00s` format (not Go's default `5m0s`) to match the issue's specified CLI output format.
- **Duration chart uses two datasets on one canvas**: More readable than two separate charts; uses a custom chart block instead of `makeChart` (which is single-dataset). Legend is shown so users can distinguish implement vs review.
- **Defensive JS**: `+(p.avg_implement_duration || 0).toFixed(1)` coerces missing fields to 0 for old run data where `omitempty` caused these fields to be absent.

### Known Limitations
- Duration averages across all issues include issues where `DurationSeconds = 0` (missing data). This matches the "no step data → 0.0" acceptance criterion but means sparse data slightly pulls averages down.
- The DB path (`runAnalyzeDB`) aggregates duration via `stats.ToRunDetails` → `Aggregate`, which correctly picks up `DurationSeconds` from `StepResultRecord` via the existing `convert.go` mapping.

### Architecture
Touched layers:
- **domain** (`internal/analysis`): `TrendPoint`, `Report`, `DurationStats`, `ComputeTrends`, `Aggregate` — pure business logic, no new dependencies
- **cmd** (`internal/cmd`): `printAnalyzeReport`, `formatDuration` — depends on domain only
- **presentation** (`internal/dashboard`): template-only change, no Go handler changes needed (new `TrendPoint` fields flow through `toJSON .Trends` automatically)

No layer violations introduced. All changes stay within the allowed dependency graph.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)