### PR TITLE
feat(config): auto-generate unique compose project names per issue (#562)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -370,6 +370,26 @@ func (c *Config) ResolveBranch(milestone string, issueNums []int) string {
 	return ""
 }
 
+// ResolveProjectName returns the docker compose project name for a given issue.
+// When prefix is empty it returns "godark-<issueNumber>".
+// When prefix is non-empty it is sanitized (lowercased, separators replaced with
+// hyphens, non-alphanumeric/hyphen characters stripped, repeated hyphens collapsed,
+// leading/trailing hyphens removed) and returns "<sanitized-prefix>-<issueNumber>".
+// The result is always a valid docker compose -p argument.
+func ResolveProjectName(prefix string, issueNumber int) string {
+	if prefix == "" {
+		return fmt.Sprintf("godark-%d", issueNumber)
+	}
+	s := strings.NewReplacer(" ", "-", "_", "-").Replace(strings.ToLower(prefix))
+	s = invalidBranchChars.ReplaceAllString(s, "-")
+	s = repeatedHyphens.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return fmt.Sprintf("godark-%d", issueNumber)
+	}
+	return fmt.Sprintf("%s-%d", s, issueNumber)
+}
+
 // EffectiveBaseBranch returns BaseBranch, defaulting to "main" when empty.
 func (c *Config) EffectiveBaseBranch() string {
 	if c.BaseBranch == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -2203,6 +2204,72 @@ docker_compose:
 	}
 	if !strings.Contains(err.Error(), "docker_compose.file") {
 		t.Errorf("error %q does not mention docker_compose.file", err.Error())
+	}
+}
+
+// --- ResolveProjectName tests ---
+
+func TestResolveProjectName_NoPrefix(t *testing.T) {
+	got := ResolveProjectName("", 42)
+	if got != "godark-42" {
+		t.Errorf("ResolveProjectName(%q, 42) = %q, want %q", "", got, "godark-42")
+	}
+}
+
+func TestResolveProjectName_WithPrefix(t *testing.T) {
+	got := ResolveProjectName("myapp", 42)
+	if got != "myapp-42" {
+		t.Errorf("ResolveProjectName(%q, 42) = %q, want %q", "myapp", got, "myapp-42")
+	}
+}
+
+func TestResolveProjectName_PrefixWithSpaces(t *testing.T) {
+	got := ResolveProjectName("My App", 42)
+	// "My App" → lowercase "my app" → "my-app" → "my-app-42"
+	if got != "my-app-42" {
+		t.Errorf("ResolveProjectName(%q, 42) = %q, want %q", "My App", got, "my-app-42")
+	}
+}
+
+func TestResolveProjectName_NameValidity(t *testing.T) {
+	tests := []struct {
+		prefix string
+		issue  int
+	}{
+		{"", 42},
+		{"myapp", 99},
+		{"My App", 1},
+		{"my_project", 543},
+	}
+	validChars := regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+	for _, tc := range tests {
+		got := ResolveProjectName(tc.prefix, tc.issue)
+		if !validChars.MatchString(got) {
+			t.Errorf("ResolveProjectName(%q, %d) = %q: contains invalid characters", tc.prefix, tc.issue, got)
+		}
+	}
+}
+
+func TestResolveProjectName_DistinctPerIssue(t *testing.T) {
+	prefix := "myapp"
+	names := make(map[string]bool)
+	for _, issue := range []int{1, 2, 42, 100, 543} {
+		name := ResolveProjectName(prefix, issue)
+		if names[name] {
+			t.Errorf("ResolveProjectName(%q, %d) produced duplicate name %q", prefix, issue, name)
+		}
+		names[name] = true
+	}
+}
+
+func TestResolveProjectName_EmptyPrefixDistinctPerIssue(t *testing.T) {
+	names := make(map[string]bool)
+	for _, issue := range []int{1, 2, 42, 100, 543} {
+		name := ResolveProjectName("", issue)
+		if names[name] {
+			t.Errorf("ResolveProjectName(%q, %d) produced duplicate name %q", "", issue, name)
+		}
+		names[name] = true
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `ResolveProjectName(prefix string, issueNumber int) string` free function to `internal/config/config.go`
- Empty prefix produces `godark-<issueNumber>`; non-empty prefix is sanitized then produces `<prefix>-<issueNumber>`
- 6 table-driven unit tests covering all acceptance criteria from #562

## Test plan

- [x] `TestResolveProjectName_NoPrefix` — verifies `godark-42` for empty prefix
- [x] `TestResolveProjectName_WithPrefix` — verifies `myapp-42` for `"myapp"` prefix
- [x] `TestResolveProjectName_PrefixWithSpaces` — verifies `"My App"` sanitizes to `my-app-42`
- [x] `TestResolveProjectName_NameValidity` — verifies all outputs match `[a-z0-9][a-z0-9-]*`
- [x] `TestResolveProjectName_DistinctPerIssue` — verifies distinct names across multiple issue numbers (prefixed)
- [x] `TestResolveProjectName_EmptyPrefixDistinctPerIssue` — verifies distinct names across multiple issue numbers (no prefix)

## Implementation Notes

### Approach
Added `ResolveProjectName` as a free function (not a method on `*Config`) because the logic depends only on a single string prefix — not on the full config — making it more testable in isolation. This mirrors the `milestoneSlug` helper in the same file.

### Key Decisions
- **Sanitization in ResolveProjectName**: The scenario file `unique-project-names.md` includes a `"My App"` case that must produce a valid name. Rather than rely solely on #556 validation at config-load time, the function sanitizes at resolution time using the existing `invalidBranchChars` and `repeatedHyphens` regexes already in `config.go`. This is the safe bet: it works whether or not #556's validation is strict.
- **Fallback to godark prefix on empty-after-sanitize**: If a prefix sanitizes to empty (e.g. all special characters), we fall back to `godark-<issueNumber>` to always produce a valid, meaningful name.
- **Free function placement**: Lives in `internal/config/` (foundation layer), importable by orchestration, service, infrastructure, and domain layers without creating any forbidden import cycles.

### Known Limitations
- Integration with the orchestrator (`processIssues`/`processUnblockedLoop`) is deferred to #560.
- Integration with `sandbox.DockerConfig` is deferred to #557.
- `DockerCompose.ProjectName` config field is deferred to #556.

### Architecture
- **Layer touched**: `foundation` (`internal/config/`) — zero-dependency, importable by all other layers.
- **No new imports** were introduced in `config.go`; the function reuses existing `fmt`, `strings`, and the two package-level regexes (`invalidBranchChars`, `repeatedHyphens`).
- Dependency rules respected: foundation has no dependencies on other layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #562