### PR TITLE
feat(init): write runtime block to godark.yaml on init

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/peter-stratton/dark-factory/internal/config"
 	"github.com/peter-stratton/dark-factory/internal/detect"
 	"github.com/peter-stratton/dark-factory/internal/github"
 	"github.com/peter-stratton/dark-factory/internal/harness/templates"
@@ -16,18 +17,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// detectedCommands holds auto-detected build/test commands for config generation.
+// detectedCommands holds auto-detected build/test commands and runtime for config generation.
 type detectedCommands struct {
-	build  string
-	test   string
-	format string
-	lint   string
+	build   string
+	test    string
+	format  string
+	lint    string
+	runtime config.Runtime
 }
 
 // buildDefaultConfig constructs the default godark.yaml config string.
 // When detected is non-nil, build/test/format/lint commands are written as
 // active (uncommented) fields. Otherwise they remain commented-out placeholders.
+// When a runtime was detected, a runtime: block is also written.
 func buildDefaultConfig(detected *detectedCommands) string {
+	var runtimeBlock string
+	if detected != nil && detected.runtime.Name != "" {
+		runtimeBlock = "# Runtime toolchain (auto-detected — verify for your project)\nruntime:\n"
+		runtimeBlock += fmt.Sprintf("  name: %s\n", detected.runtime.Name)
+		if detected.runtime.Version != "" {
+			runtimeBlock += fmt.Sprintf("  version: %q\n", detected.runtime.Version)
+		}
+		runtimeBlock += "\n"
+	}
+
 	var commandBlock string
 	if detected != nil && (detected.build != "" || detected.test != "") {
 		commandBlock = "# Build, test, format, and lint commands (auto-detected — verify for your project)\n"
@@ -68,7 +81,7 @@ auto_merge:
   feature: none
   rollup: none
 
-` + commandBlock + `
+` + runtimeBlock + commandBlock + `
 # Paths (defaults shown — override to customize)
 # roadmap_path: docs/ROADMAP.md
 # planning_dir: docs/planning/
@@ -247,9 +260,18 @@ func detectCommandsForDir(dir string) *detectedCommands {
 	if err != nil {
 		return nil
 	}
+	rt := dp.Runtime
+	// Normalize Go versions to three components (e.g. "1.21" → "1.21.0") so
+	// the Dockerfile template's patch-version requirement is satisfied.
+	if rt.Name == "go" && rt.Version != "" {
+		if parts := strings.Split(rt.Version, "."); len(parts) == 2 {
+			rt.Version = rt.Version + ".0"
+		}
+	}
 	dc := &detectedCommands{
-		build: dp.BuildCommand,
-		test:  dp.TestCommand,
+		build:   dp.BuildCommand,
+		test:    dp.TestCommand,
+		runtime: rt,
 	}
 	// Add language-specific format/lint suggestions.
 	if dp.Runtime.Name == "go" {

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -510,6 +510,81 @@ func TestInitRepoFlagPopulatesNewConfig(t *testing.T) {
 	}
 }
 
+func TestInitGoProjectWritesRuntimeBlock(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// go.mod with a two-component version — should be normalized to three.
+	if err := os.WriteFile("go.mod", []byte("module example.com/test\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	runInit(t)
+
+	data, err := os.ReadFile("godark.yaml")
+	if err != nil {
+		t.Fatalf("godark.yaml not created: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.Contains(content, "runtime:") {
+		t.Error("godark.yaml missing runtime: block")
+	}
+	if !strings.Contains(content, "name: go") {
+		t.Error("godark.yaml missing runtime name")
+	}
+	// Version should be normalized from "1.21" to "1.21.0".
+	if !strings.Contains(content, `version: "1.21.0"`) {
+		t.Errorf("godark.yaml missing normalized runtime version, got:\n%s", content)
+	}
+}
+
+func TestInitGoProjectThreeComponentVersionUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// go.mod with a three-component version — should be written as-is.
+	if err := os.WriteFile("go.mod", []byte("module example.com/test\n\ngo 1.22.3\n"), 0o644); err != nil {
+		t.Fatalf("writing go.mod: %v", err)
+	}
+
+	runInit(t)
+
+	data, err := os.ReadFile("godark.yaml")
+	if err != nil {
+		t.Fatalf("godark.yaml not created: %v", err)
+	}
+
+	if !strings.Contains(string(data), `version: "1.22.3"`) {
+		t.Errorf("godark.yaml should preserve three-component version, got:\n%s", data)
+	}
+}
+
+func TestInitNonGoProjectNoRuntimeBlock(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// No marker files — detection fails, no runtime block should be written.
+	runInit(t)
+
+	data, err := os.ReadFile("godark.yaml")
+	if err != nil {
+		t.Fatalf("godark.yaml not created: %v", err)
+	}
+
+	content := string(data)
+	if strings.Contains(content, "runtime:") {
+		t.Error("godark.yaml should not contain runtime: block when detection fails")
+	}
+}
+
 func TestInitNonGoProjectUsesGenericExamples(t *testing.T) {
 	dir := t.TempDir()
 	origDir, _ := os.Getwd()


### PR DESCRIPTION
Rollup for #583 — merges the feature branch into main.

## Summary
- `godark init` now writes the detected `runtime:` block (name + version) to `godark.yaml`
- Without this, the sandbox Dockerfile skips toolchain installation and verify commands fail with exit 127

Generated with [Claude Code](https://claude.com/claude-code)