### PR TITLE
feat(dashboard): update analysis HTML template with metrics, failure reasons, first-pass trend

### DIFF
--- a/internal/dashboard/handlers_analysis_test.go
+++ b/internal/dashboard/handlers_analysis_test.go
@@ -510,3 +510,271 @@ func TestServer_Analysis_NavLinkPresent(t *testing.T) {
 		t.Errorf("index page missing navigation link to /analysis; got: %q", truncate(body, 400))
 	}
 }
+
+func TestServer_Analysis_OverviewMetricsCard(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+	finishedAt := now
+
+	issues := []rundata.IssueDetail{
+		{
+			IssueNumber: 1,
+			Outcome:     rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+			Implement:   rundata.StepResult{Output: "done", DurationSeconds: 10},
+		},
+		{
+			IssueNumber: 2,
+			Outcome:     rundata.Outcome{IssueNumber: 2, Status: "failed"},
+			Implement:   rundata.StepResult{Output: "err", DurationSeconds: 5},
+		},
+	}
+
+	buildAnalysisRun(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1, 2},
+		StartedAt:    now,
+		FinishedAt:   &finishedAt,
+		Summary:      &rundata.RunSummary{Total: 2, Implemented: 1, Failed: 1},
+	}, issues)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/analysis", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+
+	// Overview card should contain stat-block elements.
+	if !strings.Contains(body, "Total Runs") {
+		t.Errorf("body missing 'Total Runs' overview tile; got: %q", truncate(body, 500))
+	}
+	if !strings.Contains(body, "Total Issues") {
+		t.Errorf("body missing 'Total Issues' overview tile")
+	}
+	if !strings.Contains(body, "Success Rate") {
+		t.Errorf("body missing 'Success Rate' overview tile")
+	}
+	if !strings.Contains(body, "First-Pass Rate") {
+		t.Errorf("body missing 'First-Pass Rate' overview tile")
+	}
+	if !strings.Contains(body, "Total Cost") {
+		t.Errorf("body missing 'Total Cost' overview tile")
+	}
+	if !strings.Contains(body, "Avg Cost / Success") {
+		t.Errorf("body missing 'Avg Cost / Success' overview tile")
+	}
+}
+
+func TestServer_Analysis_FailureReasonsCard(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+	finishedAt := now
+
+	// One failed issue to trigger failure reason categorization.
+	issues := []rundata.IssueDetail{
+		{
+			IssueNumber: 1,
+			Outcome:     rundata.Outcome{IssueNumber: 1, Status: "failed"},
+			Implement:   rundata.StepResult{Output: "err", DurationSeconds: 5},
+		},
+	}
+
+	buildAnalysisRun(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+		FinishedAt:   &finishedAt,
+		Summary:      &rundata.RunSummary{Total: 1, Failed: 1},
+	}, issues)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/analysis", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+
+	// Failure Reason Breakdown card should be present.
+	if !strings.Contains(body, "Failure Reason Breakdown") {
+		t.Errorf("body missing 'Failure Reason Breakdown' card; got: %q", truncate(body, 600))
+	}
+}
+
+func TestServer_Analysis_RepoTableFirstPassAndCostColumns(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+	finishedAt := now
+
+	issues := []rundata.IssueDetail{
+		{
+			IssueNumber: 1,
+			Outcome:     rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+			Implement:   rundata.StepResult{Output: "done", DurationSeconds: 10, CostUSD: 0.05},
+		},
+	}
+
+	buildAnalysisRun(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+		FinishedAt:   &finishedAt,
+		Summary:      &rundata.RunSummary{Total: 1, Implemented: 1},
+	}, issues)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/analysis", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+
+	// Repo table should have first-pass rate and avg cost column headers.
+	if !strings.Contains(body, "First-Pass Rate") {
+		t.Errorf("repo table missing 'First-Pass Rate' column header; got: %q", truncate(body, 600))
+	}
+	if !strings.Contains(body, "Avg Cost") {
+		t.Errorf("repo table missing 'Avg Cost' column header; got: %q", truncate(body, 600))
+	}
+}
+
+func TestServer_Analysis_CostCardWastedCostAndTimeout(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+	finishedAt := now
+
+	issues := []rundata.IssueDetail{
+		{
+			IssueNumber: 1,
+			Outcome:     rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+			Implement:   rundata.StepResult{Output: "done", DurationSeconds: 10},
+		},
+	}
+
+	buildAnalysisRun(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+		FinishedAt:   &finishedAt,
+		Summary:      &rundata.RunSummary{Total: 1, Implemented: 1},
+	}, issues)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/analysis", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+
+	if !strings.Contains(body, "Wasted cost") {
+		t.Errorf("cost card missing 'Wasted cost' row; got: %q", truncate(body, 600))
+	}
+	if !strings.Contains(body, "Timeout rate") {
+		t.Errorf("cost card missing 'Timeout rate' row; got: %q", truncate(body, 600))
+	}
+	if !strings.Contains(body, "Avg time to merge") {
+		t.Errorf("cost card missing 'Avg time to merge' row; got: %q", truncate(body, 600))
+	}
+}
+
+func TestServer_Analysis_TrendDataHasFirstPassField(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+
+	// Build 2 finished runs so trend JSON is embedded.
+	for i := 0; i < 2; i++ {
+		ts := now.Add(time.Duration(-i) * time.Hour).Format("20060102-150405")
+		fa := now.Add(time.Duration(-i) * time.Hour)
+		issues := []rundata.IssueDetail{
+			{
+				IssueNumber: 1,
+				Outcome:     rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+				Implement:   rundata.StepResult{Output: "done", DurationSeconds: 10},
+			},
+		}
+		buildAnalysisRun(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+			Repo:         "acme/proj",
+			Milestone:    "v1.0",
+			IssueNumbers: []int{1},
+			StartedAt:    now.Add(time.Duration(-i) * time.Hour),
+			FinishedAt:   &fa,
+			Summary:      &rundata.RunSummary{Total: 1, Implemented: 1},
+		}, issues)
+	}
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/analysis", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+	// Trend data JSON should include first_pass_success_rate field.
+	if !strings.Contains(body, "first_pass_success_rate") {
+		t.Errorf("trend data JSON missing 'first_pass_success_rate' field; got: %q", truncate(body, 800))
+	}
+	// Success rate chart should have two datasets (legend enabled).
+	if !strings.Contains(body, "First-Pass Rate") {
+		t.Errorf("success rate chart missing 'First-Pass Rate' dataset label; got: %q", truncate(body, 800))
+	}
+}
+
+func TestServer_Analysis_EmptyStateHasNoExhaustedRetriesRow(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+	finishedAt := now
+
+	issues := []rundata.IssueDetail{
+		{
+			IssueNumber: 1,
+			Outcome:     rundata.Outcome{IssueNumber: 1, Status: "implemented"},
+			Implement:   rundata.StepResult{Output: "done", DurationSeconds: 10},
+		},
+	}
+
+	buildAnalysisRun(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		Milestone:    "v1.0",
+		IssueNumbers: []int{1},
+		StartedAt:    now,
+		FinishedAt:   &finishedAt,
+		Summary:      &rundata.RunSummary{Total: 1, Implemented: 1},
+	}, issues)
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/analysis", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+
+	// The exhausted retries row should no longer be present in the retry stats card.
+	if strings.Contains(body, "Issues with exhausted retries") {
+		t.Errorf("retry stats card should not contain 'Issues with exhausted retries' row; found in: %q", truncate(body, 600))
+	}
+}

--- a/internal/dashboard/templates/analysis.html
+++ b/internal/dashboard/templates/analysis.html
@@ -129,6 +129,34 @@
 
 {{else}}
 
+<!-- Overview Metrics -->
+<div class="stats-row animate-in animate-in-1">
+  <div class="stat-block">
+    <div class="stat-block__label">Total Runs</div>
+    <div class="stat-block__value">{{.Overview.TotalRuns}}</div>
+  </div>
+  <div class="stat-block">
+    <div class="stat-block__label">Total Issues</div>
+    <div class="stat-block__value">{{.Overview.TotalIssues}}</div>
+  </div>
+  <div class="stat-block">
+    <div class="stat-block__label">Success Rate</div>
+    <div class="stat-block__value stat-block__value--success">{{printf "%.0f" (mulf .Overview.SuccessRate 100.0)}}%</div>
+  </div>
+  <div class="stat-block">
+    <div class="stat-block__label">First-Pass Rate</div>
+    <div class="stat-block__value stat-block__value--success">{{printf "%.0f" (mulf .Overview.FirstPassRate 100.0)}}%</div>
+  </div>
+  <div class="stat-block">
+    <div class="stat-block__label">Total Cost</div>
+    <div class="stat-block__value">{{if gt .Overview.TotalCostUSD 0.0}}${{printf "%.4f" .Overview.TotalCostUSD}}{{else}}—{{end}}</div>
+  </div>
+  <div class="stat-block">
+    <div class="stat-block__label">Avg Cost / Success</div>
+    <div class="stat-block__value">{{if gt .Overview.AvgCostPerSuccessUSD 0.0}}${{printf "%.4f" .Overview.AvgCostPerSuccessUSD}}{{else}}—{{end}}</div>
+  </div>
+</div>
+
 <!-- Outcome Distribution -->
 <div class="card animate-in animate-in-1">
   <div class="card__header">
@@ -225,15 +253,48 @@
         <td class="cell-num">{{.Report.RetryStats.MaxRetries}}</td>
       </tr>
       <tr>
-        <td>Issues with exhausted retries</td>
-        <td class="cell-num">{{.Report.RetryStats.ExhaustedCount}}</td>
-      </tr>
-      <tr>
         <td>Recovery rate (retried issues)</td>
         <td class="cell-num">{{printf "%.1f" (mulf .Report.RetryStats.RecoveryRate 100.0)}}%</td>
       </tr>
     </tbody>
   </table>
+</div>
+
+<!-- Failure Reason Breakdown -->
+<div class="card animate-in animate-in-2">
+  <div class="card__header">
+    <span class="card__title">Failure Reason Breakdown</span>
+    <span class="text-muted">Categorized causes of failed issues</span>
+  </div>
+  {{if .FailureReasons}}
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Reason</th>
+        <th class="cell-num">Count</th>
+        <th>% of Issues</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range .FailureReasons}}
+      <tr>
+        <td>{{.Reason}}</td>
+        <td class="cell-num">{{.Count}}</td>
+        <td>
+          <div class="pass-fail-bar">
+            <span class="text-muted">{{printf "%.1f" .Percent}}%</span>
+            <div class="pass-fail-bar__bar">
+              <div class="progress-bar__segment progress-bar__segment--danger" style="width: {{printf "%.1f" .Percent}}%;"></div>
+            </div>
+          </div>
+        </td>
+      </tr>
+      {{end}}
+    </tbody>
+  </table>
+  {{else}}
+  <p class="text-muted" style="padding: 1rem;">No failure data recorded.</p>
+  {{end}}
 </div>
 
 <!-- Cost Stats -->
@@ -260,6 +321,18 @@
       <tr>
         <td>Average cost per run</td>
         <td class="cell-num">{{printf "$%.4f" .Report.CostStats.AvgPerRunUSD}}</td>
+      </tr>
+      <tr>
+        <td>Wasted cost (failed issues)</td>
+        <td class="cell-num">{{printf "$%.4f" .Overview.WastedCostUSD}}</td>
+      </tr>
+      <tr>
+        <td>Timeout rate</td>
+        <td class="cell-num">{{printf "%.1f" (mulf .Overview.TimeoutRate 100.0)}}%</td>
+      </tr>
+      <tr>
+        <td>Avg time to merge</td>
+        <td class="cell-num">{{if .AvgTimeToMerge}}{{.AvgTimeToMerge}}{{else}}—{{end}}</td>
       </tr>
     </tbody>
   </table>
@@ -355,6 +428,8 @@
         <th class="cell-num">Implemented</th>
         <th class="cell-num">Failed</th>
         <th>Success Rate</th>
+        <th>First-Pass Rate</th>
+        <th class="cell-num">Avg Cost</th>
       </tr>
     </thead>
     <tbody>
@@ -372,6 +447,15 @@
             </div>
           </div>
         </td>
+        <td>
+          <div class="pass-fail-bar">
+            <span class="text-muted">{{printf "%.1f" (mulf .FirstPassRate 100.0)}}%</span>
+            <div class="pass-fail-bar__bar">
+              <div class="progress-bar__segment progress-bar__segment--success" style="width: {{printf "%.1f" (mulf .FirstPassRate 100.0)}}%;"></div>
+            </div>
+          </div>
+        </td>
+        <td class="cell-num">{{if gt .AvgCostPerIssueUSD 0.0}}${{printf "%.4f" .AvgCostPerIssueUSD}}{{else}}—{{end}}</td>
       </tr>
       {{end}}
     </tbody>
@@ -572,9 +656,78 @@
     });
   }
 
-  makeChart('chart-success-rate', 'Success Rate',
-    function(p) { return +(p.success_rate * 100).toFixed(1); }, '#4ade80',
-    { max: 100, ticks: { color: '#94a3b8', callback: function(v) { return v + '%'; }, stepSize: 25 } });
+  // Success rate chart: two datasets — overall and first-pass.
+  (function() {
+    var canvas = document.getElementById('chart-success-rate');
+    if (!canvas) return;
+    var ctx = canvas.getContext('2d');
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            label: 'Success Rate',
+            data: points.map(function(p) { return +(p.success_rate * 100).toFixed(1); }),
+            borderColor: '#4ade80',
+            backgroundColor: '#4ade8020',
+            fill: true,
+            pointRadius: 5,
+            pointHoverRadius: 7,
+            pointBackgroundColor: '#4ade80',
+            borderWidth: 2,
+            tension: 0.3
+          },
+          {
+            label: 'First-Pass Rate',
+            data: points.map(function(p) { return +((p.first_pass_success_rate || 0) * 100).toFixed(1); }),
+            borderColor: '#60a5fa',
+            backgroundColor: '#60a5fa20',
+            fill: true,
+            pointRadius: 5,
+            pointHoverRadius: 7,
+            pointBackgroundColor: '#60a5fa',
+            borderWidth: 2,
+            tension: 0.3
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: true, labels: { color: '#e2e8f0' } },
+          tooltip: {
+            backgroundColor: '#1e293b',
+            borderColor: '#334155',
+            borderWidth: 1,
+            titleColor: '#e2e8f0',
+            bodyColor: '#e2e8f0',
+            padding: 10,
+            callbacks: {
+              title: function(items) {
+                var p = points[items[0].dataIndex];
+                return (p.repo || '') + (p.milestone ? ' \u2014 ' + p.milestone : '');
+              }
+            }
+          }
+        },
+        scales: {
+          x: {
+            ticks: { color: '#94a3b8', maxRotation: 45, maxTicksLimit: 10, font: { size: 11 } },
+            grid: { color: '#1e293b' }
+          },
+          y: {
+            beginAtZero: true,
+            max: 100,
+            ticks: { color: '#94a3b8', callback: function(v) { return v + '%'; }, stepSize: 25 },
+            grid: { color: '#1e293b' }
+          }
+        }
+      }
+    });
+  })();
+
   makeChart('chart-avg-retries', 'Avg Retries',
     function(p) { return +p.avg_retries.toFixed(2); }, '#f59e0b');
   makeChart('chart-cost', 'Avg Cost / Issue (USD)',


### PR DESCRIPTION
## Summary

- Add 6-tile overview metrics card at top of analysis page (total runs, total issues, success rate, first-pass rate, total cost, avg cost per success)
- Add failure reason breakdown card with progress bars for each failure category (exhaustion, verify, timeout, error)
- Extend cost statistics card with wasted cost, timeout rate, and avg time-to-merge rows
- Update repo table with first-pass rate and avg cost per issue columns
- Replace single-line success rate trend chart with two-dataset chart (overall + first-pass lines)
- Remove exhausted retries row from retry statistics card

## Test plan

- [x] `TestServer_Analysis_OverviewMetricsCard` — verifies all 6 tile labels render
- [x] `TestServer_Analysis_FailureReasonsCard` — verifies failure reason breakdown card is visible with failure data
- [x] `TestServer_Analysis_RepoTableFirstPassAndCostColumns` — verifies new repo table column headers
- [x] `TestServer_Analysis_CostCardWastedCostAndTimeout` — verifies wasted cost, timeout rate, and avg time-to-merge rows
- [x] `TestServer_Analysis_TrendDataHasFirstPassField` — verifies `first_pass_success_rate` in trend JSON and "First-Pass Rate" dataset label
- [x] `TestServer_Analysis_EmptyStateHasNoExhaustedRetriesRow` — verifies exhausted retries row is removed
- [x] All existing dashboard and analysis tests continue to pass

## Implementation Notes

### Approach
All backing view-model types (`OverviewMetrics`, `FailureReasonRow`, extended `RepoRow`, `AvgTimeToMerge`, `TrendPoint.FirstPassSuccessRate`) were already present from prior work (#495/#493). This PR is purely a template + test change.

### Key Decisions
List any non-obvious decisions or trade-offs made during implementation.
- Wasted cost, timeout rate, and avg time-to-merge are added to the cost statistics card rather than a new card — they are efficiency/cost metrics and fit naturally there.
- The success rate two-line chart uses the same inline IIFE pattern as the duration chart rather than calling `makeChart()`, since `makeChart()` only supports single-dataset charts.
- The `first_pass_success_rate` JS field is read with a `|| 0` guard to handle any older trend points that might not have the field.

### Known Limitations
- The "Failure Reason Breakdown" card will show "No failure data recorded" when all issues succeed — this is correct empty-state behavior.

### Architecture
Only the `presentation` layer (`internal/dashboard/`) was modified. The template consumes data from `domain` layer types (`analysis.Report`, `analysis.TrendPoint`) which is within the allowed dependency graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #496