### PR TITLE
Add coverage diff analysis package

### DIFF
--- a/internal/coverage/diff.go
+++ b/internal/coverage/diff.go
@@ -1,0 +1,67 @@
+package coverage
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// LineRange represents an inclusive range of line numbers.
+type LineRange struct {
+	Start int
+	End   int
+}
+
+// diffFileHeader matches unified diff file headers like "+++ b/internal/foo/bar.go".
+var diffFileHeader = regexp.MustCompile(`^\+\+\+ b/(.+)$`)
+
+// diffHunkHeader matches unified diff hunk headers like "@@ -0,0 +10,5 @@".
+// With --unified=0, the range is typically "+start,count" or "+start" (count=1).
+var diffHunkHeader = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+
+// ParseUnifiedDiff parses the output of "git diff --unified=0" and returns
+// the added line ranges per file. Test files (*_test.go) are filtered out.
+func ParseUnifiedDiff(output string) map[string][]LineRange {
+	if output == "" {
+		return nil
+	}
+
+	result := make(map[string][]LineRange)
+	var currentFile string
+
+	for _, line := range strings.Split(output, "\n") {
+		if m := diffFileHeader.FindStringSubmatch(line); m != nil {
+			currentFile = m[1]
+			// Skip test files.
+			if strings.HasSuffix(currentFile, "_test.go") {
+				currentFile = ""
+			}
+			continue
+		}
+
+		if currentFile == "" {
+			continue
+		}
+
+		if m := diffHunkHeader.FindStringSubmatch(line); m != nil {
+			start, _ := strconv.Atoi(m[1])
+			count := 1
+			if m[2] != "" {
+				count, _ = strconv.Atoi(m[2])
+			}
+			// A count of 0 means no lines were added (pure deletion). Skip.
+			if count == 0 {
+				continue
+			}
+			result[currentFile] = append(result[currentFile], LineRange{
+				Start: start,
+				End:   start + count - 1,
+			})
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}

--- a/internal/coverage/diff_test.go
+++ b/internal/coverage/diff_test.go
@@ -1,0 +1,134 @@
+package coverage
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseUnifiedDiff_Basic(t *testing.T) {
+	diff := `diff --git a/internal/foo/bar.go b/internal/foo/bar.go
+--- a/internal/foo/bar.go
++++ b/internal/foo/bar.go
+@@ -10,0 +11,5 @@ func existing() {
++func newFunc() {
++	a := 1
++	b := 2
++	return a + b
++}
+@@ -30,0 +36,3 @@ func another() {
++	x := 10
++	y := 20
++	return x + y
+`
+
+	got := ParseUnifiedDiff(diff)
+
+	want := map[string][]LineRange{
+		"internal/foo/bar.go": {
+			{Start: 11, End: 15},
+			{Start: 36, End: 38},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseUnifiedDiff() = %v, want %v", got, want)
+	}
+}
+
+func TestParseUnifiedDiff_MultipleFiles(t *testing.T) {
+	diff := `diff --git a/a.go b/a.go
+--- a/a.go
++++ b/a.go
+@@ -5,0 +6,2 @@
++line1
++line2
+diff --git a/b.go b/b.go
+--- a/b.go
++++ b/b.go
+@@ -1,0 +2,1 @@
++newline
+`
+
+	got := ParseUnifiedDiff(diff)
+
+	want := map[string][]LineRange{
+		"a.go": {{Start: 6, End: 7}},
+		"b.go": {{Start: 2, End: 2}},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseUnifiedDiff() = %v, want %v", got, want)
+	}
+}
+
+func TestParseUnifiedDiff_FiltersTestFiles(t *testing.T) {
+	diff := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1,0 +2,1 @@
++added
+diff --git a/foo_test.go b/foo_test.go
+--- a/foo_test.go
++++ b/foo_test.go
+@@ -1,0 +2,5 @@
++test lines
++test lines
++test lines
++test lines
++test lines
+`
+
+	got := ParseUnifiedDiff(diff)
+
+	want := map[string][]LineRange{
+		"foo.go": {{Start: 2, End: 2}},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseUnifiedDiff() = %v, want %v", got, want)
+	}
+}
+
+func TestParseUnifiedDiff_DeletionOnly(t *testing.T) {
+	// A hunk with +N,0 means no lines were added.
+	diff := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -10,3 +10,0 @@
+-deleted1
+-deleted2
+-deleted3
+`
+
+	got := ParseUnifiedDiff(diff)
+	if got != nil {
+		t.Errorf("ParseUnifiedDiff() = %v, want nil for deletion-only diff", got)
+	}
+}
+
+func TestParseUnifiedDiff_Empty(t *testing.T) {
+	got := ParseUnifiedDiff("")
+	if got != nil {
+		t.Errorf("ParseUnifiedDiff(\"\") = %v, want nil", got)
+	}
+}
+
+func TestParseUnifiedDiff_SingleLineAdd(t *testing.T) {
+	// When count is omitted, it defaults to 1.
+	diff := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -5,0 +6 @@
++new line
+`
+
+	got := ParseUnifiedDiff(diff)
+
+	want := map[string][]LineRange{
+		"foo.go": {{Start: 6, End: 6}},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseUnifiedDiff() = %v, want %v", got, want)
+	}
+}

--- a/internal/coverage/patch.go
+++ b/internal/coverage/patch.go
@@ -1,0 +1,130 @@
+package coverage
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// UncoveredFile groups uncovered line ranges for a single file.
+type UncoveredFile struct {
+	File   string
+	Ranges []LineRange
+}
+
+// PatchResult holds the outcome of a patch coverage computation.
+type PatchResult struct {
+	Percent      float64
+	TotalLines   int
+	CoveredLines int
+	Uncovered    []UncoveredFile
+}
+
+// ComputePatchCoverage computes coverage for changed lines only.
+// changed maps file paths to added line ranges (from ParseUnifiedDiff).
+// blocks is the parsed coverage profile (from ParseProfile).
+//
+// For each changed line, it is considered covered if any coverage block
+// with Count > 0 overlaps that line.
+func ComputePatchCoverage(changed map[string][]LineRange, blocks []ProfileBlock) PatchResult {
+	if len(changed) == 0 {
+		return PatchResult{Percent: 100}
+	}
+
+	// Index coverage blocks by file.
+	blocksByFile := make(map[string][]ProfileBlock)
+	for _, b := range blocks {
+		blocksByFile[b.File] = append(blocksByFile[b.File], b)
+	}
+
+	var totalLines, coveredLines int
+	var uncovered []UncoveredFile
+
+	// Sort file names for deterministic output.
+	files := make([]string, 0, len(changed))
+	for f := range changed {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+
+	for _, file := range files {
+		ranges := changed[file]
+		fileBlocks := blocksByFile[file]
+
+		var fileUncoveredRanges []LineRange
+
+		for _, lr := range ranges {
+			for line := lr.Start; line <= lr.End; line++ {
+				totalLines++
+				if isLineCovered(line, fileBlocks) {
+					coveredLines++
+				} else {
+					// Accumulate into ranges.
+					fileUncoveredRanges = appendToRanges(fileUncoveredRanges, line)
+				}
+			}
+		}
+
+		if len(fileUncoveredRanges) > 0 {
+			uncovered = append(uncovered, UncoveredFile{
+				File:   file,
+				Ranges: fileUncoveredRanges,
+			})
+		}
+	}
+
+	var pct float64
+	if totalLines > 0 {
+		pct = float64(coveredLines) / float64(totalLines) * 100
+	}
+
+	return PatchResult{
+		Percent:      pct,
+		TotalLines:   totalLines,
+		CoveredLines: coveredLines,
+		Uncovered:    uncovered,
+	}
+}
+
+// isLineCovered checks if any coverage block with Count > 0 includes the given line.
+func isLineCovered(line int, blocks []ProfileBlock) bool {
+	for _, b := range blocks {
+		if b.Count > 0 && line >= b.StartLine && line <= b.EndLine {
+			return true
+		}
+	}
+	return false
+}
+
+// appendToRanges appends a line to the last range if contiguous, or starts a new range.
+func appendToRanges(ranges []LineRange, line int) []LineRange {
+	if len(ranges) > 0 && ranges[len(ranges)-1].End == line-1 {
+		ranges[len(ranges)-1].End = line
+		return ranges
+	}
+	return append(ranges, LineRange{Start: line, End: line})
+}
+
+// FormatResult formats a PatchResult into a human-readable string.
+// If the result is below target, the output includes uncovered line details.
+func FormatResult(result PatchResult, target int) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Patch coverage: %.1f%% (%d/%d changed lines covered), target: %d%%",
+		result.Percent, result.CoveredLines, result.TotalLines, target)
+
+	if len(result.Uncovered) > 0 {
+		sb.WriteString("\n\nUncovered changed lines:")
+		for _, uf := range result.Uncovered {
+			for _, r := range uf.Ranges {
+				if r.Start == r.End {
+					fmt.Fprintf(&sb, "\n  %s:%d", uf.File, r.Start)
+				} else {
+					fmt.Fprintf(&sb, "\n  %s:%d-%d", uf.File, r.Start, r.End)
+				}
+			}
+		}
+		sb.WriteString("\n\nWrite tests that exercise these specific code paths.")
+	}
+
+	return sb.String()
+}

--- a/internal/coverage/patch_test.go
+++ b/internal/coverage/patch_test.go
@@ -1,0 +1,213 @@
+package coverage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputePatchCoverage_AllCovered(t *testing.T) {
+	changed := map[string][]LineRange{
+		"internal/foo/bar.go": {{Start: 10, End: 15}},
+	}
+	blocks := []ProfileBlock{
+		{File: "internal/foo/bar.go", StartLine: 1, EndLine: 20, Stmts: 5, Count: 1},
+	}
+
+	result := ComputePatchCoverage(changed, blocks)
+
+	if result.Percent != 100 {
+		t.Errorf("Percent = %f, want 100", result.Percent)
+	}
+	if result.TotalLines != 6 {
+		t.Errorf("TotalLines = %d, want 6", result.TotalLines)
+	}
+	if result.CoveredLines != 6 {
+		t.Errorf("CoveredLines = %d, want 6", result.CoveredLines)
+	}
+	if len(result.Uncovered) != 0 {
+		t.Errorf("Uncovered = %v, want empty", result.Uncovered)
+	}
+}
+
+func TestComputePatchCoverage_PartiallyCovered(t *testing.T) {
+	changed := map[string][]LineRange{
+		"internal/foo/bar.go": {
+			{Start: 10, End: 15}, // 6 lines
+			{Start: 20, End: 25}, // 6 lines
+		},
+	}
+	blocks := []ProfileBlock{
+		{File: "internal/foo/bar.go", StartLine: 10, EndLine: 15, Stmts: 3, Count: 1}, // covers 10-15
+		{File: "internal/foo/bar.go", StartLine: 20, EndLine: 25, Stmts: 3, Count: 0}, // uncovered 20-25
+	}
+
+	result := ComputePatchCoverage(changed, blocks)
+
+	if result.TotalLines != 12 {
+		t.Errorf("TotalLines = %d, want 12", result.TotalLines)
+	}
+	if result.CoveredLines != 6 {
+		t.Errorf("CoveredLines = %d, want 6", result.CoveredLines)
+	}
+	if result.Percent != 50 {
+		t.Errorf("Percent = %f, want 50", result.Percent)
+	}
+	if len(result.Uncovered) != 1 {
+		t.Fatalf("Uncovered count = %d, want 1", len(result.Uncovered))
+	}
+	if result.Uncovered[0].File != "internal/foo/bar.go" {
+		t.Errorf("Uncovered file = %q, want %q", result.Uncovered[0].File, "internal/foo/bar.go")
+	}
+}
+
+func TestComputePatchCoverage_NoChangedLines(t *testing.T) {
+	result := ComputePatchCoverage(nil, nil)
+
+	if result.Percent != 100 {
+		t.Errorf("Percent = %f, want 100 for no changed lines", result.Percent)
+	}
+}
+
+func TestComputePatchCoverage_NoCoverageData(t *testing.T) {
+	changed := map[string][]LineRange{
+		"internal/foo/bar.go": {{Start: 10, End: 15}},
+	}
+
+	result := ComputePatchCoverage(changed, nil)
+
+	if result.TotalLines != 6 {
+		t.Errorf("TotalLines = %d, want 6", result.TotalLines)
+	}
+	if result.CoveredLines != 0 {
+		t.Errorf("CoveredLines = %d, want 0", result.CoveredLines)
+	}
+	if result.Percent != 0 {
+		t.Errorf("Percent = %f, want 0", result.Percent)
+	}
+}
+
+func TestComputePatchCoverage_MultipleFiles(t *testing.T) {
+	changed := map[string][]LineRange{
+		"a.go": {{Start: 1, End: 2}},  // 2 lines
+		"b.go": {{Start: 10, End: 10}}, // 1 line
+	}
+	blocks := []ProfileBlock{
+		{File: "a.go", StartLine: 1, EndLine: 2, Stmts: 1, Count: 1},
+		// b.go has no coverage blocks - uncovered
+	}
+
+	result := ComputePatchCoverage(changed, blocks)
+
+	if result.TotalLines != 3 {
+		t.Errorf("TotalLines = %d, want 3", result.TotalLines)
+	}
+	if result.CoveredLines != 2 {
+		t.Errorf("CoveredLines = %d, want 2", result.CoveredLines)
+	}
+}
+
+func TestFormatResult_BelowTarget(t *testing.T) {
+	result := PatchResult{
+		Percent:      45.0,
+		TotalLines:   40,
+		CoveredLines: 18,
+		Uncovered: []UncoveredFile{
+			{
+				File: "internal/foo/bar.go",
+				Ranges: []LineRange{
+					{Start: 23, End: 31},
+					{Start: 45, End: 47},
+				},
+			},
+			{
+				File: "internal/baz/qux.go",
+				Ranges: []LineRange{
+					{Start: 10, End: 15},
+				},
+			},
+		},
+	}
+
+	got := FormatResult(result, 80)
+
+	if !strings.Contains(got, "45.0%") {
+		t.Errorf("FormatResult() missing percentage: %s", got)
+	}
+	if !strings.Contains(got, "18/40") {
+		t.Errorf("FormatResult() missing line counts: %s", got)
+	}
+	if !strings.Contains(got, "target: 80%") {
+		t.Errorf("FormatResult() missing target: %s", got)
+	}
+	if !strings.Contains(got, "internal/foo/bar.go:23-31") {
+		t.Errorf("FormatResult() missing uncovered range: %s", got)
+	}
+	if !strings.Contains(got, "internal/baz/qux.go:10-15") {
+		t.Errorf("FormatResult() missing uncovered range: %s", got)
+	}
+	if !strings.Contains(got, "Write tests that exercise") {
+		t.Errorf("FormatResult() missing action prompt: %s", got)
+	}
+}
+
+func TestFormatResult_AtTarget(t *testing.T) {
+	result := PatchResult{
+		Percent:      100,
+		TotalLines:   10,
+		CoveredLines: 10,
+	}
+
+	got := FormatResult(result, 80)
+
+	if !strings.Contains(got, "100.0%") {
+		t.Errorf("FormatResult() missing percentage: %s", got)
+	}
+	if strings.Contains(got, "Uncovered") {
+		t.Errorf("FormatResult() should not contain uncovered section when all covered: %s", got)
+	}
+}
+
+func TestFormatResult_SingleLineUncovered(t *testing.T) {
+	result := PatchResult{
+		Percent:      50,
+		TotalLines:   2,
+		CoveredLines: 1,
+		Uncovered: []UncoveredFile{
+			{
+				File:   "foo.go",
+				Ranges: []LineRange{{Start: 5, End: 5}},
+			},
+		},
+	}
+
+	got := FormatResult(result, 80)
+
+	// Single line should be formatted as "foo.go:5" not "foo.go:5-5"
+	if !strings.Contains(got, "foo.go:5") {
+		t.Errorf("FormatResult() missing single line reference: %s", got)
+	}
+	if strings.Contains(got, "foo.go:5-5") {
+		t.Errorf("FormatResult() should not show range for single line: %s", got)
+	}
+}
+
+func TestAppendToRanges_Contiguous(t *testing.T) {
+	ranges := []LineRange{{Start: 5, End: 7}}
+	got := appendToRanges(ranges, 8)
+
+	if len(got) != 1 {
+		t.Fatalf("appendToRanges() returned %d ranges, want 1", len(got))
+	}
+	if got[0].End != 8 {
+		t.Errorf("End = %d, want 8", got[0].End)
+	}
+}
+
+func TestAppendToRanges_Gap(t *testing.T) {
+	ranges := []LineRange{{Start: 5, End: 7}}
+	got := appendToRanges(ranges, 10)
+
+	if len(got) != 2 {
+		t.Fatalf("appendToRanges() returned %d ranges, want 2", len(got))
+	}
+}

--- a/internal/coverage/profile.go
+++ b/internal/coverage/profile.go
@@ -1,0 +1,103 @@
+package coverage
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ProfileBlock represents a single block from a Go coverage profile.
+type ProfileBlock struct {
+	File      string // relative file path (module prefix stripped)
+	StartLine int
+	EndLine   int
+	Stmts     int
+	Count     int // execution count; 0 means uncovered
+}
+
+// ParseProfile parses Go coverage profile data (the output of -coverprofile).
+// modulePath is used to strip the module prefix from file paths, e.g.
+// "github.com/phs/dark-factory/internal/foo/bar.go" becomes "internal/foo/bar.go".
+//
+// Profile format: "file:startLine.startCol,endLine.endCol stmts count"
+func ParseProfile(data string, modulePath string) []ProfileBlock {
+	if data == "" {
+		return nil
+	}
+
+	prefix := modulePath + "/"
+	var blocks []ProfileBlock
+
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "mode:") {
+			continue
+		}
+
+		// Split "file:startLine.startCol,endLine.endCol stmts count"
+		// into "file:startLine.startCol,endLine.endCol" and "stmts count".
+		spaceIdx := strings.LastIndex(line, " ")
+		if spaceIdx < 0 {
+			continue
+		}
+		countStr := line[spaceIdx+1:]
+		rest := line[:spaceIdx]
+
+		spaceIdx2 := strings.LastIndex(rest, " ")
+		if spaceIdx2 < 0 {
+			continue
+		}
+		stmtsStr := rest[spaceIdx2+1:]
+		fileRange := rest[:spaceIdx2]
+
+		// Split file:startLine.startCol,endLine.endCol
+		colonIdx := strings.Index(fileRange, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		file := fileRange[:colonIdx]
+		rangePart := fileRange[colonIdx+1:]
+
+		// Strip module prefix.
+		if strings.HasPrefix(file, prefix) {
+			file = file[len(prefix):]
+		}
+
+		// Parse "startLine.startCol,endLine.endCol"
+		commaIdx := strings.Index(rangePart, ",")
+		if commaIdx < 0 {
+			continue
+		}
+		startPart := rangePart[:commaIdx]
+		endPart := rangePart[commaIdx+1:]
+
+		startLine := parseDotInt(startPart)
+		endLine := parseDotInt(endPart)
+		if startLine == 0 || endLine == 0 {
+			continue
+		}
+
+		stmts, _ := strconv.Atoi(stmtsStr)
+		count, _ := strconv.Atoi(countStr)
+
+		blocks = append(blocks, ProfileBlock{
+			File:      file,
+			StartLine: startLine,
+			EndLine:   endLine,
+			Stmts:     stmts,
+			Count:     count,
+		})
+	}
+
+	return blocks
+}
+
+// parseDotInt parses the integer before the dot in "N.M" (e.g. "10.5" -> 10).
+func parseDotInt(s string) int {
+	dotIdx := strings.Index(s, ".")
+	if dotIdx < 0 {
+		n, _ := strconv.Atoi(s)
+		return n
+	}
+	n, _ := strconv.Atoi(s[:dotIdx])
+	return n
+}

--- a/internal/coverage/profile_test.go
+++ b/internal/coverage/profile_test.go
@@ -1,0 +1,74 @@
+package coverage
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseProfile_Basic(t *testing.T) {
+	data := `mode: set
+github.com/phs/dark-factory/internal/foo/bar.go:10.2,15.3 2 1
+github.com/phs/dark-factory/internal/foo/bar.go:20.2,25.3 3 0
+github.com/phs/dark-factory/internal/baz/qux.go:5.10,8.2 1 1
+`
+
+	got := ParseProfile(data, "github.com/phs/dark-factory")
+
+	want := []ProfileBlock{
+		{File: "internal/foo/bar.go", StartLine: 10, EndLine: 15, Stmts: 2, Count: 1},
+		{File: "internal/foo/bar.go", StartLine: 20, EndLine: 25, Stmts: 3, Count: 0},
+		{File: "internal/baz/qux.go", StartLine: 5, EndLine: 8, Stmts: 1, Count: 1},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseProfile() = %v, want %v", got, want)
+	}
+}
+
+func TestParseProfile_Empty(t *testing.T) {
+	got := ParseProfile("", "github.com/phs/dark-factory")
+	if got != nil {
+		t.Errorf("ParseProfile(\"\") = %v, want nil", got)
+	}
+}
+
+func TestParseProfile_ModeLineOnly(t *testing.T) {
+	got := ParseProfile("mode: atomic\n", "github.com/phs/dark-factory")
+	if got != nil {
+		t.Errorf("ParseProfile(mode only) = %v, want nil", got)
+	}
+}
+
+func TestParseProfile_NoModulePrefix(t *testing.T) {
+	data := `mode: set
+other/module/foo.go:1.1,5.2 1 1
+`
+
+	got := ParseProfile(data, "github.com/phs/dark-factory")
+
+	// File path is not stripped since prefix doesn't match.
+	if len(got) != 1 {
+		t.Fatalf("ParseProfile() returned %d blocks, want 1", len(got))
+	}
+	if got[0].File != "other/module/foo.go" {
+		t.Errorf("File = %q, want %q", got[0].File, "other/module/foo.go")
+	}
+}
+
+func TestParseDotInt(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"10.5", 10},
+		{"1.1", 1},
+		{"100.99", 100},
+		{"42", 42},
+	}
+	for _, tt := range tests {
+		got := parseDotInt(tt.input)
+		if got != tt.want {
+			t.Errorf("parseDotInt(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/coverage` package with diff parsing, coverage-to-diff mapping, and Go coverage profile parsing
- Includes comprehensive test coverage for all three components

## Test plan
- [x] Unit tests included for diff, patch, and profile modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)