### PR TITLE
feat(progress): add costUSD parameter to IssueCompleted on ProgressReporter

### DIFF
--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -4708,7 +4708,7 @@ func (r *mockReporter) IssueStageChanged(number int, stage string) {
 }
 func (r *mockReporter) RunStarted(_, _, _, _, _, _ string, _ []progress.IssueSummary) {}
 func (r *mockReporter) IssueStarted(_ int, _ string)              {}
-func (r *mockReporter) IssueCompleted(_ int, _ string, _ string, _, _ int, _ string) {
+func (r *mockReporter) IssueCompleted(_ int, _ string, _ string, _, _ int, _ string, _ float64) {
 }
 func (r *mockReporter) WaveStarted(_, _ int)              {}
 func (r *mockReporter) AllBlocked(_, _ int)               {}

--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -273,7 +273,7 @@ func implementIssues(
 		if err != nil {
 			logger.Warn("failed to fetch issue, skipping", "issue_number", issueNumber, "error", err)
 			failed++
-			reporter.IssueCompleted(issueNumber, "", "failed", 0, 0, err.Error())
+			reporter.IssueCompleted(issueNumber, "", "failed", 0, 0, err.Error(), 0.0)
 			continue
 		}
 
@@ -333,23 +333,23 @@ func writeIssueDialogue(writer *rundata.Writer, repo string, issueNumber int, ou
 func applyOutcomeStats(outcome agent.IssueOutcome, issue github.Issue, cfg *config.Config, reporter progress.ProgressReporter, logger *slog.Logger) (int, int, int, int) {
 	switch outcome.Status {
 	case agent.StatusImplemented:
-		reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "")
+		reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "", 0.0)
 		if err := orchestrator.PullAfterMerge(cfg.EffectiveBaseBranch(), logger); err != nil {
 			logger.Warn("could not sync local repo after merge", "error", err)
 		}
 		return 1, 0, 0, 0
 	case agent.StatusReadyToMerge:
-		reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "")
+		reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "", 0.0)
 		return 0, 1, 0, 0
 	case agent.StatusNeedsHumanReview:
-		reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "")
+		reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "", 0.0)
 		return 0, 0, 1, 0
 	default:
 		errMsg := ""
 		if outcome.Err != nil {
 			errMsg = outcome.Err.Error()
 		}
-		reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg)
+		reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg, 0.0)
 		return 0, 0, 0, 1
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -407,7 +407,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 			case agent.StatusImplemented:
 				runStats.implemented++
 				implementedIssues = append(implementedIssues, issue)
-				reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "")
+				reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "", 0.0)
 				if err := PullAfterMerge(baseBranch, logger); err != nil {
 					logger.Warn("stopping loop: could not sync local repo after merge", "error", err)
 					runStats.abortReason = fmt.Sprintf("could not sync after merge: %v", err)
@@ -416,17 +416,17 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 				merged = true
 			case agent.StatusReadyToMerge:
 				runStats.readyToMerge++
-				reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "")
+				reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "", 0.0)
 			case agent.StatusNeedsHumanReview:
 				runStats.needsHumanReview++
-				reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "")
+				reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "", 0.0)
 			default:
 				runStats.failed++
 				errMsg := ""
 				if outcome.Err != nil {
 					errMsg = outcome.Err.Error()
 				}
-				reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg)
+				reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg, 0.0)
 			}
 
 			logger.Info("issue outcome",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -51,6 +51,7 @@ type fakeIssueCompleted struct {
 	prNumber    int
 	retries     int
 	errMsg      string
+	costUSD     float64
 }
 
 type fakeWaveStarted struct {
@@ -80,8 +81,8 @@ type fakeRollupCreated struct {
 func (r *fakeReporter) RunStarted(_, _, _, _, _, _ string, _ []progress.IssueSummary) {}
 func (r *fakeReporter) IssueStarted(_ int, _ string)              {}
 func (r *fakeReporter) IssueStageChanged(_ int, _ string)         {}
-func (r *fakeReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string) {
-	r.issueCompleted = append(r.issueCompleted, fakeIssueCompleted{issueNumber, title, status, prNumber, retries, errMsg})
+func (r *fakeReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string, costUSD float64) {
+	r.issueCompleted = append(r.issueCompleted, fakeIssueCompleted{issueNumber, title, status, prNumber, retries, errMsg, costUSD})
 }
 func (r *fakeReporter) WaveStarted(wave, count int) {
 	r.waveStarted = append(r.waveStarted, fakeWaveStarted{wave, count})

--- a/internal/progress/reporter.go
+++ b/internal/progress/reporter.go
@@ -17,7 +17,7 @@ type ProgressReporter interface {
 	// IssueStageChanged signals a stage transition for an in-progress issue.
 	IssueStageChanged(issueNumber int, stage string)
 	// IssueCompleted signals the final outcome for an issue.
-	IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string)
+	IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string, costUSD float64)
 	// WaveStarted signals a new dependency re-resolution wave.
 	WaveStarted(wave, count int)
 	// AllBlocked signals that all issues are blocked.

--- a/internal/progress/text.go
+++ b/internal/progress/text.go
@@ -35,7 +35,7 @@ func (r *TextReporter) IssueStageChanged(issueNumber int, stage string) {
 }
 
 // IssueCompleted writes the outcome line for an issue.
-func (r *TextReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string) {
+func (r *TextReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string, _ float64) {
 	switch status {
 	case "implemented":
 		fmt.Fprintf(r.w, "  #%d %s \u2014 implemented (PR #%d, %d retries)\n", issueNumber, title, prNumber, retries)

--- a/internal/progress/text_test.go
+++ b/internal/progress/text_test.go
@@ -9,7 +9,7 @@ import (
 func TestIssueCompleted_Implemented(t *testing.T) {
 	var buf bytes.Buffer
 	r := NewTextReporter(&buf)
-	r.IssueCompleted(42, "add cost tracking", "implemented", 87, 0, "")
+	r.IssueCompleted(42, "add cost tracking", "implemented", 87, 0, "", 0.0)
 	want := "  #42 add cost tracking \u2014 implemented (PR #87, 0 retries)\n"
 	if got := buf.String(); got != want {
 		t.Errorf("IssueCompleted implemented\ngot:  %q\nwant: %q", got, want)
@@ -19,7 +19,7 @@ func TestIssueCompleted_Implemented(t *testing.T) {
 func TestIssueCompleted_ReadyToMerge(t *testing.T) {
 	var buf bytes.Buffer
 	r := NewTextReporter(&buf)
-	r.IssueCompleted(10, "fix login", "ready-to-merge", 55, 2, "")
+	r.IssueCompleted(10, "fix login", "ready-to-merge", 55, 2, "", 0.0)
 	want := "  #10 fix login \u2014 ready-to-merge (PR #55, 2 retries)\n"
 	if got := buf.String(); got != want {
 		t.Errorf("IssueCompleted ready-to-merge\ngot:  %q\nwant: %q", got, want)
@@ -29,7 +29,7 @@ func TestIssueCompleted_ReadyToMerge(t *testing.T) {
 func TestIssueCompleted_NeedsHumanReview(t *testing.T) {
 	var buf bytes.Buffer
 	r := NewTextReporter(&buf)
-	r.IssueCompleted(7, "refactor auth", "needs-human-review", 33, 1, "")
+	r.IssueCompleted(7, "refactor auth", "needs-human-review", 33, 1, "", 0.0)
 	want := "  #7 refactor auth \u2014 needs human review (PR #33)\n"
 	if got := buf.String(); got != want {
 		t.Errorf("IssueCompleted needs-human-review\ngot:  %q\nwant: %q", got, want)
@@ -39,7 +39,7 @@ func TestIssueCompleted_NeedsHumanReview(t *testing.T) {
 func TestIssueCompleted_Failed(t *testing.T) {
 	var buf bytes.Buffer
 	r := NewTextReporter(&buf)
-	r.IssueCompleted(42, "add cost tracking", "failed", 0, 0, "timeout")
+	r.IssueCompleted(42, "add cost tracking", "failed", 0, 0, "timeout", 0.0)
 	want := "  #42 add cost tracking \u2014 failed: timeout\n"
 	if got := buf.String(); got != want {
 		t.Errorf("IssueCompleted failed\ngot:  %q\nwant: %q", got, want)

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -20,6 +20,7 @@ type IssueCompletedMsg struct {
 	PRNumber int
 	Retries  int
 	ErrMsg   string
+	CostUSD  float64
 }
 
 // WaveStartedMsg is sent when a new dependency re-resolution wave begins.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -222,6 +222,7 @@ func (m *Model) handleIssueCompleted(msg IssueCompletedMsg) {
 	case "failed":
 		m.failed++
 	}
+	m.totalCost += msg.CostUSD
 }
 
 // handleRunStarted populates header metadata and pre-fills the issue table.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -197,3 +197,48 @@ func TestNewAutoMergeNilWhenEmpty(t *testing.T) {
 		t.Errorf("autoMerge should be nil when both merge fields are empty, got %+v", m.autoMerge)
 	}
 }
+
+// --- Cost accumulation tests ---
+
+func TestHandleIssueCompletedAccumulatesCost(t *testing.T) {
+	m := Model{
+		issueIndex: map[int]int{1: 0},
+		issues:     []issueRow{{number: 1, title: "test"}},
+	}
+
+	m.handleIssueCompleted(IssueCompletedMsg{Number: 1, Status: "implemented", CostUSD: 1.50})
+	m.handleIssueCompleted(IssueCompletedMsg{Number: 1, Status: "implemented", CostUSD: 1.50})
+
+	if m.totalCost != 3.00 {
+		t.Errorf("totalCost: got %f, want 3.00", m.totalCost)
+	}
+}
+
+func TestHandleIssueCompletedZeroCostUnchanged(t *testing.T) {
+	m := Model{
+		issueIndex: map[int]int{1: 0},
+		issues:     []issueRow{{number: 1, title: "test"}},
+	}
+
+	m.handleIssueCompleted(IssueCompletedMsg{Number: 1, Status: "implemented", CostUSD: 0.0})
+
+	if m.totalCost != 0.0 {
+		t.Errorf("totalCost: got %f, want 0.0", m.totalCost)
+	}
+}
+
+func TestModelUpdateAccumulatesCostViaTUIUpdate(t *testing.T) {
+	m := Model{
+		issueIndex: map[int]int{42: 0},
+		issues:     []issueRow{{number: 42, title: "some issue"}},
+	}
+
+	next, _ := m.Update(IssueCompletedMsg{Number: 42, Status: "implemented", CostUSD: 2.25})
+	updated := next.(Model)
+	next2, _ := updated.Update(IssueCompletedMsg{Number: 42, Status: "implemented", CostUSD: 0.75})
+	final := next2.(Model)
+
+	if final.totalCost != 3.00 {
+		t.Errorf("totalCost after two updates: got %f, want 3.00", final.totalCost)
+	}
+}

--- a/internal/tui/reporter.go
+++ b/internal/tui/reporter.go
@@ -54,7 +54,7 @@ func (r *TUIReporter) IssueStageChanged(issueNumber int, stage string) {
 }
 
 // IssueCompleted sends IssueCompletedMsg with the terminal outcome for an issue.
-func (r *TUIReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string) {
+func (r *TUIReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string, costUSD float64) {
 	r.p.Send(IssueCompletedMsg{
 		Number:   issueNumber,
 		Title:    title,
@@ -62,6 +62,7 @@ func (r *TUIReporter) IssueCompleted(issueNumber int, title, status string, prNu
 		PRNumber: prNumber,
 		Retries:  retries,
 		ErrMsg:   errMsg,
+		CostUSD:  costUSD,
 	})
 }
 

--- a/internal/tui/reporter_test.go
+++ b/internal/tui/reporter_test.go
@@ -61,7 +61,7 @@ func TestIssueStageChangedSendsMessage(t *testing.T) {
 
 func TestIssueCompletedSendsMessage(t *testing.T) {
 	r, s := newTestReporter()
-	r.IssueCompleted(42, "add endpoint", "implemented", 87, 0, "")
+	r.IssueCompleted(42, "add endpoint", "implemented", 87, 0, "", 0.0)
 
 	if len(s.msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(s.msgs))
@@ -87,6 +87,9 @@ func TestIssueCompletedSendsMessage(t *testing.T) {
 	}
 	if msg.ErrMsg != "" {
 		t.Errorf("ErrMsg: got %q, want %q", msg.ErrMsg, "")
+	}
+	if msg.CostUSD != 0.0 {
+		t.Errorf("CostUSD: got %f, want 0.0", msg.CostUSD)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `costUSD float64` parameter to `ProgressReporter.IssueCompleted` interface
- Updates all implementors (`TextReporter`, `TUIReporter`) and all call sites with `0.0` placeholder
- Wires `IssueCompletedMsg.CostUSD` through to `m.totalCost` accumulation in `handleIssueCompleted`, fixing the TUI summary bar showing `$0.00`

## Test plan

- [x] `TestIssueCompleted_*` tests in `internal/progress/text_test.go` — all pass with updated `0.0` arg
- [x] `TestIssueCompletedSendsMessage` in `internal/tui/reporter_test.go` — updated with `0.0` arg and `CostUSD` assertion
- [x] `TestHandleIssueCompletedAccumulatesCost` — sends `IssueCompletedMsg{CostUSD: 1.50}` twice, asserts `totalCost == 3.00`
- [x] `TestHandleIssueCompletedZeroCostUnchanged` — sends zero cost, asserts `totalCost` stays `0.0`
- [x] `TestModelUpdateAccumulatesCostViaTUIUpdate` — drives cost accumulation through `Model.Update`
- [x] Build passes: `go build ./...`

## Implementation Notes

### Approach
Pure signature propagation — `costUSD` flows from the interface definition through all implementors into `IssueCompletedMsg.CostUSD`, which `handleIssueCompleted` accumulates into `m.totalCost`. `TextReporter` ignores the parameter (text mode doesn't display cost). All callers pass `0.0` as a placeholder; actual cost values will be wired in a subsequent issue.

### Key Decisions
- Used `_ float64` in `TextReporter` to make the intent explicit that the parameter is intentionally unused.
- Added `CostUSD` as the last field in `IssueCompletedMsg` to match the parameter order convention.
- `m.totalCost += msg.CostUSD` placed after the status switch in `handleIssueCompleted` — accumulation is unconditional regardless of status.

### Known Limitations
- All callers currently pass `0.0`; the TUI summary bar will still show `$0.00` until a future issue wires in actual cost values from the agent outcome.

### Architecture
- `internal/progress/` (foundation layer): interface + `TextReporter` updated
- `internal/tui/` (presentation layer): `messages.go`, `reporter.go`, `model.go` updated
- `internal/orchestrator/` (orchestration layer): 4 call sites updated
- `internal/cmd/` (cmd layer): 5 call sites updated
- No new cross-layer dependencies introduced; the change respects all existing layer boundaries

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)