### PR TITLE
feat(cmd): add --no-tui flag to godark watch

### DIFF
--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -28,6 +28,7 @@ linked issue is closed.
 Runs as a long-lived foreground process. Press Ctrl+C to stop.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		configPath, _ := cmd.Flags().GetString("config")
+		noTUI, _ := cmd.Flags().GetBool("no-tui")
 		flags := config.CLIFlags{Config: configPath}
 		if cmd.Flags().Changed("repo") {
 			v, _ := cmd.Flags().GetString("repo")
@@ -39,12 +40,22 @@ Runs as a long-lived foreground process. Press Ctrl+C to stop.`,
 			return fmt.Errorf("loading config: %w", err)
 		}
 
+		// Determine whether to use TUI mode: interactive terminal and --no-tui not set.
+		useTUI := !noTUI && isTerminalFn(int(os.Stdout.Fd()))
+
+		// Select the appropriate logger factory. In TUI mode the TUI owns stdout,
+		// so the logger must write only to the JSON file.
+		logFactory := logging.NewLogger
+		if useTUI {
+			logFactory = logging.NewLoggerFileOnly
+		}
+
 		logDir, err := os.MkdirTemp("", "godark-watch-*")
 		if err != nil {
 			return fmt.Errorf("creating temp log dir: %w", err)
 		}
 
-		logger, err := logging.NewLogger(logDir)
+		logger, err := logFactory(logDir)
 		if err != nil {
 			return fmt.Errorf("creating logger: %w", err)
 		}
@@ -71,6 +82,7 @@ func init() {
 	f := watchCmd.Flags()
 	f.String("repo", "", "GitHub repository (owner/repo)")
 	f.String("config", "godark.yaml", "Path to configuration file")
+	f.Bool("no-tui", false, "Disable TUI and use plain-text output")
 
 	rootCmd.AddCommand(watchCmd)
 }

--- a/internal/cmd/watch_test.go
+++ b/internal/cmd/watch_test.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"os"
 	"testing"
+
+	"github.com/phs/dark-factory/internal/logging"
 )
 
 func TestWatchCmd_Registered(t *testing.T) {
@@ -24,4 +27,95 @@ func TestWatchCmd_HasHelpOutput(t *testing.T) {
 	if watchCmd.Short == "" {
 		t.Error("watchCmd.Short must not be empty")
 	}
+}
+
+// TestWatchCmd_NoTUIFlagRegistered verifies that the --no-tui flag is present
+// on watchCmd so that `godark watch --help` shows it.
+func TestWatchCmd_NoTUIFlagRegistered(t *testing.T) {
+	if watchCmd.Flags().Lookup("no-tui") == nil {
+		t.Error("expected --no-tui flag to be registered on watchCmd")
+	}
+}
+
+// TestWatchCmd_LoggerSelection_TUIMode verifies that when the terminal is
+// interactive (and --no-tui is not set), the file-only logger factory is
+// selected.
+func TestWatchCmd_LoggerSelection_TUIMode(t *testing.T) {
+	orig := isTerminalFn
+	isTerminalFn = func(_ int) bool { return true }
+	defer func() { isTerminalFn = orig }()
+
+	// Simulate the logger selection logic from RunE.
+	noTUI := false
+	useTUI := !noTUI && isTerminalFn(0)
+	logFactory := logging.NewLogger
+	if useTUI {
+		logFactory = logging.NewLoggerFileOnly
+	}
+
+	dir := t.TempDir()
+	logger, err := logFactory(dir)
+	if err != nil {
+		t.Fatalf("logFactory returned error: %v", err)
+	}
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+
+	// In TUI mode the file debug.log must exist and stdout must not be written to.
+	entries, err := readDir(t, dir)
+	if err != nil {
+		t.Fatalf("reading log dir: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if e == "debug.log" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected debug.log to be created by NewLoggerFileOnly")
+	}
+}
+
+// TestWatchCmd_LoggerSelection_NoTUIForced verifies that --no-tui forces the
+// standard logger even when the terminal appears interactive.
+func TestWatchCmd_LoggerSelection_NoTUIForced(t *testing.T) {
+	orig := isTerminalFn
+	isTerminalFn = func(_ int) bool { return true }
+	defer func() { isTerminalFn = orig }()
+
+	// Simulate the logger selection logic from RunE with --no-tui set.
+	noTUI := true
+	useTUI := !noTUI && isTerminalFn(0)
+	logFactory := logging.NewLogger
+	if useTUI {
+		logFactory = logging.NewLoggerFileOnly
+	}
+
+	// useTUI must be false when noTUI is true.
+	if useTUI {
+		t.Error("expected useTUI=false when --no-tui is set")
+	}
+
+	dir := t.TempDir()
+	logger, err := logFactory(dir)
+	if err != nil {
+		t.Fatalf("logFactory returned error: %v", err)
+	}
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+}
+
+// readDir returns a list of entry names in dir.
+func readDir(t *testing.T, dir string) ([]string, error) {
+	t.Helper()
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	names, err := f.Readdirnames(-1)
+	return names, err
 }


### PR DESCRIPTION
## Summary

- Adds `--no-tui` flag to `godark watch` for consistency with `godark run` and `godark implement`
- When an interactive terminal is detected and `--no-tui` is not set, the file-only logger (`NewLoggerFileOnly`) is selected; otherwise the standard logger is used
- TUI rendering is a no-op for now — the flag only controls logger selection

## Test plan

- [x] `TestWatchCmd_NoTUIFlagRegistered` — flag is present on `watchCmd`
- [x] `TestWatchCmd_LoggerSelection_TUIMode` — TUI mode selects file-only logger
- [x] `TestWatchCmd_LoggerSelection_NoTUIForced` — `--no-tui` forces standard logger even with interactive terminal
- [x] All existing cmd tests pass

---

## Implementation Notes

### Approach
Applied the identical `--no-tui` pattern already used in `run.go` (lines 67–87): read the `no-tui` flag, compute `useTUI`, select a `logFactory` variable, then call `logFactory(logDir)` instead of the hardcoded `logging.NewLogger(logDir)`.

### Key Decisions
- Reused the existing `isTerminalFn` package-level variable from `run.go` (same `cmd` package) rather than importing `golang.org/x/term` directly in `watch.go`. This keeps the testability seam consistent and avoids a redundant import.
- TUI is intentionally a no-op: the `useTUI` value only drives `logFactory` selection; no TUI program is instantiated. This is consistent with the issue spec ("TUI mode is a no-op for now").

### Known Limitations
- Actual TUI rendering for the watch command is deferred to the next issue.

### Architecture
- Only the `cmd` layer (`internal/cmd/`) was touched.
- `cmd` already depends on `foundation` (`internal/logging/`) — no new layer dependencies introduced.
- `isTerminalFn` is defined in `run.go` within the same `cmd` package, so no cross-package dependency was added.

Closes #517