### PR TITLE
feat(dashboard): surface peak memory and CPU time in issue detail view

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -113,6 +113,8 @@ type TimelineStepView struct {
 	MarkerClass    string // "success", "danger", "warning", "info", "neutral"
 	Duration       string // formatted duration, e.g. "42s" or "—"
 	Cost           string // formatted cost, e.g. "$0.0042" or "—"
+	PeakMemory     string // formatted peak memory, e.g. "123.4 MB" or "—"
+	CPUTime        string // formatted CPU time, e.g. "1.23s" or "—"
 	Verdict        string // "Passed", "Failed", "Flagged", "Error", "—"
 	VerdictClass   string // badge class suffix
 	Flags          []rundata.Flag
@@ -667,6 +669,8 @@ func stepToView(name string, step rundata.StepResult) TimelineStepView {
 		MarkerClass:  markerClass,
 		Duration:     formatDuration(step.DurationSeconds),
 		Cost:         formatCost(step.CostUSD),
+		PeakMemory:   formatMemoryMB(step.PeakMemoryBytes),
+		CPUTime:      formatCPUSecs(step.CPUNanoseconds),
 		Verdict:      verdict,
 		VerdictClass: verdictClass,
 		Flags:        step.Flags,
@@ -725,6 +729,8 @@ func verifyToTimelineView(vr rundata.VerifyStepResult) TimelineStepView {
 		MarkerClass:    markerClass,
 		Duration:       "—",
 		Cost:           "—",
+		PeakMemory:     "—",
+		CPUTime:        "—",
 		Verdict:        verdict,
 		VerdictClass:   verdictClass,
 		HasOutput:      output != "",
@@ -753,6 +759,22 @@ func formatDuration(seconds float64) string {
 	mins := int(d.Minutes())
 	secs := int(d.Seconds()) % 60
 	return fmt.Sprintf("%dm%ds", mins, secs)
+}
+
+// formatMemoryMB formats bytes as MB with 1 decimal place, or "—" for zero.
+func formatMemoryMB(bytes int64) string {
+	if bytes == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%.1f MB", float64(bytes)/1048576)
+}
+
+// formatCPUSecs formats nanoseconds as seconds with 2 decimal places, or "—" for zero.
+func formatCPUSecs(nanos int64) string {
+	if nanos == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%.2fs", float64(nanos)/1e9)
 }
 
 // OutcomeRow is one row in the outcome distribution table on the analysis page.

--- a/internal/dashboard/handlers_detail_test.go
+++ b/internal/dashboard/handlers_detail_test.go
@@ -1705,3 +1705,149 @@ func TestServer_IssueDetail_VerifyCheckSummaries_NoChecks(t *testing.T) {
 		t.Errorf("body missing 'Passed' verdict")
 	}
 }
+
+// --- Resource stats tests ---
+
+func TestServer_IssueDetail_ResourceStats_WithData(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		IssueNumbers: []int{60},
+		StartedAt:    now,
+	})
+
+	issueDir := buildIssueDir(t, runDir, 60)
+	// 104857600 bytes = 100.0 MB; 2500000000 ns = 2.50s
+	writeJSON(t, filepath.Join(issueDir, "implement.json"), rundata.StepResult{
+		Output:          "done",
+		DurationSeconds: 30,
+		CostUSD:         0.001,
+		PeakMemoryBytes: 104857600,
+		CPUNanoseconds:  2500000000,
+	})
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"), rundata.Outcome{
+		IssueNumber: 60,
+		Status:      "implemented",
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/60", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+
+	if !strings.Contains(body, "100.0 MB") {
+		t.Errorf("body missing formatted peak memory '100.0 MB'; got: %q", truncate(body, 500))
+	}
+	if !strings.Contains(body, "2.50s") {
+		t.Errorf("body missing formatted CPU time '2.50s'; got: %q", truncate(body, 500))
+	}
+}
+
+func TestServer_IssueDetail_ResourceStats_NoData(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		IssueNumbers: []int{61},
+		StartedAt:    now,
+	})
+
+	issueDir := buildIssueDir(t, runDir, 61)
+	// Older run: resource fields absent (zero values).
+	writeJSON(t, filepath.Join(issueDir, "implement.json"), rundata.StepResult{
+		Output:          "done",
+		DurationSeconds: 15,
+		CostUSD:         0.0005,
+		// PeakMemoryBytes and CPUNanoseconds intentionally zero (pre-feature run).
+	})
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"), rundata.Outcome{
+		IssueNumber: 61,
+		Status:      "implemented",
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/61", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+
+	// Both resource columns should show the placeholder "—" for zero values.
+	// We check that "—" appears (it will appear at least for the two resource columns).
+	count := strings.Count(body, "—")
+	if count < 2 {
+		t.Errorf("expected at least 2 '—' placeholders for missing resource data, got %d; body: %q", count, truncate(body, 500))
+	}
+	// Ensure no MB or CPU seconds values are rendered for zero data.
+	if strings.Contains(body, " MB") {
+		t.Errorf("body should not contain ' MB' when PeakMemoryBytes is zero; got: %q", truncate(body, 500))
+	}
+}
+
+func TestServer_IssueDetail_ResourceStats_MixedSteps(t *testing.T) {
+	tmpDir := t.TempDir()
+	now := time.Now().UTC()
+	ts := now.Format("20060102-150405")
+
+	runDir := buildRunDir(t, tmpDir, "acme", "proj", ts, rundata.RunMeta{
+		Repo:         "acme/proj",
+		IssueNumbers: []int{62},
+		StartedAt:    now,
+	})
+
+	issueDir := buildIssueDir(t, runDir, 62)
+	// Implement step has resource data.
+	writeJSON(t, filepath.Join(issueDir, "implement.json"), rundata.StepResult{
+		Output:          "done",
+		DurationSeconds: 20,
+		CostUSD:         0.002,
+		PeakMemoryBytes: 52428800, // 50.0 MB
+		CPUNanoseconds:  1000000000, // 1.00s
+	})
+	// Quality review step has no resource data.
+	writeJSON(t, filepath.Join(issueDir, "quality-review.json"), rundata.StepResult{
+		Output:          "AGENT_RESULT=APPROVED",
+		DurationSeconds: 10,
+		CostUSD:         0.001,
+		// No resource fields.
+	})
+	writeJSON(t, filepath.Join(issueDir, "outcome.json"), rundata.Outcome{
+		IssueNumber: 62,
+		Status:      "implemented",
+	})
+
+	srv := newServer(t, tmpDir)
+	req := httptest.NewRequest(http.MethodGet, "/runs/acme/proj/"+ts+"/issues/62", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %q", rr.Code, truncate(rr.Body.String(), 300))
+	}
+	body := rr.Body.String()
+
+	// Implement step should show resource values.
+	if !strings.Contains(body, "50.0 MB") {
+		t.Errorf("body missing '50.0 MB' for implement step; got: %q", truncate(body, 500))
+	}
+	if !strings.Contains(body, "1.00s") {
+		t.Errorf("body missing '1.00s' for implement step; got: %q", truncate(body, 500))
+	}
+	// Quality review step (no resource data) should contribute "—" placeholders.
+	if !strings.Contains(body, "—") {
+		t.Errorf("body missing '—' placeholder for quality review step with no resource data")
+	}
+}

--- a/internal/dashboard/templates/issue-detail.html
+++ b/internal/dashboard/templates/issue-detail.html
@@ -262,6 +262,10 @@
         <span>{{.Duration}}</span>
         <span class="text-muted">&middot;</span>
         <span>{{.Cost}}</span>
+        <span class="text-muted">&middot;</span>
+        <span>{{.PeakMemory}}</span>
+        <span class="text-muted">&middot;</span>
+        <span>{{.CPUTime}}</span>
       </div>
       {{if .HasOutput}}
       <div class="expandable mt-2" x-data="{ outputOpen: false }">


### PR DESCRIPTION
## Summary

- Add `PeakMemory` and `CPUTime` fields to `TimelineStepView` in `internal/dashboard/handlers.go`
- Populate those fields via new `formatMemoryMB` (bytes → MB, 1 dp) and `formatCPUSecs` (ns → seconds, 2 dp) helpers in `stepToView`; verify steps hard-code `"—"` as they have no resource data
- Extend the `.timeline__meta` span row in `issue-detail.html` to display the two new columns
- Add three test cases covering: step with data, step without data (pre-feature run), and mixed steps

Closes #546

## Implementation Notes

### Approach
Followed the established pattern of pre-formatting display strings in Go (`formatCost`, `formatDuration`) and passing them as typed string fields to the template. No template logic needed — all formatting stays in the handler layer.

### Key Decisions
- `formatMemoryMB`: `bytes / 1048576` with `"%.1f MB"` format (exact 1 MiB divisor as specified)
- `formatCPUSecs`: `nanos / 1e9` with `"%.2fs"` format
- Both return `"—"` for zero, consistent with `formatCost` and `formatDuration`
- `verifyToTimelineView` explicitly sets both new fields to `"—"` since `VerifyStepResult` has no resource fields
- New spans added inside the existing `.timeline__meta` div using the same `&middot;` separator pattern — no table refactor needed

### Known Limitations
None. `PeakMemoryBytes` and `CPUNanoseconds` were already present in `rundata.StepResult` (added by #544).

### Architecture
Only the **presentation** layer (`internal/dashboard/`) was modified. It reads `rundata.StepResult` fields which is already an allowed dependency (domain → presentation). No new dependencies introduced.