### PR TITLE
feat(sandbox): add MountDockerSocket to RunOpts

### DIFF
--- a/internal/sandbox/container.go
+++ b/internal/sandbox/container.go
@@ -15,11 +15,12 @@ import (
 
 // RunOpts configures a container run.
 type RunOpts struct {
-	Image   string
-	Cmd     []string
-	Env     map[string]string
-	Timeout time.Duration
-	Mount   string // host:container bind mount
+	Image             string
+	Cmd               []string
+	Env               map[string]string
+	Timeout           time.Duration
+	Mount             string // host:container bind mount
+	MountDockerSocket bool   // mount /var/run/docker.sock into the container
 }
 
 // RunResult holds the outcome of a container run.
@@ -93,6 +94,9 @@ func RunContainer(ctx context.Context, opts RunOpts, logger *slog.Logger) (*RunR
 	}
 	if opts.Mount != "" {
 		createArgs = append(createArgs, "-v", opts.Mount)
+	}
+	if opts.MountDockerSocket {
+		createArgs = append(createArgs, "-v", "/var/run/docker.sock:/var/run/docker.sock")
 	}
 	createArgs = append(createArgs, opts.Image)
 	createArgs = append(createArgs, opts.Cmd...)

--- a/internal/sandbox/container_test.go
+++ b/internal/sandbox/container_test.go
@@ -196,6 +196,102 @@ func TestRunContainerMount(t *testing.T) {
 	}
 }
 
+func TestRunContainerDockerSocketMountEnabled(t *testing.T) {
+	defer saveRunners()()
+
+	var createArgs string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "create" {
+			createArgs = strings.Join(args, " ")
+			return []byte("abc123\n"), nil
+		}
+		return []byte{}, nil
+	}
+	CommandRunnerWithContext = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		return []byte("0\n"), nil
+	}
+	SplitRunner = func(name string, args ...string) ([]byte, []byte, error) {
+		return nil, nil, nil
+	}
+
+	_, err := RunContainer(context.Background(), RunOpts{
+		Image:             "test:latest",
+		Cmd:               []string{"docker", "ps"},
+		MountDockerSocket: true,
+	}, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(createArgs, "-v /var/run/docker.sock:/var/run/docker.sock") {
+		t.Errorf("docker create missing socket mount, got: %s", createArgs)
+	}
+}
+
+func TestRunContainerDockerSocketMountDisabled(t *testing.T) {
+	defer saveRunners()()
+
+	var createArgs string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "create" {
+			createArgs = strings.Join(args, " ")
+			return []byte("abc123\n"), nil
+		}
+		return []byte{}, nil
+	}
+	CommandRunnerWithContext = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		return []byte("0\n"), nil
+	}
+	SplitRunner = func(name string, args ...string) ([]byte, []byte, error) {
+		return nil, nil, nil
+	}
+
+	_, err := RunContainer(context.Background(), RunOpts{
+		Image: "test:latest",
+		Cmd:   []string{"ls"},
+	}, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(createArgs, "docker.sock") {
+		t.Errorf("docker create should not include socket mount, got: %s", createArgs)
+	}
+}
+
+func TestRunContainerBothMounts(t *testing.T) {
+	defer saveRunners()()
+
+	var createArgs string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		if len(args) > 0 && args[0] == "create" {
+			createArgs = strings.Join(args, " ")
+			return []byte("abc123\n"), nil
+		}
+		return []byte{}, nil
+	}
+	CommandRunnerWithContext = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		return []byte("0\n"), nil
+	}
+	SplitRunner = func(name string, args ...string) ([]byte, []byte, error) {
+		return nil, nil, nil
+	}
+
+	_, err := RunContainer(context.Background(), RunOpts{
+		Image:             "test:latest",
+		Cmd:               []string{"ls"},
+		Mount:             "/host/path:/container/path",
+		MountDockerSocket: true,
+	}, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(createArgs, "-v /host/path:/container/path") {
+		t.Errorf("docker create missing workspace mount, got: %s", createArgs)
+	}
+	if !strings.Contains(createArgs, "-v /var/run/docker.sock:/var/run/docker.sock") {
+		t.Errorf("docker create missing socket mount, got: %s", createArgs)
+	}
+}
+
 func TestRunContainerTimeout(t *testing.T) {
 	defer saveRunners()()
 


### PR DESCRIPTION
## Summary

- Add `MountDockerSocket bool` field to `sandbox.RunOpts`
- When `true`, appends `-v /var/run/docker.sock:/var/run/docker.sock` to `docker create` args
- Three new tests cover: socket mount enabled, disabled, and combined with workspace mount

## Test plan

- [x] `TestRunContainerDockerSocketMountEnabled` — verifies socket `-v` flag appears when `MountDockerSocket: true`
- [x] `TestRunContainerDockerSocketMountDisabled` — verifies socket path absent when `MountDockerSocket` is zero value
- [x] `TestRunContainerBothMounts` — verifies both `-v` flags present when both `Mount` and `MountDockerSocket` are set
- [x] All existing tests continue to pass (`go test ./internal/sandbox/...`)

## Implementation Notes

### Approach
Added `MountDockerSocket bool` as an independent field in `RunOpts` and inserted a standalone `if opts.MountDockerSocket` block immediately after the existing `opts.Mount` block in `RunContainer`. The two mount conditionals are fully independent, so both can apply simultaneously without any interaction.

### Key Decisions
- Socket path `/var/run/docker.sock:/var/run/docker.sock` is a hard-coded literal — no config lookup needed, matching the issue's spec.
- The new field defaults to `false` (Go zero value), so all existing callers are unaffected with no code changes required.

### Known Limitations
- Caller wiring (setting `MountDockerSocket` from config in `launcher.go` or orchestrator) is deferred to a later issue (~#560) per the recon brief.

### Architecture
- Only `internal/sandbox/` (infrastructure layer) was touched — no upward imports, no layer violations.

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)