### PR TITLE
fix(init): default Go lint command to go vet instead of golangci-lint

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -243,7 +243,7 @@ func detectCommandsForDir(dir string) *detectedCommands {
 	// Add language-specific format/lint suggestions.
 	if dp.Runtime.Name == "go" {
 		dc.format = "gofmt -l -d ."
-		dc.lint = "golangci-lint run ./..."
+		dc.lint = "go vet ./..."
 	}
 	return dc
 }

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -421,7 +421,7 @@ func TestInitGoProjectWritesActiveCommands(t *testing.T) {
 		"build_command: \"go build ./...\"",
 		"test_command: \"go test ./...\"",
 		"format_command: \"gofmt -l -d .\"",
-		"lint_command: \"golangci-lint run ./...\"",
+		"lint_command: \"go vet ./...\"",
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("godark.yaml missing active command line: %s", want)


### PR DESCRIPTION
Rollup for #585 — merges the feature branch into main.

## Summary
- Changes the default Go lint command from `golangci-lint run ./...` to `go vet ./...`
- `go vet` ships with the Go toolchain and works in the sandbox without extra install steps

Generated with [Claude Code](https://claude.com/claude-code)