### PR TITLE
feat: pass per-issue cost to reporter.IssueCompleted

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -281,7 +281,14 @@ func implementIssues(
 		outcome := agent.ProcessIssue(ctx, issue, cfg, prompts, authEnv, logger, hook, reporter)
 		writeIssueDialogue(writer, cfg.Repo, issueNumber, outcome, logger)
 
-		di, drtm, dnhr, df := applyOutcomeStats(outcome, issue, cfg, reporter, logger)
+		// Compute per-issue cost from recorded step result files. Gracefully
+		// degrades to 0.0 when the writer is nil or step files have no cost data.
+		var issueCost float64
+		if writer != nil {
+			issueCost = rundata.IssueCostUSD(writer.IssueDir(issueNumber))
+		}
+
+		di, drtm, dnhr, df := applyOutcomeStats(outcome, issue, cfg, reporter, logger, issueCost)
 		implemented += di
 		readyToMerge += drtm
 		needsHumanReview += dnhr
@@ -330,26 +337,26 @@ func writeIssueDialogue(writer *rundata.Writer, repo string, issueNumber int, ou
 
 // applyOutcomeStats updates the reporter and returns counter increments
 // (implemented, readyToMerge, needsHumanReview, failed).
-func applyOutcomeStats(outcome agent.IssueOutcome, issue github.Issue, cfg *config.Config, reporter progress.ProgressReporter, logger *slog.Logger) (int, int, int, int) {
+func applyOutcomeStats(outcome agent.IssueOutcome, issue github.Issue, cfg *config.Config, reporter progress.ProgressReporter, logger *slog.Logger, costUSD float64) (int, int, int, int) {
 	switch outcome.Status {
 	case agent.StatusImplemented:
-		reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "", 0.0)
+		reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "", costUSD)
 		if err := orchestrator.PullAfterMerge(cfg.EffectiveBaseBranch(), logger); err != nil {
 			logger.Warn("could not sync local repo after merge", "error", err)
 		}
 		return 1, 0, 0, 0
 	case agent.StatusReadyToMerge:
-		reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "", 0.0)
+		reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "", costUSD)
 		return 0, 1, 0, 0
 	case agent.StatusNeedsHumanReview:
-		reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "", 0.0)
+		reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "", costUSD)
 		return 0, 0, 1, 0
 	default:
 		errMsg := ""
 		if outcome.Err != nil {
 			errMsg = outcome.Err.Error()
 		}
-		reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg, 0.0)
+		reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg, costUSD)
 		return 0, 0, 0, 1
 	}
 }

--- a/internal/cmd/implement_test.go
+++ b/internal/cmd/implement_test.go
@@ -7,9 +7,40 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/phs/dark-factory/internal/agent"
+	"github.com/phs/dark-factory/internal/config"
 	"github.com/phs/dark-factory/internal/github"
 	"github.com/phs/dark-factory/internal/notify"
+	"github.com/phs/dark-factory/internal/orchestrator"
+	"github.com/phs/dark-factory/internal/progress"
 )
+
+// stubProgressReporter records IssueCompleted calls for assertions.
+type stubProgressReporter struct {
+	issueCompleted []stubIssueCompleted
+}
+
+type stubIssueCompleted struct {
+	issueNumber int
+	title       string
+	status      string
+	prNumber    int
+	retries     int
+	errMsg      string
+	costUSD     float64
+}
+
+func (r *stubProgressReporter) RunStarted(_, _, _, _, _, _ string, _ []progress.IssueSummary) {}
+func (r *stubProgressReporter) IssueStarted(_ int, _ string)                                   {}
+func (r *stubProgressReporter) IssueStageChanged(_ int, _ string)                              {}
+func (r *stubProgressReporter) IssueCompleted(issueNumber int, title, status string, prNumber, retries int, errMsg string, costUSD float64) {
+	r.issueCompleted = append(r.issueCompleted, stubIssueCompleted{issueNumber, title, status, prNumber, retries, errMsg, costUSD})
+}
+func (r *stubProgressReporter) WaveStarted(_ int, _ int)                                     {}
+func (r *stubProgressReporter) AllBlocked(_ int, _ int)                                      {}
+func (r *stubProgressReporter) RollupCreated(_ int, _ string, _ bool)                        {}
+func (r *stubProgressReporter) RunFinished(_ int, _ int, _ int, _ int, _ int)                {}
+func (r *stubProgressReporter) PunchlistText(_ string)                                       {}
 
 // stubNotifier records sent events and optionally returns an error.
 type stubNotifier struct {
@@ -301,4 +332,65 @@ func TestFireImplementNotification_NoNotifiers(t *testing.T) {
 	// Should not panic with nil or empty slice.
 	notify.Fire(context.Background(), nil, notify.Event{Type: "implementation_complete"}, slog.Default())
 	notify.Fire(context.Background(), []notify.Notifier{}, notify.Event{Type: "implementation_complete"}, slog.Default())
+}
+
+func TestApplyOutcomeStats_PassesCostToReporter(t *testing.T) {
+	issue := github.Issue{Number: 10, Title: "test issue"}
+	cfg := &config.Config{Repo: "owner/repo"}
+	reporter := &stubProgressReporter{}
+	logger := slog.Default()
+
+	tests := []struct {
+		name    string
+		outcome agent.IssueOutcome
+		cost    float64
+	}{
+		{
+			name:    "implemented",
+			outcome: agent.IssueOutcome{IssueNumber: 10, Status: agent.StatusImplemented, PRNumber: 5},
+			cost:    1.50,
+		},
+		{
+			name:    "ready-to-merge",
+			outcome: agent.IssueOutcome{IssueNumber: 10, Status: agent.StatusReadyToMerge, PRNumber: 5},
+			cost:    2.00,
+		},
+		{
+			name:    "needs-human-review",
+			outcome: agent.IssueOutcome{IssueNumber: 10, Status: agent.StatusNeedsHumanReview, PRNumber: 5},
+			cost:    0.75,
+		},
+		{
+			name:    "failed",
+			outcome: agent.IssueOutcome{IssueNumber: 10, Status: agent.StatusFailed, Err: fmt.Errorf("oops")},
+			cost:    0.10,
+		},
+		{
+			name:    "zero cost graceful",
+			outcome: agent.IssueOutcome{IssueNumber: 10, Status: agent.StatusFailed},
+			cost:    0.0,
+		},
+	}
+
+	// Stub orchestrator.CommandRunner so PullAfterMerge (called on StatusImplemented)
+	// does not invoke real git commands.
+	origRunner := orchestrator.CommandRunner
+	orchestrator.CommandRunner = func(_ string, _ ...string) ([]byte, error) { return []byte(""), nil }
+	defer func() { orchestrator.CommandRunner = origRunner }()
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reporter.issueCompleted = nil
+
+			applyOutcomeStats(tc.outcome, issue, cfg, reporter, logger, tc.cost)
+
+			if len(reporter.issueCompleted) != 1 {
+				t.Fatalf("expected 1 IssueCompleted call, got %d", len(reporter.issueCompleted))
+			}
+			got := reporter.issueCompleted[0].costUSD
+			if got != tc.cost {
+				t.Errorf("IssueCompleted costUSD = %f, want %f", got, tc.cost)
+			}
+		})
+	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -403,11 +403,18 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 				}
 			}
 
+			// Compute per-issue cost from recorded step result files. Gracefully
+			// degrades to 0.0 when the writer is nil or step files have no cost data.
+			var issueCost float64
+			if writer != nil {
+				issueCost = rundata.IssueCostUSD(writer.IssueDir(issue.Number))
+			}
+
 			switch outcome.Status {
 			case agent.StatusImplemented:
 				runStats.implemented++
 				implementedIssues = append(implementedIssues, issue)
-				reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "", 0.0)
+				reporter.IssueCompleted(issue.Number, issue.Title, "implemented", outcome.PRNumber, outcome.Retries, "", issueCost)
 				if err := PullAfterMerge(baseBranch, logger); err != nil {
 					logger.Warn("stopping loop: could not sync local repo after merge", "error", err)
 					runStats.abortReason = fmt.Sprintf("could not sync after merge: %v", err)
@@ -416,17 +423,17 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 				merged = true
 			case agent.StatusReadyToMerge:
 				runStats.readyToMerge++
-				reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "", 0.0)
+				reporter.IssueCompleted(issue.Number, issue.Title, "ready-to-merge", outcome.PRNumber, outcome.Retries, "", issueCost)
 			case agent.StatusNeedsHumanReview:
 				runStats.needsHumanReview++
-				reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "", 0.0)
+				reporter.IssueCompleted(issue.Number, issue.Title, "needs-human-review", outcome.PRNumber, 0, "", issueCost)
 			default:
 				runStats.failed++
 				errMsg := ""
 				if outcome.Err != nil {
 					errMsg = outcome.Err.Error()
 				}
-				reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg, 0.0)
+				reporter.IssueCompleted(issue.Number, issue.Title, "failed", 0, 0, errMsg, issueCost)
 			}
 
 			logger.Info("issue outcome",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2082,3 +2082,74 @@ func TestRollupVerify_ManualMode_VerifyFailsLeavesOpen(t *testing.T) {
 		t.Errorf("manual rollup: PR should be left open, got rollupCreated: %v", reporter.rollupCreated)
 	}
 }
+
+// TestReporter_IssueCompleted_WithCost verifies that processIssues reads per-issue
+// cost from step result files written to the run data writer directory and passes
+// the cost to reporter.IssueCompleted.
+func TestReporter_IssueCompleted_WithCost(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 42, Title: "add cost tracking"},
+	}
+
+	setupProcessMocks(t, func() []int { return nil },
+		func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook, _ progress.ProgressReporter) agent.IssueOutcome {
+			return agent.IssueOutcome{IssueNumber: issue.Number, Status: "failed", Err: fmt.Errorf("test error")}
+		})
+
+	// Create a writer with a known step cost so IssueCostUSD can find it.
+	tmpDir := t.TempDir()
+	writer, err := rundata.NewWithBase(tmpDir, "owner/repo", "m1", []int{42}, "", rundata.AutoMerge{})
+	if err != nil {
+		t.Fatalf("NewWithBase() error: %v", err)
+	}
+	if err := writer.WriteImplementResult(42, rundata.StepResult{CostUSD: 1.50}); err != nil {
+		t.Fatalf("WriteImplementResult() error: %v", err)
+	}
+
+	reporter := &fakeReporter{}
+	closedSet := map[int]bool{}
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), reporter, writer, false, "", "m1", nil); err != nil {
+		t.Fatalf("processIssues() error = %v", err)
+	}
+
+	if len(reporter.issueCompleted) != 1 {
+		t.Fatalf("expected 1 IssueCompleted call, got %d", len(reporter.issueCompleted))
+	}
+	got := reporter.issueCompleted[0]
+	if got.costUSD != 1.50 {
+		t.Errorf("IssueCompleted costUSD = %f, want 1.50", got.costUSD)
+	}
+}
+
+// TestReporter_IssueCompleted_ZeroCostWhenNoWriter verifies that cost is 0.0
+// when the writer is nil (no run data directory).
+func TestReporter_IssueCompleted_ZeroCostWhenNoWriter(t *testing.T) {
+	allIssues := []github.Issue{
+		{Number: 99, Title: "no cost"},
+	}
+
+	setupProcessMocks(t, func() []int { return nil },
+		func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook, _ progress.ProgressReporter) agent.IssueOutcome {
+			return agent.IssueOutcome{IssueNumber: issue.Number, Status: "failed"}
+		})
+
+	reporter := &fakeReporter{}
+	closedSet := map[int]bool{}
+	cfg := testConfig()
+	cfg.NoSandbox = true
+
+	// Pass nil writer — cost must degrade gracefully to 0.0.
+	if err := processIssues(context.Background(), allIssues, closedSet, cfg, testLogger(t), reporter, nil, false, "", "m1", nil); err != nil {
+		t.Fatalf("processIssues() error = %v", err)
+	}
+
+	if len(reporter.issueCompleted) != 1 {
+		t.Fatalf("expected 1 IssueCompleted call, got %d", len(reporter.issueCompleted))
+	}
+	if got := reporter.issueCompleted[0].costUSD; got != 0.0 {
+		t.Errorf("IssueCompleted costUSD = %f, want 0.0", got)
+	}
+}

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -169,6 +169,55 @@ func (w *Writer) issueDir(issueNum int) string {
 	return filepath.Join(w.dir, "issues", strconv.Itoa(issueNum))
 }
 
+// IssueDir returns the directory path for the given issue number.
+// Callers use this to locate step result files after processing.
+func (w *Writer) IssueDir(issueNum int) string {
+	return w.issueDir(issueNum)
+}
+
+// IssueCostUSD returns the total cost of all recorded step results in issueDir.
+// It reads recon.json, spec-generator.json, implement.json, quality-review.json,
+// functional-review.json, and all retry subdirectory JSON files. Errors reading
+// individual files are silently ignored — cost computation is best-effort.
+func IssueCostUSD(issueDir string) float64 {
+	var total float64
+	for _, name := range []string{"recon.json", "spec-generator.json", "implement.json", "quality-review.json", "functional-review.json"} {
+		total += readStepCost(filepath.Join(issueDir, name))
+	}
+	retriesDir := filepath.Join(issueDir, "retries")
+	entries, err := os.ReadDir(retriesDir)
+	if err != nil {
+		// No retries directory or unreadable — not an error.
+		return total
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		retryDir := filepath.Join(retriesDir, entry.Name())
+		for _, name := range []string{"retry.json", "quality-review.json", "functional-review.json"} {
+			total += readStepCost(filepath.Join(retryDir, name))
+		}
+	}
+	return total
+}
+
+// readStepCost reads a StepResult JSON file and returns its CostUSD field.
+// Returns 0.0 if the file does not exist or cannot be parsed.
+func readStepCost(path string) float64 {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0.0
+	}
+	var step struct {
+		CostUSD float64 `json:"cost_usd"`
+	}
+	if err := json.Unmarshal(data, &step); err != nil {
+		return 0.0
+	}
+	return step.CostUSD
+}
+
 // issueRetryDir returns the directory path for the given issue and retry number.
 func (w *Writer) issueRetryDir(issueNum, retryNum int) string {
 	return filepath.Join(w.issueDir(issueNum), "retries", strconv.Itoa(retryNum))

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -1139,3 +1139,99 @@ func TestWriteRollupVerifyResultMultipleAttempts(t *testing.T) {
 		}
 	}
 }
+
+func TestIssueCostUSD_NoFiles(t *testing.T) {
+	// When no step files exist, IssueCostUSD must return 0.0.
+	got := IssueCostUSD(t.TempDir())
+	if got != 0.0 {
+		t.Errorf("IssueCostUSD with no files = %f, want 0.0", got)
+	}
+}
+
+func TestIssueCostUSD_SingleStep(t *testing.T) {
+	base := t.TempDir()
+	w, err := NewWithBase(base, "owner/repo", "m1", []int{1}, "", AutoMerge{})
+	if err != nil {
+		t.Fatalf("NewWithBase() error: %v", err)
+	}
+
+	if err := w.WriteImplementResult(1, StepResult{CostUSD: 1.50}); err != nil {
+		t.Fatalf("WriteImplementResult() error: %v", err)
+	}
+
+	got := IssueCostUSD(w.IssueDir(1))
+	if got != 1.50 {
+		t.Errorf("IssueCostUSD = %f, want 1.50", got)
+	}
+}
+
+func TestIssueCostUSD_MultipleSteps(t *testing.T) {
+	base := t.TempDir()
+	w, err := NewWithBase(base, "owner/repo", "m1", []int{7}, "", AutoMerge{})
+	if err != nil {
+		t.Fatalf("NewWithBase() error: %v", err)
+	}
+
+	if err := w.WriteReconResult(7, StepResult{CostUSD: 0.10}); err != nil {
+		t.Fatalf("WriteReconResult() error: %v", err)
+	}
+	if err := w.WriteImplementResult(7, StepResult{CostUSD: 1.00}); err != nil {
+		t.Fatalf("WriteImplementResult() error: %v", err)
+	}
+	if err := w.WriteReviewResult(7, "quality", StepResult{CostUSD: 0.20}); err != nil {
+		t.Fatalf("WriteReviewResult(quality) error: %v", err)
+	}
+	if err := w.WriteReviewResult(7, "functional", StepResult{CostUSD: 0.30}); err != nil {
+		t.Fatalf("WriteReviewResult(functional) error: %v", err)
+	}
+	// Retry steps.
+	if err := w.WriteRetryResult(7, 1, StepResult{CostUSD: 0.80}); err != nil {
+		t.Fatalf("WriteRetryResult() error: %v", err)
+	}
+	if err := w.WriteRetryReviewResult(7, 1, StepResult{CostUSD: 0.15}); err != nil {
+		t.Fatalf("WriteRetryReviewResult() error: %v", err)
+	}
+	if err := w.WriteRetryFunctionalReviewResult(7, 1, StepResult{CostUSD: 0.25}); err != nil {
+		t.Fatalf("WriteRetryFunctionalReviewResult() error: %v", err)
+	}
+
+	const want = 0.10 + 1.00 + 0.20 + 0.30 + 0.80 + 0.15 + 0.25
+	got := IssueCostUSD(w.IssueDir(7))
+	// Use a small epsilon for floating-point comparison.
+	const eps = 1e-9
+	if got < want-eps || got > want+eps {
+		t.Errorf("IssueCostUSD = %.10f, want %.10f", got, want)
+	}
+}
+
+func TestIssueCostUSD_ZeroCostSteps(t *testing.T) {
+	// Steps written without CostUSD (zero value) should not inflate the total.
+	base := t.TempDir()
+	w, err := NewWithBase(base, "owner/repo", "m1", []int{3}, "", AutoMerge{})
+	if err != nil {
+		t.Fatalf("NewWithBase() error: %v", err)
+	}
+
+	if err := w.WriteImplementResult(3, StepResult{}); err != nil {
+		t.Fatalf("WriteImplementResult() error: %v", err)
+	}
+
+	got := IssueCostUSD(w.IssueDir(3))
+	if got != 0.0 {
+		t.Errorf("IssueCostUSD with zero-cost step = %f, want 0.0", got)
+	}
+}
+
+func TestIssueDir(t *testing.T) {
+	base := t.TempDir()
+	w, err := NewWithBase(base, "owner/repo", "m1", []int{5}, "", AutoMerge{})
+	if err != nil {
+		t.Fatalf("NewWithBase() error: %v", err)
+	}
+
+	got := w.IssueDir(5)
+	want := filepath.Join(w.Dir(), "issues", "5")
+	if got != want {
+		t.Errorf("IssueDir(5) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #503

## Summary

- Adds `rundata.IssueCostUSD(issueDir string) float64` — reads step result JSON files (recon, spec-generator, implement, quality-review, functional-review, retries) and sums their `cost_usd` fields
- Adds `rundata.Writer.IssueDir(issueNum int) string` — exposes the issue directory path for callers
- Updates `internal/orchestrator/orchestrator.go` to compute per-issue cost after `processIssueFn` returns, passing it to all four `reporter.IssueCompleted` call sites
- Updates `internal/cmd/implement.go` to compute per-issue cost after `agent.ProcessIssue` returns and thread it through `applyOutcomeStats` to all four `reporter.IssueCompleted` call sites

## Test plan

- [x] `TestIssueCostUSD_NoFiles` — zero when no step files exist
- [x] `TestIssueCostUSD_SingleStep` — correct cost from a single implement.json
- [x] `TestIssueCostUSD_MultipleSteps` — correct sum across all step types + retries
- [x] `TestIssueCostUSD_ZeroCostSteps` — no inflation from steps with zero cost
- [x] `TestIssueDir` — exported IssueDir returns expected path
- [x] `TestReporter_IssueCompleted_WithCost` — orchestrator passes non-zero costUSD when step file has cost data
- [x] `TestReporter_IssueCompleted_ZeroCostWhenNoWriter` — orchestrator passes 0.0 when writer is nil
- [x] `TestApplyOutcomeStats_PassesCostToReporter` — implement command's applyOutcomeStats passes costUSD for all outcome statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Implementation Notes

### Approach
Used Strategy B (read from disk) after `processIssueFn`/`agent.ProcessIssue` returns. A new `rundata.IssueCostUSD(issueDir)` helper reads the named step JSON files and sums their `cost_usd` fields. The orchestrator and implement command compute cost immediately after processing each issue using `writer.IssueDir(issueNum)`, then pass it to `reporter.IssueCompleted`. Graceful degradation to `0.0` when `writer == nil`.

### Key Decisions
- **Strategy B (disk read) over Strategy A (in-memory accumulation)**: Avoids modifying the agent loop sub-functions (`runQualityReviewCycle`, `runFunctionalReviewCycle`, `runVerifyPhase`) which would require threading cost through multiple return values. The disk files are already written by the time `IssueCompleted` is called, so the read is always coherent.
- **`IssueCostUSD` as a package-level function in `rundata`**: Keeps it in the domain layer, alongside the types it reads. No struct receiver needed — just a path.
- **`applyOutcomeStats` signature extended with `costUSD float64`**: Cleanest way to thread cost through the implement command without duplicating the switch logic.
- **Verify-fix costs not captured**: `VerifyStepResult` has no `cost_usd` field and there is no named verify-fix step JSON file. These costs are not included in the sum — acceptable per the issue's graceful degradation requirement.

### Known Limitations
- Verify-fix agent costs are not captured (no step file written for verify-fix). This is consistent with the existing on-disk schema and acceptable per the issue spec.
- Cost is read from disk after each issue completes. If step files are not written (e.g. writer is nil), cost is 0.0.

### Architecture
- `internal/rundata` (domain layer): new `IssueCostUSD` function and `IssueDir` method
- `internal/orchestrator` (orchestration layer): imports `rundata`, already in dependency graph
- `internal/cmd` (cmd layer): imports `rundata`, already in dependency graph
- No new cross-layer dependencies introduced