### PR TITLE
refactor(analysis): drop scenario spec gap and exhausted retries listing

### DIFF
--- a/internal/analysis/gaps.go
+++ b/internal/analysis/gaps.go
@@ -1,10 +1,8 @@
 package analysis
 
 import (
-	"fmt"
 	"math"
 	"sort"
-	"strings"
 
 	"github.com/phs/dark-factory/internal/rundata"
 )
@@ -53,40 +51,6 @@ func DetectGaps(runs []rundata.RunDetail) []PromptGap {
 			gap.WithoutLabel = "without flag"
 			gaps = append(gaps, *gap)
 		}
-	}
-
-	// Scenario specs present vs absent.
-	if gap := gapByCondition(allIssues, "scenario specs", func(issue rundata.IssueDetail) bool {
-		return isStepRecorded(issue.SpecGenerator)
-	}); gap != nil {
-		gap.WithLabel = "with spec"
-		gap.WithoutLabel = "without spec"
-		gaps = append(gaps, *gap)
-	}
-
-	// Exhausted retries — list issue numbers and titles as a separate finding.
-	var exhausted, notExhausted []rundata.IssueDetail
-	for _, issue := range allIssues {
-		if issue.Outcome.Status == "needs-human-review" {
-			exhausted = append(exhausted, issue)
-		} else {
-			notExhausted = append(notExhausted, issue)
-		}
-	}
-	if len(exhausted) > 0 {
-		parts := make([]string, 0, len(exhausted))
-		for _, issue := range exhausted {
-			parts = append(parts, fmt.Sprintf("#%d %q", issue.IssueNumber, issue.Outcome.Title))
-		}
-		gaps = append(gaps, PromptGap{
-			Finding:         "exhausted retries: " + strings.Join(parts, ", "),
-			FailRateWith:    issueFailureRate(exhausted),
-			FailRateWithout: issueFailureRate(notExhausted),
-			SamplesWith:     len(exhausted),
-			SamplesWithout:  len(notExhausted),
-			WithLabel:       "exhausted",
-			WithoutLabel:    "not exhausted",
-		})
 	}
 
 	if len(gaps) == 0 {
@@ -144,11 +108,6 @@ func issueFailureRate(issues []rundata.IssueDetail) float64 {
 		}
 	}
 	return float64(count) / float64(len(issues))
-}
-
-// isStepRecorded reports whether a StepResult contains any recorded data.
-func isStepRecorded(step rundata.StepResult) bool {
-	return step.StartedAt != nil || step.Output != ""
 }
 
 // issueHasFlag reports whether any step in the issue carries a flag with the given code.

--- a/internal/analysis/gaps_test.go
+++ b/internal/analysis/gaps_test.go
@@ -2,7 +2,6 @@ package analysis
 
 import (
 	"math"
-	"strings"
 	"testing"
 
 	"github.com/phs/dark-factory/internal/rundata"
@@ -113,107 +112,6 @@ func TestDetectGapsQualityReviewGapRemoved(t *testing.T) {
 	}
 }
 
-func TestDetectGapsScenarioSpecGap(t *testing.T) {
-	// 10 issues with spec gen: 1 failed (10%), 9 implemented.
-	// 10 issues without spec gen: 5 failed (50%), 5 implemented.
-	var issues []rundata.IssueDetail
-
-	for i := 0; i < 10; i++ {
-		status := "implemented"
-		if i == 0 {
-			status = "failed"
-		}
-		issues = append(issues, rundata.IssueDetail{
-			SpecGenerator: rundata.StepResult{Output: "spec generated"},
-			Outcome:       rundata.Outcome{Status: status},
-		})
-	}
-
-	for i := 0; i < 10; i++ {
-		status := "implemented"
-		if i < 5 {
-			status = "failed"
-		}
-		issues = append(issues, rundata.IssueDetail{
-			Outcome: rundata.Outcome{Status: status},
-		})
-	}
-
-	runs := []rundata.RunDetail{{Issues: issues}}
-	got := DetectGaps(runs)
-
-	var specGap *PromptGap
-	for i := range got {
-		if got[i].Finding == "scenario specs" {
-			specGap = &got[i]
-			break
-		}
-	}
-
-	if specGap == nil {
-		t.Fatal("expected scenario specs finding, got none")
-	}
-	if !nearlyEqual(specGap.FailRateWith, 0.1, 0.001) {
-		t.Errorf("FailRateWith = %f, want 0.1", specGap.FailRateWith)
-	}
-	if !nearlyEqual(specGap.FailRateWithout, 0.5, 0.001) {
-		t.Errorf("FailRateWithout = %f, want 0.5", specGap.FailRateWithout)
-	}
-	if specGap.SamplesWith != 10 {
-		t.Errorf("SamplesWith = %d, want 10", specGap.SamplesWith)
-	}
-	if specGap.SamplesWithout != 10 {
-		t.Errorf("SamplesWithout = %d, want 10", specGap.SamplesWithout)
-	}
-}
-
-func TestDetectGapsExhaustedRetries(t *testing.T) {
-	// 2 issues with needs-human-review — finding lists both.
-	runs := []rundata.RunDetail{
-		{
-			Issues: []rundata.IssueDetail{
-				{
-					IssueNumber: 10,
-					Outcome:     rundata.Outcome{Status: "needs-human-review", Title: "Issue Alpha"},
-				},
-				{
-					IssueNumber: 20,
-					Outcome:     rundata.Outcome{Status: "needs-human-review", Title: "Issue Beta"},
-				},
-			},
-		},
-	}
-
-	got := DetectGaps(runs)
-
-	var exGap *PromptGap
-	for i := range got {
-		if strings.HasPrefix(got[i].Finding, "exhausted retries:") {
-			exGap = &got[i]
-			break
-		}
-	}
-
-	if exGap == nil {
-		t.Fatal("expected exhausted retries finding, got none")
-	}
-	if !strings.Contains(exGap.Finding, "#10") {
-		t.Errorf("finding %q should contain #10", exGap.Finding)
-	}
-	if !strings.Contains(exGap.Finding, "#20") {
-		t.Errorf("finding %q should contain #20", exGap.Finding)
-	}
-	if !strings.Contains(exGap.Finding, "Issue Alpha") {
-		t.Errorf("finding %q should contain 'Issue Alpha'", exGap.Finding)
-	}
-	if !strings.Contains(exGap.Finding, "Issue Beta") {
-		t.Errorf("finding %q should contain 'Issue Beta'", exGap.Finding)
-	}
-	if exGap.SamplesWith != 2 {
-		t.Errorf("SamplesWith = %d, want 2", exGap.SamplesWith)
-	}
-}
-
 func TestDetectGapsInsufficientSamples(t *testing.T) {
 	// 2 issues with low_cost flag (below minimum of 3), 5 without.
 	// The flag finding should be excluded.
@@ -245,8 +143,6 @@ func TestDetectGapsInsufficientSamples(t *testing.T) {
 
 func TestDetectGapsNoGaps(t *testing.T) {
 	// No quality flags across any issues — no flag gaps.
-	// No issues have spec gen — no "with" group for comparison.
-	// No exhausted retries.
 	// Result should be nil.
 	var issues []rundata.IssueDetail
 


### PR DESCRIPTION
## Summary

- Removes the scenario spec presence/absence block from `DetectGaps()` — specs are now expected on every issue, so the comparison is noise
- Removes the exhausted retries listing block — already covered by `RetryStats.ExhaustedCount`
- Deletes the `isStepRecorded` helper that was only used by the removed block
- Drops unused `fmt`/`strings` imports from `gaps.go` and `strings` from `gaps_test.go`
- Removes `TestDetectGapsScenarioSpecGap` and `TestDetectGapsExhaustedRetries`

## Test plan

- [x] `go test ./internal/analysis/...` — all tests pass
- [x] `TestDetectGapsFlagCorrelation` — flag-based gaps still work
- [x] `TestDetectGapsQualityReviewGapRemoved` — pattern for removed conditions
- [x] `TestDetectGapsNoGaps` — nil result when no conditions fire
- [x] `TestDetectGapsSortedByMagnitude` — sort order intact

## Implementation Notes

### Approach
Pure removal — no new logic introduced. Deleted both gap-detection blocks from `DetectGaps()`, the `isStepRecorded` helper, and their tests.

### Key Decisions
- `isStepRecorded` was only called by the scenario spec block; deleting it avoids dead code
- `fmt` and `strings` became fully unused after the removal and were dropped from imports
- Updated the comment in `TestDetectGapsNoGaps` to remove the stale spec-gen mention

### Known Limitations
None — this is a straightforward removal with no deferred work.

### Architecture
Only `internal/analysis/` (domain layer) was touched. No layer boundaries crossed or violated.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)