### PR TITLE
feat(orchestrator): run docker compose down in deferred cleanup (#561)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -606,6 +606,10 @@ func processIssues(ctx context.Context, allIssues []github.Issue, closedSet map[
 		if err := sandbox.ComposeUp(ctx, dc, logger); err != nil {
 			return fmt.Errorf("starting compose services: %w", err)
 		}
+		// Tear down compose services when processIssues returns, regardless of
+		// how it exits (error, context cancellation, or normal completion).
+		// defer arguments are evaluated immediately, so dc is captured by value.
+		defer sandbox.ComposeDown(dc, logger)
 	}
 
 	// Wire up the RunDataHook from the pre-created writer (may be nil).

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2555,6 +2555,200 @@ func TestProcessIssues_ComposeProjectNamePassed(t *testing.T) {
 	}
 }
 
+// hasComposeDown returns true if any recorded call is `docker compose ... down
+// --volumes`.
+func hasComposeDown(calls [][]string) bool {
+	for _, call := range calls {
+		if len(call) < 2 || call[0] != "docker" || call[1] != "compose" {
+			continue
+		}
+		var foundDown, foundVolumes bool
+		for _, a := range call[2:] {
+			if a == "down" {
+				foundDown = true
+			}
+			if a == "--volumes" {
+				foundVolumes = true
+			}
+		}
+		if foundDown && foundVolumes {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProcessIssues_ComposeDownCalledAfterNormalRun verifies that
+// docker compose down --volumes is called after a successful run.
+func TestProcessIssues_ComposeDownCalledAfterNormalRun(t *testing.T) {
+	allIssues := []github.Issue{{Number: 1, Title: "task"}}
+
+	setupProcessMocks(t, func() []int { return nil }, func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook, _ progress.ProgressReporter) agent.IssueOutcome {
+		return agent.IssueOutcome{IssueNumber: issue.Number, Status: "implemented", PRNumber: 101}
+	})
+
+	var composeCalls [][]string
+	origSandboxRunner := sandbox.CommandRunner
+	t.Cleanup(func() { sandbox.CommandRunner = origSandboxRunner })
+	sandbox.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		composeCalls = append(composeCalls, append([]string{name}, args...))
+		return []byte("ok"), nil
+	}
+
+	cfg := testConfig()
+	cfg.NoSandbox = true
+	cfg.DockerCompose = &config.DockerCompose{
+		File:        "docker-compose.test.yml",
+		ProjectName: "myapp",
+	}
+
+	captureStdout(t, func() {
+		err := processIssues(context.Background(), allIssues, map[int]bool{}, nil, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "test-milestone", nil)
+		if err != nil {
+			t.Fatalf("processIssues() error = %v", err)
+		}
+	})
+
+	if !hasComposeDown(composeCalls) {
+		t.Errorf("expected docker compose down --volumes to be called, got calls: %v", composeCalls)
+	}
+}
+
+// TestProcessIssues_ComposeDownCalledAfterRunFailure verifies that
+// docker compose down --volumes is called even when the run encounters an
+// agent failure (deferred cleanup runs regardless of exit path).
+func TestProcessIssues_ComposeDownCalledAfterRunFailure(t *testing.T) {
+	allIssues := []github.Issue{{Number: 1, Title: "task"}}
+
+	setupProcessMocks(t, func() []int { return nil }, func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook, _ progress.ProgressReporter) agent.IssueOutcome {
+		return agent.IssueOutcome{IssueNumber: issue.Number, Status: "failed"}
+	})
+
+	var composeCalls [][]string
+	origSandboxRunner := sandbox.CommandRunner
+	t.Cleanup(func() { sandbox.CommandRunner = origSandboxRunner })
+	sandbox.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		composeCalls = append(composeCalls, append([]string{name}, args...))
+		return []byte("ok"), nil
+	}
+
+	cfg := testConfig()
+	cfg.NoSandbox = true
+	cfg.DockerCompose = &config.DockerCompose{
+		File:        "docker-compose.test.yml",
+		ProjectName: "myapp",
+	}
+
+	captureStdout(t, func() {
+		// The run may return nil even on agent failures (failing is a valid
+		// outcome, not a processIssues error).
+		_ = processIssues(context.Background(), allIssues, map[int]bool{}, nil, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "test-milestone", nil)
+	})
+
+	if !hasComposeDown(composeCalls) {
+		t.Errorf("expected docker compose down --volumes to be called after agent failure, got calls: %v", composeCalls)
+	}
+}
+
+// TestProcessIssues_ComposeDownCalledAfterContextCancellation verifies that
+// docker compose down --volumes is called when the context is cancelled before
+// the run processes any issues.
+func TestProcessIssues_ComposeDownCalledAfterContextCancellation(t *testing.T) {
+	allIssues := []github.Issue{{Number: 1, Title: "task"}}
+
+	setupProcessMocks(t, func() []int { return nil }, func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook, _ progress.ProgressReporter) agent.IssueOutcome {
+		return agent.IssueOutcome{IssueNumber: issue.Number, Status: "implemented", PRNumber: 101}
+	})
+
+	var composeCalls [][]string
+	origSandboxRunner := sandbox.CommandRunner
+	t.Cleanup(func() { sandbox.CommandRunner = origSandboxRunner })
+	sandbox.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		composeCalls = append(composeCalls, append([]string{name}, args...))
+		return []byte("ok"), nil
+	}
+
+	cfg := testConfig()
+	cfg.NoSandbox = true
+	cfg.DockerCompose = &config.DockerCompose{
+		File:        "docker-compose.test.yml",
+		ProjectName: "myapp",
+	}
+
+	// Use a pre-cancelled context. ComposeUp ignores the context, so it will
+	// succeed. The inner issue loop will detect the cancellation and exit via
+	// goto done, after which the deferred ComposeDown fires.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	captureStdout(t, func() {
+		_ = processIssues(ctx, allIssues, map[int]bool{}, nil, cfg, testLogger(t), progress.NewTextReporter(os.Stdout), nil, false, "", "test-milestone", nil)
+	})
+
+	if !hasComposeDown(composeCalls) {
+		t.Errorf("expected docker compose down --volumes to be called after context cancellation, got calls: %v", composeCalls)
+	}
+}
+
+// TestProcessIssues_ComposeDownFailureLogsWarning verifies that when
+// docker compose down fails, the error is logged as a warning and the run
+// exit status is not changed (processIssues still returns nil).
+func TestProcessIssues_ComposeDownFailureLogsWarning(t *testing.T) {
+	allIssues := []github.Issue{{Number: 1, Title: "task"}}
+
+	setupProcessMocks(t, func() []int { return nil }, func(_ context.Context, issue github.Issue, _ *config.Config, _ *agent.Prompts, _ map[string]string, _ *slog.Logger, _ agent.RunDataHook, _ progress.ProgressReporter) agent.IssueOutcome {
+		return agent.IssueOutcome{IssueNumber: issue.Number, Status: "implemented", PRNumber: 101}
+	})
+
+	origSandboxRunner := sandbox.CommandRunner
+	t.Cleanup(func() { sandbox.CommandRunner = origSandboxRunner })
+	sandbox.CommandRunner = func(name string, args ...string) ([]byte, error) {
+		if len(args) >= 2 && args[0] == "compose" {
+			for _, a := range args {
+				if a == "down" {
+					return []byte("down failed"), fmt.Errorf("exit status 1")
+				}
+			}
+		}
+		return []byte("ok"), nil
+	}
+
+	cfg := testConfig()
+	cfg.NoSandbox = true
+	cfg.DockerCompose = &config.DockerCompose{
+		File:        "docker-compose.test.yml",
+		ProjectName: "myapp",
+	}
+
+	handler := &recordingHandler{}
+	logger := slog.New(handler)
+
+	var runErr error
+	captureStdout(t, func() {
+		runErr = processIssues(context.Background(), allIssues, map[int]bool{}, nil, cfg, logger, progress.NewTextReporter(os.Stdout), nil, false, "", "test-milestone", nil)
+	})
+
+	// The run must still succeed despite the compose down failure.
+	if runErr != nil {
+		t.Errorf("expected processIssues to return nil when compose down fails, got: %v", runErr)
+	}
+
+	// A warning must have been logged.
+	var foundWarn bool
+	for _, r := range handler.records {
+		if r.Level == slog.LevelWarn {
+			msg := r.Message
+			if strings.Contains(msg, "compose") || strings.Contains(msg, "down") {
+				foundWarn = true
+				break
+			}
+		}
+	}
+	if !foundWarn {
+		t.Error("expected a warning log record about compose down failure")
+	}
+}
+
 func TestRefreshAndCategorize_ReturnsCorrectSplit(t *testing.T) {
 	// Issue 3 is blocked by #1. After #1 closes, #3 becomes processable.
 	allIssues := []github.Issue{

--- a/internal/sandbox/compose.go
+++ b/internal/sandbox/compose.go
@@ -29,3 +29,27 @@ func ComposeUp(_ context.Context, dc DockerConfig, logger *slog.Logger) error {
 	logger.Info("compose services started", "file", dc.ComposeFile, "project", projectName)
 	return nil
 }
+
+// ComposeDown runs `docker compose down --volumes` for the configured compose
+// file and project name. It is a no-op when dc.ComposeFile is empty. Errors
+// are logged as warnings but not returned — teardown is best-effort.
+func ComposeDown(dc DockerConfig, logger *slog.Logger) {
+	if dc.ComposeFile == "" {
+		return
+	}
+
+	projectName := dc.ComposeProjectName
+	if projectName == "" {
+		projectName = "godark"
+	}
+
+	logger.Info("stopping compose services", "file", dc.ComposeFile, "project", projectName)
+
+	out, err := CommandRunner("docker", "compose", "-f", dc.ComposeFile, "-p", projectName, "down", "--volumes")
+	if err != nil {
+		logger.Warn("docker compose down failed", "error", err, "output", string(out))
+		return
+	}
+
+	logger.Info("compose services stopped", "file", dc.ComposeFile, "project", projectName)
+}

--- a/internal/sandbox/compose_test.go
+++ b/internal/sandbox/compose_test.go
@@ -1,0 +1,166 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// testNopLogger returns a logger that discards all output.
+func testNopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// composeRecordingHandler is a slog.Handler that captures all log records.
+type composeRecordingHandler struct {
+	records []slog.Record
+}
+
+func (h *composeRecordingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *composeRecordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *composeRecordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *composeRecordingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func TestComposeDown_NoOp_WhenComposeFileEmpty(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	called := false
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		called = true
+		return nil, nil
+	}
+
+	dc := DockerConfig{ComposeFile: ""}
+	ComposeDown(dc, testNopLogger())
+
+	if called {
+		t.Error("expected CommandRunner not to be called when ComposeFile is empty")
+	}
+}
+
+func TestComposeDown_CallsDockerComposeDown(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	var gotName string
+	var gotArgs []string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		gotName = name
+		gotArgs = args
+		return []byte("done"), nil
+	}
+
+	dc := DockerConfig{
+		ComposeFile:        "docker-compose.yml",
+		ComposeProjectName: "myproject",
+	}
+	ComposeDown(dc, testNopLogger())
+
+	if gotName != "docker" {
+		t.Errorf("expected command %q, got %q", "docker", gotName)
+	}
+
+	wantArgs := []string{"compose", "-f", "docker-compose.yml", "-p", "myproject", "down", "--volumes"}
+	if len(gotArgs) != len(wantArgs) {
+		t.Fatalf("expected args %v, got %v", wantArgs, gotArgs)
+	}
+	for i, w := range wantArgs {
+		if gotArgs[i] != w {
+			t.Errorf("arg[%d]: want %q, got %q", i, w, gotArgs[i])
+		}
+	}
+}
+
+func TestComposeDown_DefaultProjectName_WhenEmpty(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	var gotArgs []string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return nil, nil
+	}
+
+	dc := DockerConfig{
+		ComposeFile:        "docker-compose.yml",
+		ComposeProjectName: "",
+	}
+	ComposeDown(dc, testNopLogger())
+
+	// Find the -p flag and its value.
+	for i, a := range gotArgs {
+		if a == "-p" && i+1 < len(gotArgs) {
+			if gotArgs[i+1] != "godark" {
+				t.Errorf("expected default project name %q, got %q", "godark", gotArgs[i+1])
+			}
+			return
+		}
+	}
+	t.Errorf("expected -p flag in args %v", gotArgs)
+}
+
+func TestComposeDown_ErrorLogged_NotReturned(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		return []byte("some error output"), errors.New("exit status 1")
+	}
+
+	handler := &composeRecordingHandler{}
+	logger := slog.New(handler)
+
+	dc := DockerConfig{
+		ComposeFile:        "docker-compose.yml",
+		ComposeProjectName: "myproject",
+	}
+
+	// ComposeDown must not panic and returns void (error is not propagated).
+	ComposeDown(dc, logger)
+
+	// Verify a warning was logged.
+	found := false
+	for _, r := range handler.records {
+		if r.Level == slog.LevelWarn {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a warning log record when compose down fails")
+	}
+}
+
+func TestComposeDown_IncludesVolumesFlag(t *testing.T) {
+	orig := CommandRunner
+	defer func() { CommandRunner = orig }()
+
+	var gotArgs []string
+	CommandRunner = func(name string, args ...string) ([]byte, error) {
+		gotArgs = args
+		return nil, nil
+	}
+
+	dc := DockerConfig{
+		ComposeFile:        "docker-compose.yml",
+		ComposeProjectName: "proj",
+	}
+	ComposeDown(dc, testNopLogger())
+
+	found := false
+	for _, a := range gotArgs {
+		if a == "--volumes" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --volumes flag in args %v", gotArgs)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ComposeDown` function to `internal/sandbox/compose.go` that runs `docker compose -f <file> -p <project> down --volumes`
- Register a deferred `sandbox.ComposeDown` call in `processIssues` immediately after `ComposeUp` succeeds
- Teardown fires on all exit paths: normal return, error return, context cancellation, and the `goto done` path
- Teardown failures are logged as warnings and do not change the run exit status

## Implementation Notes

### Approach
Describe what approach you took and why.

After `ComposeUp` succeeds in `processIssues`, a `defer sandbox.ComposeDown(dc, logger)` is registered. Because `defer` arguments are evaluated immediately (at statement time, not fire time), the `dc` value is captured as-is — using the same file and project name that was passed to `ComposeUp`. The deferred call fires on every return path from `processIssues`, including the `goto done` path used for context cancellation.

`ComposeDown` lives in the `sandbox` (infrastructure) package alongside `ComposeUp`, keeping compose lifecycle logic co-located.

### Key Decisions
- **No error return from `ComposeDown`**: The issue requires teardown to be best-effort. `ComposeDown` returns void and logs a warning on failure.
- **`defer` over explicit cleanup**: Using `defer` is the only mechanism that correctly handles all exit paths (including `goto done` and panics) without duplicating cleanup code.
- **Argument evaluation semantics**: `defer sandbox.ComposeDown(dc, logger)` evaluates `dc` by value at defer-registration time, so any later mutation of `dc` (none exists today, but belt-and-suspenders) doesn't affect cleanup.
- **`--volumes` flag**: Included as required by the issue to avoid anonymous volume disk leaks.

### Known Limitations
- If `ComposeUp` is called but the process is killed with SIGKILL (not SIGTERM), the deferred call won't run. This is a fundamental Go limitation and matches the issue's stated scope.

### Architecture
- `internal/sandbox/compose.go` — **infrastructure** layer. `ComposeDown` is added here alongside `ComposeUp`. No new dependencies.
- `internal/orchestrator/orchestrator.go` — **orchestration** layer. Calls `sandbox.ComposeDown` via defer. This is permitted (orchestration may depend on infrastructure).
- No layer violations introduced.

Closes #561