### PR TITLE
feat: add duration breakdown by step to analyze and dashboard

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -29,8 +29,9 @@ type RepoSummary struct {
 
 // DurationStats holds aggregate step duration statistics.
 type DurationStats struct {
-	AvgImplementSeconds float64 `json:"avg_implement_seconds"` // average across all issues
-	AvgReviewSeconds    float64 `json:"avg_review_seconds"`    // average across all issues
+	AvgImplementSeconds float64            `json:"avg_implement_seconds"` // average across all issues
+	AvgReviewSeconds    float64            `json:"avg_review_seconds"`    // average across all issues
+	DurationByStep      map[string]float64 `json:"duration_by_step"`      // step name to total seconds
 }
 
 // FlagFrequency records how often a quality flag code appears across all issues.
@@ -105,6 +106,7 @@ func (a *issueAcc) add(report *Report, repo string, issue rundata.IssueDetail) {
 	}
 
 	a.totalCost += accumulateIssueCosts(report.CostStats.CostByStep, issue)
+	accumulateIssueDurations(report.DurationStats.DurationByStep, issue)
 	a.totalImplementDuration += issue.Implement.DurationSeconds
 	a.totalReviewDuration += issue.QualityReview.DurationSeconds
 
@@ -147,6 +149,7 @@ func Aggregate(runs []rundata.RunDetail) Report {
 		RepoStats:   make(map[string]RepoSummary),
 	}
 	report.CostStats.CostByStep = make(map[string]float64)
+	report.DurationStats.DurationByStep = make(map[string]float64)
 
 	acc := issueAcc{flagCounts: make(map[string]int)}
 
@@ -228,6 +231,29 @@ func collectFlags(flagCounts map[string]int, flags []rundata.Flag) {
 func accumulateStepCost(costByStep map[string]float64, step string, cost float64) {
 	if cost > 0 {
 		costByStep[step] += cost
+	}
+}
+
+// accumulateStepDuration adds duration to the named step's entry in durationByStep.
+// Zero duration values are ignored so the map only contains steps that ran.
+func accumulateStepDuration(durationByStep map[string]float64, step string, duration float64) {
+	if duration > 0 {
+		durationByStep[step] += duration
+	}
+}
+
+// accumulateIssueDurations records per-step durations for a single issue into durationByStep.
+// Note: VerifyStepResult does not have a DurationSeconds field so verify duration is not tracked.
+func accumulateIssueDurations(durationByStep map[string]float64, issue rundata.IssueDetail) {
+	accumulateStepDuration(durationByStep, "recon", issue.Recon.DurationSeconds)
+	accumulateStepDuration(durationByStep, "spec-generator", issue.SpecGenerator.DurationSeconds)
+	accumulateStepDuration(durationByStep, "implement", issue.Implement.DurationSeconds)
+	accumulateStepDuration(durationByStep, "quality-review", issue.QualityReview.DurationSeconds)
+	accumulateStepDuration(durationByStep, "functional-review", issue.FunctionalReview.DurationSeconds)
+	for _, retry := range issue.Retries {
+		accumulateStepDuration(durationByStep, "retries", retry.Retry.DurationSeconds)
+		accumulateStepDuration(durationByStep, "retries", retry.QualityReview.DurationSeconds)
+		accumulateStepDuration(durationByStep, "retries", retry.FunctionalReview.DurationSeconds)
 	}
 }
 

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -697,3 +697,146 @@ func TestAggregateRepoStatsMultiple(t *testing.T) {
 		t.Errorf("beta.SuccessRate = %f, want 0.5", beta.SuccessRate)
 	}
 }
+
+func TestAggregateDurationByStepZeroDuration(t *testing.T) {
+	// No duration data — DurationByStep should be an empty (non-nil) map.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: "implemented"}},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if got.DurationStats.DurationByStep == nil {
+		t.Error("DurationStats.DurationByStep is nil, want empty map")
+	}
+	if len(got.DurationStats.DurationByStep) != 0 {
+		t.Errorf("DurationStats.DurationByStep = %v, want empty map", got.DurationStats.DurationByStep)
+	}
+}
+
+func TestAggregateDurationByStepSingleStep(t *testing.T) {
+	// Only implement steps present — implement should be 100%.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{Implement: rundata.StepResult{DurationSeconds: 420.0}},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if !nearlyEqual(got.DurationStats.DurationByStep["implement"], 420.0, 0.0001) {
+		t.Errorf("DurationByStep[implement] = %f, want 420.0", got.DurationStats.DurationByStep["implement"])
+	}
+	// Other steps should not appear.
+	if v, ok := got.DurationStats.DurationByStep["quality-review"]; ok && v != 0 {
+		t.Errorf("DurationByStep[quality-review] = %f, want 0 or absent", v)
+	}
+	// With one step, that step is 100% of total.
+	var total float64
+	for _, secs := range got.DurationStats.DurationByStep {
+		total += secs
+	}
+	if !nearlyEqual(total, 420.0, 0.0001) {
+		t.Errorf("total DurationByStep = %f, want 420.0", total)
+	}
+}
+
+func TestAggregateDurationByStepMultipleSteps(t *testing.T) {
+	// Implement 420s, quality-review 180s — percentages ~70%, ~30%.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Implement:     rundata.StepResult{DurationSeconds: 420.0},
+					QualityReview: rundata.StepResult{DurationSeconds: 180.0},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if !nearlyEqual(got.DurationStats.DurationByStep["implement"], 420.0, 0.0001) {
+		t.Errorf("DurationByStep[implement] = %f, want 420.0", got.DurationStats.DurationByStep["implement"])
+	}
+	if !nearlyEqual(got.DurationStats.DurationByStep["quality-review"], 180.0, 0.0001) {
+		t.Errorf("DurationByStep[quality-review] = %f, want 180.0", got.DurationStats.DurationByStep["quality-review"])
+	}
+
+	// Percentages should sum to ~100%.
+	var total float64
+	for _, secs := range got.DurationStats.DurationByStep {
+		total += secs
+	}
+	if !nearlyEqual(total, 600.0, 0.0001) {
+		t.Errorf("total DurationByStep = %f, want 600.0", total)
+	}
+	var sumPct float64
+	for _, secs := range got.DurationStats.DurationByStep {
+		sumPct += secs / total * 100
+	}
+	if !nearlyEqual(sumPct, 100.0, 0.1) {
+		t.Errorf("sum of percentages = %f, want ~100", sumPct)
+	}
+}
+
+func TestAggregateDurationByStepWithRetries(t *testing.T) {
+	// Retry durations should accumulate under the "retries" key.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Implement: rundata.StepResult{DurationSeconds: 300.0},
+					Retries: []rundata.RetryDetail{
+						{
+							Retry:         rundata.StepResult{DurationSeconds: 60.0},
+							QualityReview: rundata.StepResult{DurationSeconds: 30.0},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if !nearlyEqual(got.DurationStats.DurationByStep["implement"], 300.0, 0.0001) {
+		t.Errorf("DurationByStep[implement] = %f, want 300.0", got.DurationStats.DurationByStep["implement"])
+	}
+	if !nearlyEqual(got.DurationStats.DurationByStep["retries"], 90.0, 0.0001) {
+		t.Errorf("DurationByStep[retries] = %f, want 90.0 (retry 60s + qr 30s)", got.DurationStats.DurationByStep["retries"])
+	}
+}
+
+func TestAggregateDurationByStepRecon(t *testing.T) {
+	// Recon and spec-generator durations should be tracked.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Recon:         rundata.StepResult{DurationSeconds: 20.0},
+					SpecGenerator: rundata.StepResult{DurationSeconds: 10.0},
+					Implement:     rundata.StepResult{DurationSeconds: 300.0},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if !nearlyEqual(got.DurationStats.DurationByStep["recon"], 20.0, 0.0001) {
+		t.Errorf("DurationByStep[recon] = %f, want 20.0", got.DurationStats.DurationByStep["recon"])
+	}
+	if !nearlyEqual(got.DurationStats.DurationByStep["spec-generator"], 10.0, 0.0001) {
+		t.Errorf("DurationByStep[spec-generator] = %f, want 10.0", got.DurationStats.DurationByStep["spec-generator"])
+	}
+	if !nearlyEqual(got.DurationStats.DurationByStep["implement"], 300.0, 0.0001) {
+		t.Errorf("DurationByStep[implement] = %f, want 300.0", got.DurationStats.DurationByStep["implement"])
+	}
+}

--- a/internal/cmd/analyze.go
+++ b/internal/cmd/analyze.go
@@ -316,6 +316,7 @@ func printAnalyzeReport(w io.Writer, report analysis.Report, gaps []analysis.Pro
 	fmt.Fprintf(w, "  Avg implement duration: %s\n", formatDuration(report.DurationStats.AvgImplementSeconds))
 	fmt.Fprintf(w, "  Avg review duration:    %s\n", formatDuration(report.DurationStats.AvgReviewSeconds))
 
+	printDurationByStep(w, report)
 	printRepoStats(w, report)
 	printVerifyStats(w, report)
 	printPromptGaps(w, gaps)
@@ -352,6 +353,43 @@ func printCostByStep(w io.Writer, report analysis.Report) {
 			pct = s.cost / report.CostStats.TotalUSD * 100
 		}
 		fmt.Fprintf(tw, "  %s\t$%.4f\t%.1f%%\n", s.name, s.cost, pct)
+	}
+	_ = tw.Flush()
+}
+
+// printDurationByStep writes the "Duration by Step" section to w.
+func printDurationByStep(w io.Writer, report analysis.Report) {
+	fmt.Fprintf(w, "\nDuration by Step\n")
+	if len(report.DurationStats.DurationByStep) == 0 {
+		fmt.Fprintf(w, "  (no duration data)\n")
+		return
+	}
+	type stepDuration struct {
+		name    string
+		seconds float64
+	}
+	steps := make([]stepDuration, 0, len(report.DurationStats.DurationByStep))
+	var total float64
+	for name, secs := range report.DurationStats.DurationByStep {
+		if secs > 0 {
+			steps = append(steps, stepDuration{name, secs})
+			total += secs
+		}
+	}
+	sort.Slice(steps, func(i, j int) bool {
+		if steps[i].seconds != steps[j].seconds {
+			return steps[i].seconds > steps[j].seconds
+		}
+		return steps[i].name < steps[j].name
+	})
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "  Step\tTotal Duration\tPercent\n")
+	for _, s := range steps {
+		var pct float64
+		if total > 0 {
+			pct = s.seconds / total * 100
+		}
+		fmt.Fprintf(tw, "  %s\t%s\t%.1f%%\n", s.name, formatDuration(s.seconds), pct)
 	}
 	_ = tw.Flush()
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -768,6 +768,14 @@ type CostByStepRow struct {
 	Percent float64
 }
 
+// DurationByStepRow is one row in the duration-by-step breakdown table on the analysis page.
+type DurationByStepRow struct {
+	Step     string
+	Seconds  float64
+	Duration string // pre-formatted, e.g. "7m00s"
+	Percent  float64
+}
+
 // VerifyRow is one row in the verify check failures table on the analysis page.
 type VerifyRow struct {
 	Name       string
@@ -797,17 +805,18 @@ type GapView struct {
 
 // AnalysisData is the data passed to the analysis template.
 type AnalysisData struct {
-	Report      analysis.Report
-	Gaps        []GapView
-	Outcomes    []OutcomeRow    // sorted by count desc
-	CostByStep  []CostByStepRow // sorted by cost desc
-	VerifyRows  []VerifyRow     // sorted by count desc, then name asc
-	RepoRows    []RepoRow       // sorted by repo name asc
-	Trends      []analysis.TrendPoint
-	Repos       []string
-	RepoFilter  string
-	HasData     bool
-	HasTrends   bool // true when Trends has at least 2 points
+	Report         analysis.Report
+	Gaps           []GapView
+	Outcomes       []OutcomeRow         // sorted by count desc
+	CostByStep     []CostByStepRow      // sorted by cost desc
+	DurationByStep []DurationByStepRow  // sorted by duration desc
+	VerifyRows     []VerifyRow          // sorted by count desc, then name asc
+	RepoRows       []RepoRow            // sorted by repo name asc
+	Trends         []analysis.TrendPoint
+	Repos          []string
+	RepoFilter     string
+	HasData        bool
+	HasTrends      bool // true when Trends has at least 2 points
 }
 
 func (s *Server) handleAnalysis(w http.ResponseWriter, r *http.Request) {
@@ -892,22 +901,24 @@ func (s *Server) buildAnalysisDataFromDB(ctx context.Context, repoFilter string)
 	trends := analysis.ComputeTrends(runs)
 	outcomes := buildOutcomeRows(report)
 	costByStep := buildCostByStepRows(report)
+	durationByStep := buildDurationByStepRows(report)
 	verifyRows := buildVerifyRows(report)
 	repoRows := buildRepoRows(report)
 	gaps := buildGapViews(rawGaps)
 
 	return &AnalysisData{
-		Report:     report,
-		Gaps:       gaps,
-		Outcomes:   outcomes,
-		CostByStep: costByStep,
-		VerifyRows: verifyRows,
-		RepoRows:   repoRows,
-		Trends:     trends,
-		Repos:      repos,
-		RepoFilter: repoFilter,
-		HasData:    len(runs) > 0,
-		HasTrends:  len(trends) >= 2,
+		Report:         report,
+		Gaps:           gaps,
+		Outcomes:       outcomes,
+		CostByStep:     costByStep,
+		DurationByStep: durationByStep,
+		VerifyRows:     verifyRows,
+		RepoRows:       repoRows,
+		Trends:         trends,
+		Repos:          repos,
+		RepoFilter:     repoFilter,
+		HasData:        len(runs) > 0,
+		HasTrends:      len(trends) >= 2,
 	}, nil
 }
 
@@ -960,22 +971,24 @@ func (s *Server) buildAnalysisDataFromFS(repoFilter string) (*AnalysisData, erro
 	trends := analysis.ComputeTrends(runs)
 	outcomes := buildOutcomeRows(report)
 	costByStep := buildCostByStepRows(report)
+	durationByStep := buildDurationByStepRows(report)
 	verifyRows := buildVerifyRows(report)
 	repoRows := buildRepoRows(report)
 	gaps := buildGapViews(rawGaps)
 
 	return &AnalysisData{
-		Report:     report,
-		Gaps:       gaps,
-		Outcomes:   outcomes,
-		CostByStep: costByStep,
-		VerifyRows: verifyRows,
-		RepoRows:   repoRows,
-		Trends:     trends,
-		Repos:      repos,
-		RepoFilter: repoFilter,
-		HasData:    len(runs) > 0,
-		HasTrends:  len(trends) >= 2,
+		Report:         report,
+		Gaps:           gaps,
+		Outcomes:       outcomes,
+		CostByStep:     costByStep,
+		DurationByStep: durationByStep,
+		VerifyRows:     verifyRows,
+		RepoRows:       repoRows,
+		Trends:         trends,
+		Repos:          repos,
+		RepoFilter:     repoFilter,
+		HasData:        len(runs) > 0,
+		HasTrends:      len(trends) >= 2,
 	}, nil
 }
 
@@ -1041,6 +1054,48 @@ func buildCostByStepRows(report analysis.Report) []CostByStepRow {
 	sort.Slice(rows, func(i, j int) bool {
 		if rows[i].CostUSD != rows[j].CostUSD {
 			return rows[i].CostUSD > rows[j].CostUSD
+		}
+		return rows[i].Step < rows[j].Step
+	})
+	return rows
+}
+
+// buildDurationByStepRows converts the DurationByStep map in a Report to a sorted slice with
+// pre-computed percentages and pre-formatted duration strings, ready for template rendering.
+func buildDurationByStepRows(report analysis.Report) []DurationByStepRow {
+	rows := make([]DurationByStepRow, 0, len(report.DurationStats.DurationByStep))
+	var total float64
+	for _, secs := range report.DurationStats.DurationByStep {
+		total += secs
+	}
+	for step, secs := range report.DurationStats.DurationByStep {
+		if secs <= 0 {
+			continue
+		}
+		var pct float64
+		if total > 0 {
+			pct = secs / total * 100
+		}
+		dur := time.Duration(secs * float64(time.Second))
+		h := int(dur.Hours())
+		m := int(dur.Minutes()) % 60
+		s := int(dur.Seconds()) % 60
+		var formatted string
+		if h > 0 {
+			formatted = fmt.Sprintf("%dh%02dm%02ds", h, m, s)
+		} else {
+			formatted = fmt.Sprintf("%dm%02ds", m, s)
+		}
+		rows = append(rows, DurationByStepRow{
+			Step:     step,
+			Seconds:  secs,
+			Duration: formatted,
+			Percent:  pct,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Seconds != rows[j].Seconds {
+			return rows[i].Seconds > rows[j].Seconds
 		}
 		return rows[i].Step < rows[j].Step
 	})

--- a/internal/dashboard/templates/analysis.html
+++ b/internal/dashboard/templates/analysis.html
@@ -302,6 +302,43 @@
   {{end}}
 </div>
 
+<!-- Duration by Step -->
+<div class="card animate-in animate-in-2">
+  <div class="card__header">
+    <span class="card__title">Duration by Step</span>
+    <span class="text-muted">Total wall-clock time per step type</span>
+  </div>
+  {{if .DurationByStep}}
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Step</th>
+        <th class="cell-num">Total Duration</th>
+        <th>Share</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range .DurationByStep}}
+      <tr>
+        <td>{{.Step}}</td>
+        <td class="cell-num">{{.Duration}}</td>
+        <td>
+          <div class="pass-fail-bar">
+            <span class="text-muted">{{printf "%.1f" .Percent}}%</span>
+            <div class="pass-fail-bar__bar">
+              <div class="progress-bar__segment progress-bar__segment--success" style="width: {{printf "%.1f" .Percent}}%;"></div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      {{end}}
+    </tbody>
+  </table>
+  {{else}}
+  <p class="text-muted" style="padding: 1rem;">No duration data recorded.</p>
+  {{end}}
+</div>
+
 {{if .RepoRows}}
 
 <!-- Success by Repo -->


### PR DESCRIPTION
## Summary

- Adds `DurationByStep map[string]float64` to `DurationStats` in `analysis.go`, populated by a new `accumulateIssueDurations()` helper mirroring `accumulateIssueCosts()`
- Adds `printDurationByStep()` to `analyze.go` CLI output showing step name, total duration (human-readable), and percentage of total
- Adds `DurationByStepRow` type, `buildDurationByStepRows()` builder, and `DurationByStep` field on `AnalysisData` in `handlers.go`
- Adds a "Duration by Step" card to `analysis.html` dashboard alongside the existing "Cost by Step" card

## Test plan

- [ ] `TestAggregateDurationByStepZeroDuration` — empty map when no duration data
- [ ] `TestAggregateDurationByStepSingleStep` — single implement step is 100%
- [ ] `TestAggregateDurationByStepMultipleSteps` — percentages sum to ~100%
- [ ] `TestAggregateDurationByStepWithRetries` — retry durations accumulate under "retries"
- [ ] `TestAggregateDurationByStepRecon` — recon and spec-generator tracked
- [ ] All existing tests continue to pass (`go test ./...`)

## Implementation Notes

### Approach
Followed the exact pattern of the existing `CostByStep` feature: new helper functions `accumulateStepDuration()` and `accumulateIssueDurations()` mirror `accumulateStepCost()` and `accumulateIssueCosts()`. The CLI `printDurationByStep()` mirrors `printCostByStep()`. The dashboard `buildDurationByStepRows()` mirrors `buildCostByStepRows()`, with duration formatting done inline using `time.Duration` arithmetic (since `formatDuration` is unexported in the cmd package).

### Key Decisions
- **`DurationByStep` placed on `DurationStats`** (not `CostStats`) — it already owns duration aggregation and this avoids confusing naming.
- **Total for percentages computed from map sum at display time** — no stored total field, mirroring how the dashboard computes percentage from `CostStats.TotalUSD` (which is stored) but the CLI computes it by summing the map.
- **Verify step duration not included** — `VerifyStepResult` has no `DurationSeconds` field; omitted to match the cost function which also skips verify.
- **Duration formatting inlined in `buildDurationByStepRows()`** — avoids cross-package dependency on the unexported `formatDuration` in `internal/cmd`.

### Known Limitations
- Verify step duration is unavailable at the `IssueDetail` level (no `DurationSeconds` on `VerifyStepResult`), so verify is omitted from the breakdown. This matches the cost breakdown behavior.

### Architecture
- `internal/analysis/` — **domain** layer: pure business logic, no new dependencies
- `internal/cmd/` — **cmd** layer: consumes domain, no new dependencies  
- `internal/dashboard/` — **presentation** layer: consumes domain (`internal/analysis`), no new layer crossings

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)