### PR TITLE
feat(analyze): update CLI output with new metrics (#494)

### DIFF
--- a/internal/cmd/analyze.go
+++ b/internal/cmd/analyze.go
@@ -264,6 +264,13 @@ func printAnalyzeJSON(w io.Writer, report analysis.Report, gaps []analysis.Promp
 func printAnalyzeReport(w io.Writer, report analysis.Report, gaps []analysis.PromptGap) {
 	fmt.Fprintf(w, "Analyzed %d runs, %d issues\n", report.RunCount, report.IssueCount)
 
+	// Overview section.
+	fmt.Fprintf(w, "\nOverview\n")
+	fmt.Fprintf(w, "  First-pass success rate:  %.1f%%\n", report.FirstPassSuccessRate*100)
+	fmt.Fprintf(w, "  Avg cost per success:     $%.2f\n", report.AvgCostPerSuccessUSD)
+	fmt.Fprintf(w, "  Wasted cost:              $%.2f\n", report.WastedCostUSD)
+	fmt.Fprintf(w, "  Timeout rate:             %.1f%%\n", report.TimeoutRate*100)
+
 	// Outcome table.
 	fmt.Fprintf(w, "\nOutcomes\n")
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -300,8 +307,9 @@ func printAnalyzeReport(w io.Writer, report analysis.Report, gaps []analysis.Pro
 	fmt.Fprintf(w, "\nRetry Stats\n")
 	fmt.Fprintf(w, "  Avg per issue:  %.2f\n", report.RetryStats.AvgPerIssue)
 	fmt.Fprintf(w, "  Max retries:    %d\n", report.RetryStats.MaxRetries)
-	fmt.Fprintf(w, "  Exhausted:      %d\n", report.RetryStats.ExhaustedCount)
 	fmt.Fprintf(w, "  Recovery rate:  %.1f%%\n", report.RetryStats.RecoveryRate*100)
+
+	printFailureReasons(w, report)
 
 	// Cost stats.
 	fmt.Fprintf(w, "\nCost Stats\n")
@@ -315,6 +323,7 @@ func printAnalyzeReport(w io.Writer, report analysis.Report, gaps []analysis.Pro
 	fmt.Fprintf(w, "\nDuration Stats\n")
 	fmt.Fprintf(w, "  Avg implement duration: %s\n", formatDuration(report.DurationStats.AvgImplementSeconds))
 	fmt.Fprintf(w, "  Avg review duration:    %s\n", formatDuration(report.DurationStats.AvgReviewSeconds))
+	fmt.Fprintf(w, "  Avg time to merge:      %s\n", formatDuration(report.DurationStats.AvgTimeToMergeSeconds))
 
 	printDurationByStep(w, report)
 	printRepoStats(w, report)
@@ -406,10 +415,10 @@ func printRepoStats(w io.Writer, report analysis.Report) {
 	}
 	sort.Strings(repoNames)
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, "  Repo\tTotal\tImplemented\tFailed\tSuccess Rate\n")
+	fmt.Fprintf(tw, "  Repo\tTotal\tImplemented\tFailed\tSuccess Rate\tFirst-pass\tAvg cost\n")
 	for _, repo := range repoNames {
 		rs := report.RepoStats[repo]
-		fmt.Fprintf(tw, "  %s\t%d\t%d\t%d\t%.1f%%\n", repo, rs.Total, rs.Implemented, rs.Failed, rs.SuccessRate*100)
+		fmt.Fprintf(tw, "  %s\t%d\t%d\t%d\t%.1f%%\t%.1f%%\t$%.2f\n", repo, rs.Total, rs.Implemented, rs.Failed, rs.SuccessRate*100, rs.FirstPassRate*100, rs.AvgCostPerIssueUSD)
 	}
 	_ = tw.Flush()
 }
@@ -434,6 +443,37 @@ func printVerifyStats(w io.Writer, report analysis.Report) {
 			pct = float64(count) / float64(report.IssueCount) * 100
 		}
 		fmt.Fprintf(tw, "  %s\t%d\t%.1f%%\n", check, count, pct)
+	}
+	_ = tw.Flush()
+}
+
+// printFailureReasons writes the "Failure Reasons" section to w.
+// Only non-zero rows are shown. The canonical order is: verify, exhaustion, timeout, error.
+func printFailureReasons(w io.Writer, report analysis.Report) {
+	canonicalOrder := []string{"verify", "exhaustion", "timeout", "error"}
+	hasAny := false
+	for _, reason := range canonicalOrder {
+		if report.FailureReasons[reason] > 0 {
+			hasAny = true
+			break
+		}
+	}
+	if !hasAny {
+		return
+	}
+	fmt.Fprintf(w, "\nFailure Reasons\n")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(tw, "  Reason\tCount\tPercent\n")
+	for _, reason := range canonicalOrder {
+		count := report.FailureReasons[reason]
+		if count == 0 {
+			continue
+		}
+		var pct float64
+		if report.IssueCount > 0 {
+			pct = float64(count) / float64(report.IssueCount) * 100
+		}
+		fmt.Fprintf(tw, "  %s\t%d\t%.1f%%\n", reason, count, pct)
 	}
 	_ = tw.Flush()
 }

--- a/internal/cmd/analyze_test.go
+++ b/internal/cmd/analyze_test.go
@@ -689,6 +689,175 @@ func TestAnalyzeDurationOutput(t *testing.T) {
 	}
 }
 
+// TestAnalyzeOverviewSection: output contains Overview section with first-pass success rate line.
+func TestAnalyzeOverviewSection(t *testing.T) {
+	base := t.TempDir()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	meta := rundata.RunMeta{
+		Repo:         "owner/repo",
+		Milestone:    "Phase 1",
+		IssueNumbers: []int{1, 2},
+		StartedAt:    ts,
+	}
+	writeRunDir(t, base, "owner", "repo", meta, []rundata.Outcome{
+		{IssueNumber: 1, Status: "implemented"},
+		{IssueNumber: 2, Status: "failed"},
+	})
+
+	out, err := analyzeWithReader(t, base, "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{
+		"Overview",
+		"First-pass success rate:",
+		"Avg cost per success:",
+		"Wasted cost:",
+		"Timeout rate:",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+// TestAnalyzeFailureReasonsSection: output contains failure reasons table with non-zero rows.
+func TestAnalyzeFailureReasonsSection(t *testing.T) {
+	base := t.TempDir()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	meta := rundata.RunMeta{
+		Repo:         "owner/repo",
+		Milestone:    "Phase 1",
+		IssueNumbers: []int{1, 2, 3},
+		StartedAt:    ts,
+	}
+	writeRunDir(t, base, "owner", "repo", meta, []rundata.Outcome{
+		{IssueNumber: 1, Status: "implemented"},
+		{IssueNumber: 2, Status: "failed"},
+		{IssueNumber: 3, Status: "needs-human-review"},
+	})
+
+	out, err := analyzeWithReader(t, base, "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "Failure Reasons") {
+		t.Errorf("output missing 'Failure Reasons' section\nfull output:\n%s", out)
+	}
+	// "exhaustion" bucket should appear (needs-human-review issue).
+	if !strings.Contains(out, "exhaustion") {
+		t.Errorf("output missing 'exhaustion' row in Failure Reasons\nfull output:\n%s", out)
+	}
+	// "Exhausted:" line should no longer appear in Retry Stats.
+	if strings.Contains(out, "Exhausted:") {
+		t.Errorf("output must not contain removed 'Exhausted:' line in Retry Stats\nfull output:\n%s", out)
+	}
+}
+
+// TestAnalyzeTimeToMergeInDuration: Avg time to merge appears in Duration Stats section.
+func TestAnalyzeTimeToMergeInDuration(t *testing.T) {
+	base := t.TempDir()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	meta := rundata.RunMeta{
+		Repo:         "owner/repo",
+		Milestone:    "Phase 1",
+		IssueNumbers: []int{1},
+		StartedAt:    ts,
+	}
+	writeRunDirWithSteps(t, base, "owner", "repo", meta, []issueWithSteps{
+		{
+			Outcome:       rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+			Implement:     rundata.StepResult{DurationSeconds: 300.0},
+			QualityReview: rundata.StepResult{DurationSeconds: 120.0},
+		},
+	})
+
+	out, err := analyzeWithReader(t, base, "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "Avg time to merge:") {
+		t.Errorf("output missing 'Avg time to merge:' in Duration Stats\nfull output:\n%s", out)
+	}
+}
+
+// TestAnalyzeRepoTableEnriched: per-repo table includes First-pass and Avg cost columns.
+func TestAnalyzeRepoTableEnriched(t *testing.T) {
+	base := t.TempDir()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	meta := rundata.RunMeta{
+		Repo:         "owner/repo",
+		Milestone:    "Phase 1",
+		IssueNumbers: []int{1, 2},
+		StartedAt:    ts,
+	}
+	writeRunDir(t, base, "owner", "repo", meta, []rundata.Outcome{
+		{IssueNumber: 1, Status: "implemented"},
+		{IssueNumber: 2, Status: "implemented"},
+	})
+
+	out, err := analyzeWithReader(t, base, "", "", "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out, "First-pass") {
+		t.Errorf("repo table missing 'First-pass' column\nfull output:\n%s", out)
+	}
+	if !strings.Contains(out, "Avg cost") {
+		t.Errorf("repo table missing 'Avg cost' column\nfull output:\n%s", out)
+	}
+}
+
+// TestAnalyzeJSONIncludesNewFields: --json output deserializes with new Report fields.
+func TestAnalyzeJSONIncludesNewFields(t *testing.T) {
+	base := t.TempDir()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	meta := rundata.RunMeta{
+		Repo:         "owner/repo",
+		Milestone:    "Phase 1",
+		IssueNumbers: []int{1, 2},
+		StartedAt:    ts,
+	}
+	writeRunDir(t, base, "owner", "repo", meta, []rundata.Outcome{
+		{IssueNumber: 1, Status: "implemented"},
+		{IssueNumber: 2, Status: "failed"},
+	})
+
+	out, err := analyzeWithReader(t, base, "", "", "", "", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result struct {
+		Report analysis.Report `json:"report"`
+	}
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v\noutput:\n%s", err, out)
+	}
+
+	// first_pass_success_rate should be 0.5 (1 out of 2 issues, no retries, implemented)
+	if result.Report.FirstPassSuccessRate != 0.5 {
+		t.Errorf("FirstPassSuccessRate = %v, want 0.5", result.Report.FirstPassSuccessRate)
+	}
+	// wasted_cost_usd should be 0 (no cost data in test, but field must be present)
+	if result.Report.WastedCostUSD < 0 {
+		t.Errorf("WastedCostUSD = %v, want >= 0", result.Report.WastedCostUSD)
+	}
+	// failure_reasons must be non-nil map
+	if result.Report.FailureReasons == nil {
+		t.Errorf("FailureReasons is nil, want non-nil map")
+	}
+}
+
 // TestAnalyzeDB_DurationFromSteps: step duration records flow through to report.
 func TestAnalyzeDB_DurationFromSteps(t *testing.T) {
 	db := openTestDB(t)


### PR DESCRIPTION
## Summary

- Add **Overview** section at top of `godark analyze` output: first-pass success rate, avg cost per success, wasted cost, timeout rate
- Add **Failure Reasons** table (non-zero rows only, canonical order: verify/exhaustion/timeout/error) after Retry Stats; remove the now-redundant `Exhausted:` line from Retry Stats
- Add **Avg time to merge** line to Duration Stats section
- Enrich **per-repo table** with First-pass and Avg cost columns
- Add 5 new test functions covering every new display section and JSON field presence

## Test plan

- [x] `TestAnalyzeOverviewSection` — Overview section with all four lines present
- [x] `TestAnalyzeFailureReasonsSection` — Failure Reasons table renders non-zero rows; `Exhausted:` line absent from Retry Stats
- [x] `TestAnalyzeTimeToMergeInDuration` — `Avg time to merge:` appears in Duration Stats
- [x] `TestAnalyzeRepoTableEnriched` — `First-pass` and `Avg cost` columns in repo table
- [x] `TestAnalyzeJSONIncludesNewFields` — JSON deserializes `FirstPassSuccessRate`, `WastedCostUSD`, `FailureReasons`
- [x] All 25 existing + new tests pass (`go test ./internal/cmd/... -run TestAnalyze`)

## Implementation Notes

### Approach
All new metrics were already computed in `internal/analysis/analysis.go` (blocked issues #489, #490, #491 are merged). This PR is purely a display-layer change within `internal/cmd/analyze.go`.

### Key Decisions
- `printFailureReasons` is a new helper following the same pattern as `printVerifyStats` and `printRepoStats`. It shows only non-zero rows to keep output clean when no failures exist.
- Canonical failure reason order (verify, exhaustion, timeout, error) is hard-coded in the helper rather than map-sorted, so the display is deterministic and meaningful.
- `Exhausted:` line removed from Retry Stats since exhaustion is now surfaced in the Failure Reasons table, avoiding double-counting in the output.
- The `analyzeOutput` struct needed no changes — `analysis.Report` already carries all new fields with JSON tags, so `--json` output was already correct before this PR.

### Known Limitations
None. All acceptance criteria from the issue are satisfied.

### Architecture
Only the **cmd** layer (`internal/cmd/`) is modified. The **domain** layer (`internal/analysis/`) is read-only. The cmd→domain dependency is explicitly permitted per `docs/architecture.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #494