### PR TITLE
feat(sandbox): map docker_compose config through DockerConfig

### DIFF
--- a/internal/cmd/implement.go
+++ b/internal/cmd/implement.go
@@ -158,7 +158,7 @@ Issue numbers may be provided as positional arguments, via --issues, or both.`,
 		}
 
 		if !cfg.NoSandbox {
-			dc := sandbox.DockerConfigFromConfig(cfg.Docker, cfg.Runtime, cfg.SandboxEnv)
+			dc := sandbox.DockerConfigFromConfig(cfg.Docker, cfg.Runtime, cfg.SandboxEnv, cfg.DockerCompose)
 			tag, err := sandbox.BuildImage(cmd.Context(), dc, logger)
 			if err != nil {
 				return fmt.Errorf("building Docker image: %w", err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -315,7 +315,7 @@ func prepareResolveEnv(ctx context.Context, cfg *config.Config, logger *slog.Log
 	}
 
 	if !cfg.NoSandbox {
-		dc := sandbox.DockerConfigFromConfig(cfg.Docker, cfg.Runtime, cfg.SandboxEnv)
+		dc := sandbox.DockerConfigFromConfig(cfg.Docker, cfg.Runtime, cfg.SandboxEnv, cfg.DockerCompose)
 		tag, err := sandbox.BuildImage(ctx, dc, logger)
 		if err != nil {
 			return nil, nil, fmt.Errorf("building Docker image: %w", err)
@@ -591,7 +591,7 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 
 	// Build Docker image once if using sandbox mode.
 	if !cfg.NoSandbox {
-		dc := sandbox.DockerConfigFromConfig(cfg.Docker, cfg.Runtime, cfg.SandboxEnv)
+		dc := sandbox.DockerConfigFromConfig(cfg.Docker, cfg.Runtime, cfg.SandboxEnv, cfg.DockerCompose)
 		tag, err := sandbox.BuildImage(ctx, dc, logger)
 		if err != nil {
 			return fmt.Errorf("building Docker image: %w", err)

--- a/internal/sandbox/config.go
+++ b/internal/sandbox/config.go
@@ -9,14 +9,16 @@ import (
 
 // DockerConfig holds the resolved configuration for Dockerfile generation.
 type DockerConfig struct {
-	Image           string
-	Runtime         config.Runtime
-	NodeVersion     string
-	User            string
-	ExtraPackages   []string
-	InstallCommands []string
-	Mount           string
-	SandboxEnv      map[string]string
+	Image              string
+	Runtime            config.Runtime
+	NodeVersion        string
+	User               string
+	ExtraPackages      []string
+	InstallCommands    []string
+	Mount              string
+	SandboxEnv         map[string]string
+	ComposeFile        string
+	ComposeProjectName string
 }
 
 // DefaultDockerConfig returns a DockerConfig with sensible defaults.
@@ -28,9 +30,10 @@ func DefaultDockerConfig() DockerConfig {
 	}
 }
 
-// DockerConfigFromConfig maps a config.Docker, config.Runtime, and sandbox environment
-// variables into a DockerConfig, applying defaults for any zero-value fields.
-func DockerConfigFromConfig(docker config.Docker, runtime config.Runtime, sandboxEnv map[string]string) DockerConfig {
+// DockerConfigFromConfig maps a config.Docker, config.Runtime, sandbox environment
+// variables, and an optional config.DockerCompose into a DockerConfig, applying
+// defaults for any zero-value fields. compose may be nil (feature disabled).
+func DockerConfigFromConfig(docker config.Docker, runtime config.Runtime, sandboxEnv map[string]string, compose *config.DockerCompose) DockerConfig {
 	dc := DefaultDockerConfig()
 	if docker.Image != "" {
 		dc.Image = docker.Image
@@ -52,6 +55,10 @@ func DockerConfigFromConfig(docker config.Docker, runtime config.Runtime, sandbo
 		dc.InstallCommands = docker.InstallCommands
 	}
 	dc.SandboxEnv = sandboxEnv
+	if compose != nil {
+		dc.ComposeFile = compose.File
+		dc.ComposeProjectName = compose.ProjectName
+	}
 	return dc
 }
 

--- a/internal/sandbox/dockerfile_test.go
+++ b/internal/sandbox/dockerfile_test.go
@@ -39,7 +39,7 @@ func TestDockerConfigFromConfig(t *testing.T) {
 		ExtraPackages: []string{"vim", "jq"},
 	}
 	runtime := config.Runtime{Name: "go", Version: "1.26.0"}
-	dc := DockerConfigFromConfig(docker, runtime, map[string]string{"GOOS": "linux"})
+	dc := DockerConfigFromConfig(docker, runtime, map[string]string{"GOOS": "linux"}, nil)
 
 	if dc.Image != "debian:bookworm" {
 		t.Errorf("Image = %q, want debian:bookworm", dc.Image)
@@ -68,7 +68,7 @@ func TestDockerConfigFromConfig(t *testing.T) {
 }
 
 func TestDockerConfigFromConfigDefaults(t *testing.T) {
-	dc := DockerConfigFromConfig(config.Docker{}, config.Runtime{}, nil)
+	dc := DockerConfigFromConfig(config.Docker{}, config.Runtime{}, nil, nil)
 	def := DefaultDockerConfig()
 
 	if dc.Image != def.Image {
@@ -736,7 +736,7 @@ func TestDockerConfigFromConfigInstallCommands(t *testing.T) {
 			"curl -sSfL https://golangci-lint.run/install.sh | sh -s v2.10.1",
 		},
 	}
-	dc := DockerConfigFromConfig(docker, config.Runtime{}, nil)
+	dc := DockerConfigFromConfig(docker, config.Runtime{}, nil, nil)
 
 	if len(dc.InstallCommands) != 1 {
 		t.Fatalf("InstallCommands len = %d, want 1", len(dc.InstallCommands))
@@ -748,7 +748,7 @@ func TestDockerConfigFromConfigInstallCommands(t *testing.T) {
 
 func TestDockerConfigFromConfigInstallCommandsEmpty(t *testing.T) {
 	// Empty install_commands in config should leave DockerConfig.InstallCommands nil.
-	dc := DockerConfigFromConfig(config.Docker{}, config.Runtime{}, nil)
+	dc := DockerConfigFromConfig(config.Docker{}, config.Runtime{}, nil, nil)
 	if len(dc.InstallCommands) != 0 {
 		t.Errorf("InstallCommands = %v, want empty", dc.InstallCommands)
 	}
@@ -792,5 +792,53 @@ func TestImageTagChangesWithRuntime(t *testing.T) {
 	tagNode := ImageTag(dfNode)
 	if tagGo == tagNode {
 		t.Error("image tags should differ when runtime changes")
+	}
+}
+
+func TestDockerConfigFromConfigComposeConfigured(t *testing.T) {
+	compose := &config.DockerCompose{
+		File:        "docker-compose.test.yml",
+		ProjectName: "myproject",
+	}
+	dc := DockerConfigFromConfig(config.Docker{}, config.Runtime{}, nil, compose)
+
+	if dc.ComposeFile != "docker-compose.test.yml" {
+		t.Errorf("ComposeFile = %q, want docker-compose.test.yml", dc.ComposeFile)
+	}
+	if dc.ComposeProjectName != "myproject" {
+		t.Errorf("ComposeProjectName = %q, want myproject", dc.ComposeProjectName)
+	}
+}
+
+func TestDockerConfigFromConfigComposeAbsent(t *testing.T) {
+	dc := DockerConfigFromConfig(config.Docker{}, config.Runtime{}, nil, nil)
+
+	if dc.ComposeFile != "" {
+		t.Errorf("ComposeFile = %q, want empty string", dc.ComposeFile)
+	}
+	if dc.ComposeProjectName != "" {
+		t.Errorf("ComposeProjectName = %q, want empty string", dc.ComposeProjectName)
+	}
+}
+
+func TestDockerConfigFromConfigComposeRoundTrip(t *testing.T) {
+	compose := &config.DockerCompose{
+		File:        "infra/compose.yml",
+		ProjectName: "ci",
+	}
+	docker := config.Docker{Image: "ubuntu:22.04"}
+	dc := DockerConfigFromConfig(docker, config.Runtime{Name: "go", Version: "1.26.0"}, map[string]string{"FOO": "bar"}, compose)
+
+	if dc.Image != "ubuntu:22.04" {
+		t.Errorf("Image = %q, want ubuntu:22.04", dc.Image)
+	}
+	if dc.ComposeFile != "infra/compose.yml" {
+		t.Errorf("ComposeFile = %q, want infra/compose.yml", dc.ComposeFile)
+	}
+	if dc.ComposeProjectName != "ci" {
+		t.Errorf("ComposeProjectName = %q, want ci", dc.ComposeProjectName)
+	}
+	if dc.SandboxEnv["FOO"] != "bar" {
+		t.Errorf("SandboxEnv[FOO] = %q, want bar", dc.SandboxEnv["FOO"])
 	}
 }


### PR DESCRIPTION
Closes #557

## Summary

- Add `ComposeFile string` and `ComposeProjectName string` fields to `DockerConfig` in `internal/sandbox/config.go`
- Extend `DockerConfigFromConfig` with a fourth parameter `compose *config.DockerCompose`; fields are populated nil-safely
- Update three production call sites (orchestrator ×2, cmd/implement) to pass `cfg.DockerCompose`
- Update four existing test call sites to pass `nil`; add three new test cases covering compose configured, compose absent, and round-trip

## Test plan

- [x] `go build ./...` — clean compile
- [x] `go test ./internal/sandbox/...` — all tests pass including the three new compose tests
- [x] Existing tests updated with `nil` compose arg (no behavior change)

## Implementation Notes

### Approach
Added a fourth `compose *config.DockerCompose` parameter to `DockerConfigFromConfig`. When non-nil, `File` and `ProjectName` are copied into the two new `DockerConfig` fields. All existing callers now pass `cfg.DockerCompose` (which may be nil when the feature is not configured), preserving existing behavior.

### Key Decisions
- Fourth parameter rather than passing full `*config.Config`, consistent with the existing pattern of passing `config.Docker` and `config.Runtime` individually.
- Nil-guard is a simple `if compose != nil` block — no extra abstraction needed for this data-plumbing change.

### Known Limitations
None. This is pure data plumbing; no behavioral changes.

### Architecture
- `internal/sandbox/` (infrastructure) — primary change; already imported `internal/config/` (foundation), no new layer dependencies.
- `internal/orchestrator/` (orchestration) and `internal/cmd/` (cmd) — call-site updates only; both are permitted to depend on infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)