### PR TITLE
feat(sandbox): install Docker CLI when compose is configured (#559)

### DIFF
--- a/internal/sandbox/dockerfile.go
+++ b/internal/sandbox/dockerfile.go
@@ -35,6 +35,13 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
+{{- if .HasCompose}}
+# Install Docker CLI for compose support
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    docker.io \
+    docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/*
+{{- end}}
 {{if eq .RuntimeName "go"}}
 # Install Go
 RUN curl -fsSL https://go.dev/dl/go{{.RuntimeVersion}}.linux-amd64.tar.gz \
@@ -192,6 +199,7 @@ func GenerateDockerfile(cfg DockerConfig, logger *slog.Logger) (string, error) {
 		ExtraPackages   []string
 		InstallCommands []string
 		SandboxEnv      []envVar
+		HasCompose      bool
 	}{
 		Image:           cfg.Image,
 		RuntimeName:     runtimeName,
@@ -201,6 +209,7 @@ func GenerateDockerfile(cfg DockerConfig, logger *slog.Logger) (string, error) {
 		ExtraPackages:   cfg.ExtraPackages,
 		InstallCommands: cfg.InstallCommands,
 		SandboxEnv:      sortedEnv,
+		HasCompose:      cfg.ComposeFile != "",
 	}
 
 	var buf bytes.Buffer

--- a/internal/sandbox/dockerfile_test.go
+++ b/internal/sandbox/dockerfile_test.go
@@ -842,3 +842,52 @@ func TestDockerConfigFromConfigComposeRoundTrip(t *testing.T) {
 		t.Errorf("SandboxEnv[FOO] = %q, want bar", dc.SandboxEnv["FOO"])
 	}
 }
+
+func TestGenerateDockerfileDockerCLIInstalledWhenComposeConfigured(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.ComposeFile = "docker-compose.test.yml"
+
+	df, err := GenerateDockerfile(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(df, "docker.io") {
+		t.Error("Dockerfile missing docker.io when compose is configured")
+	}
+	if !strings.Contains(df, "docker-compose-plugin") {
+		t.Error("Dockerfile missing docker-compose-plugin when compose is configured")
+	}
+}
+
+func TestGenerateDockerfileDockerCLIOmittedWhenComposeNotConfigured(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	// ComposeFile is empty — Docker CLI must not be installed
+
+	df, err := GenerateDockerfile(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(df, "docker.io") {
+		t.Error("Dockerfile should not contain docker.io when compose is not configured")
+	}
+	if strings.Contains(df, "docker-compose-plugin") {
+		t.Error("Dockerfile should not contain docker-compose-plugin when compose is not configured")
+	}
+}
+
+func TestGenerateDockerfileDockerCLIAlongsideExtraPackages(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.ComposeFile = "docker-compose.test.yml"
+	cfg.ExtraPackages = []string{"chromium"}
+
+	df, err := GenerateDockerfile(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(df, "docker.io") {
+		t.Error("Dockerfile missing docker.io when compose is configured alongside extra packages")
+	}
+	if !strings.Contains(df, "chromium") {
+		t.Error("Dockerfile missing extra package chromium when compose is configured")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a conditional `RUN apt-get install` block for `docker.io` and `docker-compose-plugin` in `GenerateDockerfile()` when `ComposeFile` is non-empty
- Adds `HasCompose bool` to the Dockerfile template data struct, derived from `cfg.ComposeFile != ""`
- Adds three unit tests covering: CLI installed when compose configured, CLI omitted when not configured, CLI alongside ExtraPackages

## Test plan
- [x] `TestGenerateDockerfileDockerCLIInstalledWhenComposeConfigured` — verifies `docker.io` and `docker-compose-plugin` appear when `ComposeFile` is set
- [x] `TestGenerateDockerfileDockerCLIOmittedWhenComposeNotConfigured` — verifies neither package appears when `ComposeFile` is empty
- [x] `TestGenerateDockerfileDockerCLIAlongsideExtraPackages` — verifies `docker.io` and user-supplied extra packages both appear
- [x] Full `./internal/sandbox/...` test suite passes

## Implementation Notes

### Approach
Added a `{{- if .HasCompose}}` block in the Dockerfile template (after the GitHub CLI install, before the runtime-specific blocks). The `HasCompose` boolean is computed as `cfg.ComposeFile != ""` when assembling the template data struct — the file path itself is not passed to the template since the Dockerfile only needs to know whether to install the CLI, not the path.

### Key Decisions
- Separate `RUN` layer rather than injecting into `ExtraPackages`: keeps Docker CLI install orthogonal to user-supplied packages and makes the install intent explicit in the Dockerfile output.
- `HasCompose bool` (not the path string): injection-safe by construction; the template only needs a presence signal.
- Placed after GitHub CLI install block: keeps all tool installs grouped before runtime-specific blocks; ordering is consistent with existing pattern.

### Known Limitations
None. This is a complete implementation of the issue's acceptance criteria.

### Architecture
Only the **infrastructure** layer was touched (`internal/sandbox/`). Dependencies remain: infrastructure → foundation (`internal/config/`). No new cross-layer imports were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #559