### PR TITLE
feat: first-pass rate, wasted cost, and avg cost metrics in analysis

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -8,23 +8,31 @@ import (
 
 // Report holds aggregate statistics computed across multiple runs.
 type Report struct {
-	RunCount        int                    `json:"run_count"`
-	IssueCount      int                    `json:"issue_count"`
-	Outcomes        map[string]int         `json:"outcomes"`
-	FlagFrequencies []FlagFrequency        `json:"flag_frequencies"`
-	RetryStats      RetryStats             `json:"retry_stats"`
-	VerifyStats     map[string]int         `json:"verify_stats"`
-	CostStats       CostStats              `json:"cost_stats"`
-	DurationStats   DurationStats          `json:"duration_stats"`
-	RepoStats       map[string]RepoSummary `json:"repo_stats"`
+	RunCount             int                    `json:"run_count"`
+	IssueCount           int                    `json:"issue_count"`
+	Outcomes             map[string]int         `json:"outcomes"`
+	FlagFrequencies      []FlagFrequency        `json:"flag_frequencies"`
+	RetryStats           RetryStats             `json:"retry_stats"`
+	VerifyStats          map[string]int         `json:"verify_stats"`
+	CostStats            CostStats              `json:"cost_stats"`
+	DurationStats        DurationStats          `json:"duration_stats"`
+	RepoStats            map[string]RepoSummary `json:"repo_stats"`
+	FirstPassCount       int                    `json:"first_pass_count"`
+	FirstPassSuccessRate float64                `json:"first_pass_success_rate"`
+	WastedCostUSD        float64                `json:"wasted_cost_usd"`
+	AvgCostPerSuccessUSD float64                `json:"avg_cost_per_success_usd"`
 }
 
 // RepoSummary holds per-repository outcome statistics.
 type RepoSummary struct {
-	Total       int     `json:"total"`
-	Implemented int     `json:"implemented"`
-	Failed      int     `json:"failed"`
-	SuccessRate float64 `json:"success_rate"`
+	Total              int     `json:"total"`
+	Implemented        int     `json:"implemented"`
+	Failed             int     `json:"failed"`
+	SuccessRate        float64 `json:"success_rate"`
+	FirstPassCount     int     `json:"first_pass_count"`
+	FirstPassRate      float64 `json:"first_pass_rate"`
+	TotalCostUSD       float64 `json:"total_cost_usd"`
+	AvgCostPerIssueUSD float64 `json:"avg_cost_per_issue_usd"`
 }
 
 // DurationStats holds aggregate step duration statistics.
@@ -68,6 +76,8 @@ type issueAcc struct {
 	totalCost              float64
 	totalImplementDuration float64
 	totalReviewDuration    float64
+	firstPassCount         int
+	wastedCost             float64
 }
 
 // add incorporates a single issue's data into the accumulator and the report.
@@ -77,8 +87,6 @@ func (a *issueAcc) add(report *Report, repo string, issue rundata.IssueDetail) {
 	if issue.Outcome.Status != "" {
 		report.Outcomes[issue.Outcome.Status]++
 	}
-
-	accumulateRepoStat(report.RepoStats, repo, issue.Outcome.Status)
 
 	retries := len(issue.Retries)
 	a.totalRetries += retries
@@ -105,7 +113,26 @@ func (a *issueAcc) add(report *Report, repo string, issue rundata.IssueDetail) {
 		collectFlags(a.flagCounts, retry.FunctionalReview.Flags)
 	}
 
-	a.totalCost += accumulateIssueCosts(report.CostStats.CostByStep, issue)
+	// Compute cost before accumulateRepoStat so the per-issue cost is available.
+	issueCost := accumulateIssueCosts(report.CostStats.CostByStep, issue)
+	a.totalCost += issueCost
+
+	// First-pass: succeeded on the initial attempt (no retries).
+	isFirstPass := retries == 0 &&
+		(issue.Outcome.Status == rundata.OutcomeStatusImplemented ||
+			issue.Outcome.Status == rundata.OutcomeStatusReadyToMerge)
+	if isFirstPass {
+		a.firstPassCount++
+	}
+
+	// Wasted cost: issues that ultimately failed or exhausted retries.
+	if issue.Outcome.Status == rundata.OutcomeStatusFailed ||
+		issue.Outcome.Status == rundata.OutcomeStatusNeedsHumanReview {
+		a.wastedCost += issueCost
+	}
+
+	accumulateRepoStat(report.RepoStats, repo, issue.Outcome.Status, isFirstPass, issueCost)
+
 	accumulateIssueDurations(report.DurationStats.DurationByStep, issue)
 	a.totalImplementDuration += issue.Implement.DurationSeconds
 	a.totalReviewDuration += issue.QualityReview.DurationSeconds
@@ -120,7 +147,7 @@ func (a *issueAcc) add(report *Report, repo string, issue rundata.IssueDetail) {
 }
 
 // accumulateRepoStat updates per-repository counters for a single issue outcome.
-func accumulateRepoStat(repoStats map[string]RepoSummary, repo, status string) {
+func accumulateRepoStat(repoStats map[string]RepoSummary, repo, status string, isFirstPass bool, cost float64) {
 	if repo == "" {
 		return
 	}
@@ -132,6 +159,10 @@ func accumulateRepoStat(repoStats map[string]RepoSummary, repo, status string) {
 	case rundata.OutcomeStatusFailed, rundata.OutcomeStatusNeedsHumanReview:
 		rs.Failed++
 	}
+	if isFirstPass {
+		rs.FirstPassCount++
+	}
+	rs.TotalCostUSD += cost
 	repoStats[repo] = rs
 }
 
@@ -182,10 +213,22 @@ func Aggregate(runs []rundata.RunDetail) Report {
 		report.DurationStats.AvgReviewSeconds = acc.totalReviewDuration / float64(report.IssueCount)
 	}
 
-	// Compute per-repo success rates.
+	// Populate first-pass and wasted-cost stats.
+	report.FirstPassCount = acc.firstPassCount
+	if report.IssueCount > 0 {
+		report.FirstPassSuccessRate = float64(acc.firstPassCount) / float64(report.IssueCount)
+	}
+	report.WastedCostUSD = acc.wastedCost
+	if implementedCount := report.Outcomes["implemented"]; implementedCount > 0 {
+		report.AvgCostPerSuccessUSD = acc.totalCost / float64(implementedCount)
+	}
+
+	// Compute per-repo rates.
 	for repo, rs := range report.RepoStats {
 		if rs.Total > 0 {
 			rs.SuccessRate = float64(rs.Implemented) / float64(rs.Total)
+			rs.FirstPassRate = float64(rs.FirstPassCount) / float64(rs.Total)
+			rs.AvgCostPerIssueUSD = rs.TotalCostUSD / float64(rs.Total)
 		}
 		report.RepoStats[repo] = rs
 	}

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -814,6 +814,248 @@ func TestAggregateDurationByStepWithRetries(t *testing.T) {
 	}
 }
 
+func TestAggregateFirstPassAllFirstPass(t *testing.T) {
+	// 5 issues, 0 retries each, all implemented — FirstPassSuccessRate=1.0, FirstPassCount=5.
+	issues := make([]rundata.IssueDetail, 5)
+	for i := range issues {
+		issues[i] = rundata.IssueDetail{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}}
+	}
+	runs := []rundata.RunDetail{{Issues: issues}}
+
+	got := Aggregate(runs)
+
+	if got.FirstPassCount != 5 {
+		t.Errorf("FirstPassCount = %d, want 5", got.FirstPassCount)
+	}
+	if !nearlyEqual(got.FirstPassSuccessRate, 1.0, 0.001) {
+		t.Errorf("FirstPassSuccessRate = %f, want 1.0", got.FirstPassSuccessRate)
+	}
+}
+
+func TestAggregateFirstPassMixed(t *testing.T) {
+	// 3 issues succeed first-pass, 2 retry and succeed — FirstPassSuccessRate=0.6.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}},
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}},
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}},
+				{
+					Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Retries: []rundata.RetryDetail{{Attempt: 0}},
+				},
+				{
+					Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Retries: []rundata.RetryDetail{{Attempt: 0}},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if got.FirstPassCount != 3 {
+		t.Errorf("FirstPassCount = %d, want 3", got.FirstPassCount)
+	}
+	if !nearlyEqual(got.FirstPassSuccessRate, 0.6, 0.001) {
+		t.Errorf("FirstPassSuccessRate = %f, want 0.6", got.FirstPassSuccessRate)
+	}
+}
+
+func TestAggregateWastedCost(t *testing.T) {
+	// 2 failed issues with $1.50 total cost — WastedCostUSD=1.50.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusFailed},
+					Implement: rundata.StepResult{CostUSD: 1.00},
+				},
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusFailed},
+					Implement: rundata.StepResult{CostUSD: 0.50},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if !nearlyEqual(got.WastedCostUSD, 1.50, 0.0001) {
+		t.Errorf("WastedCostUSD = %f, want 1.50", got.WastedCostUSD)
+	}
+}
+
+func TestAggregateAvgCostPerSuccessNoSuccesses(t *testing.T) {
+	// All issues fail — AvgCostPerSuccessUSD=0.0 (no division by zero).
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusFailed},
+					Implement: rundata.StepResult{CostUSD: 2.00},
+				},
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusNeedsHumanReview},
+					Implement: rundata.StepResult{CostUSD: 1.00},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if got.AvgCostPerSuccessUSD != 0.0 {
+		t.Errorf("AvgCostPerSuccessUSD = %f, want 0.0", got.AvgCostPerSuccessUSD)
+	}
+}
+
+func TestAggregateRepoFirstPassRate(t *testing.T) {
+	// repo-a: 3 first-pass out of 4, repo-b: 1 first-pass out of 3.
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{Repo: "owner/repo-a"},
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}},
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}},
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}},
+				{
+					Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Retries: []rundata.RetryDetail{{Attempt: 0}},
+				},
+			},
+		},
+		{
+			RunMeta: rundata.RunMeta{Repo: "owner/repo-b"},
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}},
+				{
+					Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Retries: []rundata.RetryDetail{{Attempt: 0}},
+				},
+				{
+					Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Retries: []rundata.RetryDetail{{Attempt: 0}},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	repoA := got.RepoStats["owner/repo-a"]
+	if repoA.FirstPassCount != 3 {
+		t.Errorf("repo-a FirstPassCount = %d, want 3", repoA.FirstPassCount)
+	}
+	if !nearlyEqual(repoA.FirstPassRate, 3.0/4.0, 0.001) {
+		t.Errorf("repo-a FirstPassRate = %f, want 0.75", repoA.FirstPassRate)
+	}
+
+	repoB := got.RepoStats["owner/repo-b"]
+	if repoB.FirstPassCount != 1 {
+		t.Errorf("repo-b FirstPassCount = %d, want 1", repoB.FirstPassCount)
+	}
+	if !nearlyEqual(repoB.FirstPassRate, 1.0/3.0, 0.001) {
+		t.Errorf("repo-b FirstPassRate = %f, want ~0.333", repoB.FirstPassRate)
+	}
+}
+
+func TestAggregateAvgCostPerSuccessUSD(t *testing.T) {
+	// 2 implemented issues at $2.00 each, 1 failed at $1.00 — AvgCostPerSuccessUSD = 5.0/2 = 2.5.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Implement: rundata.StepResult{CostUSD: 2.00},
+				},
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Implement: rundata.StepResult{CostUSD: 2.00},
+				},
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusFailed},
+					Implement: rundata.StepResult{CostUSD: 1.00},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	// total cost = 5.0, implemented count = 2 → AvgCostPerSuccessUSD = 2.5
+	if !nearlyEqual(got.AvgCostPerSuccessUSD, 2.5, 0.0001) {
+		t.Errorf("AvgCostPerSuccessUSD = %f, want 2.5", got.AvgCostPerSuccessUSD)
+	}
+}
+
+func TestAggregateRepoAvgCostPerIssueUSD(t *testing.T) {
+	// Verify per-repo AvgCostPerIssueUSD is computed correctly.
+	runs := []rundata.RunDetail{
+		{
+			RunMeta: rundata.RunMeta{Repo: "owner/repo"},
+			Issues: []rundata.IssueDetail{
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Implement: rundata.StepResult{CostUSD: 1.00},
+				},
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusImplemented},
+					Implement: rundata.StepResult{CostUSD: 3.00},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	rs := got.RepoStats["owner/repo"]
+	if !nearlyEqual(rs.TotalCostUSD, 4.00, 0.0001) {
+		t.Errorf("RepoStats TotalCostUSD = %f, want 4.00", rs.TotalCostUSD)
+	}
+	if !nearlyEqual(rs.AvgCostPerIssueUSD, 2.00, 0.0001) {
+		t.Errorf("RepoStats AvgCostPerIssueUSD = %f, want 2.00", rs.AvgCostPerIssueUSD)
+	}
+}
+
+func TestAggregateFirstPassReadyToMergeCountsAsSuccess(t *testing.T) {
+	// ready-to-merge with no retries should count as first-pass.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusReadyToMerge}},
+				{Outcome: rundata.Outcome{Status: rundata.OutcomeStatusImplemented}},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if got.FirstPassCount != 2 {
+		t.Errorf("FirstPassCount = %d, want 2 (both implemented and ready-to-merge count)", got.FirstPassCount)
+	}
+}
+
+func TestAggregateWastedCostNeedsHumanReview(t *testing.T) {
+	// needs-human-review issues also contribute to wasted cost.
+	runs := []rundata.RunDetail{
+		{
+			Issues: []rundata.IssueDetail{
+				{
+					Outcome:   rundata.Outcome{Status: rundata.OutcomeStatusNeedsHumanReview},
+					Implement: rundata.StepResult{CostUSD: 0.75},
+				},
+			},
+		},
+	}
+
+	got := Aggregate(runs)
+
+	if !nearlyEqual(got.WastedCostUSD, 0.75, 0.0001) {
+		t.Errorf("WastedCostUSD = %f, want 0.75", got.WastedCostUSD)
+	}
+}
+
 func TestAggregateDurationByStepRecon(t *testing.T) {
 	// Recon and spec-generator durations should be tracked.
 	runs := []rundata.RunDetail{


### PR DESCRIPTION
## Summary
- Adds `FirstPassCount`, `FirstPassSuccessRate`, `WastedCostUSD`, and `AvgCostPerSuccessUSD` to `Report`
- Adds `FirstPassRate` and `AvgCostPerIssueUSD` to `RepoSummary` (with `FirstPassCount` and `TotalCostUSD` as accumulator fields)
- 8 new test functions covering all acceptance criteria and edge cases

## Implementation Notes

### Approach
Extended `internal/analysis/analysis.go` with four new `Report` fields and four new `RepoSummary` fields. The key restructuring was moving `accumulateIssueCosts` before `accumulateRepoStat` in `add()` so the per-issue cost is available when updating repo stats. Extended `accumulateRepoStat` with `isFirstPass bool` and `cost float64` parameters. Both new per-repo rates are finalized in the existing per-repo loop in `Aggregate()`, following the established pattern for `SuccessRate`.

### Key Decisions
- `TotalCostUSD` and `FirstPassCount` are exported fields on `RepoSummary` (with JSON tags) — they are useful data in their own right, not merely private accumulators.
- `AvgCostPerSuccessUSD` divides by `Outcomes["implemented"]` only (not `ready-to-merge`), as specified in the issue.
- `FirstPassSuccessRate` uses `IssueCount` as denominator (all issues, not just successes), making it a harness quality signal.
- `RepoSummary.AvgCostPerIssueUSD` divides by `Total` (all issues in the repo), while the global `AvgCostPerSuccessUSD` divides by implemented count — two different denominators by design.

### Known Limitations
- `printRepoStats` in `internal/cmd/analyze.go` does not yet render the new `FirstPassRate` and `AvgCostPerIssueUSD` columns — that is display follow-on work not required by the issue.

### Architecture
Only `internal/analysis/` (domain layer) was modified. No new imports or layer dependencies introduced.

## Test plan
- [x] `TestAggregateFirstPassAllFirstPass` — 5 first-pass issues → rate=1.0
- [x] `TestAggregateFirstPassMixed` — 3/5 first-pass → rate=0.6
- [x] `TestAggregateWastedCost` — 2 failed issues at $1.50 total → WastedCostUSD=1.50
- [x] `TestAggregateAvgCostPerSuccessNoSuccesses` — all fail → AvgCostPerSuccessUSD=0.0
- [x] `TestAggregateRepoFirstPassRate` — repo-a 3/4, repo-b 1/3 computed independently
- [x] `TestAggregateAvgCostPerSuccessUSD` — total/implemented denominator verified
- [x] `TestAggregateRepoAvgCostPerIssueUSD` — per-repo avg cost verified
- [x] `TestAggregateFirstPassReadyToMergeCountsAsSuccess` — ready-to-merge counts as first-pass
- [x] `TestAggregateWastedCostNeedsHumanReview` — needs-human-review contributes to wasted cost
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #489