### PR TITLE
feat(agent): wire judge into agent loop — intervention events and run data

### DIFF
--- a/internal/agent/launcher.go
+++ b/internal/agent/launcher.go
@@ -228,6 +228,45 @@ func runHost(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result, e
 	return res, nil
 }
 
+// buildJudgeCallback creates a LogCallback for the sandbox that feeds lines
+// to the judge. Returns nil when the judge is disabled or not configured.
+func buildJudgeCallback(
+	opts RunOpts,
+	cancel context.CancelFunc,
+	interventionPtr *atomic.Pointer[judge.Intervention],
+	judgeKilled *atomic.Bool,
+	logger *slog.Logger,
+) func(line string) {
+	if opts.JudgeConfig == nil {
+		return nil
+	}
+	if opts.JudgeConfig.Enabled != nil && !*opts.JudgeConfig.Enabled {
+		return nil
+	}
+
+	j := judge.NewJudge(opts.Role, judge.Config{
+		IdleTimeoutByRole:         opts.JudgeConfig.IdleTimeoutByRole,
+		DefaultIdleTimeout:        opts.JudgeConfig.DefaultIdleTimeout,
+		ToolThrashThreshold:       opts.JudgeConfig.ToolThrashThreshold,
+		ToolThrashWindowSecs:      opts.JudgeConfig.ToolThrashWindowSecs,
+		TransportFailureThreshold: opts.JudgeConfig.TransportFailureThreshold,
+	})
+	logger.Info("judge enabled for sandbox run", "role", opts.Role)
+
+	return func(line string) {
+		iv := j.ProcessLine(line, time.Now())
+		if iv == nil {
+			return
+		}
+		// Store the intervention (first one wins).
+		interventionPtr.CompareAndSwap(nil, iv)
+		if iv.Judgment == judge.Kill {
+			judgeKilled.Store(true)
+			cancel()
+		}
+	}
+}
+
 func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result, error) {
 	logger.Info("running agent in sandbox", "image", opts.Image, "timeout", opts.Timeout)
 
@@ -266,31 +305,7 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 		interventionPtr atomic.Pointer[judge.Intervention]
 		judgeKilled     atomic.Bool
 	)
-	var logCallback func(line string)
-	if opts.JudgeConfig != nil && (opts.JudgeConfig.Enabled == nil || *opts.JudgeConfig.Enabled) {
-		j := judge.NewJudge(opts.Role, judge.Config{
-			IdleTimeoutByRole:         opts.JudgeConfig.IdleTimeoutByRole,
-			DefaultIdleTimeout:        opts.JudgeConfig.DefaultIdleTimeout,
-			ToolThrashThreshold:       opts.JudgeConfig.ToolThrashThreshold,
-			ToolThrashWindowSecs:      opts.JudgeConfig.ToolThrashWindowSecs,
-			TransportFailureThreshold: opts.JudgeConfig.TransportFailureThreshold,
-		})
-		logCallback = func(line string) {
-			iv := j.ProcessLine(line, time.Now())
-			if iv == nil {
-				return
-			}
-			// Store the intervention (first one wins).
-			// Use atomic compare-and-swap to avoid a data race between
-			// concurrent log lines; only the first intervention is recorded.
-			interventionPtr.CompareAndSwap(nil, iv)
-			if iv.Judgment == judge.Kill {
-				judgeKilled.Store(true)
-				cancel() // stop the container
-			}
-		}
-		logger.Info("judge enabled for sandbox run", "role", opts.Role)
-	}
+	logCallback := buildJudgeCallback(opts, cancel, &interventionPtr, &judgeKilled, logger)
 
 	sandboxOpts := sandbox.RunOpts{
 		Image:             opts.Image,

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -92,6 +92,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	if prompts.SpecGenerator != "" && !HasScenarioSpec(cfg.ScenarioDir, issue.Number) {
 		logger.Info("no scenario spec found, generating", "issue_number", issue.Number)
 		specResult, err := GenerateSpec(ctx, issue, cfg, prompts, authEnv, logger)
+		if specResult != nil {
+			handleJudgeIntervention(issue.Number, "spec_generator", specResult, hook, logger)
+		}
 		var specWriteHook func(rundata.StepResult) error
 		if hook != nil {
 			specWriteHook = func(step rundata.StepResult) error {
@@ -123,6 +126,9 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 			reporter.IssueStageChanged(issue.Number, "recon")
 		}
 		reconResult, reconErr := Recon(ctx, issue, cfg, prompts, authEnv, logger)
+		if reconResult != nil {
+			handleJudgeIntervention(issue.Number, "recon", reconResult, hook, logger)
+		}
 		var reconWriteHook func(rundata.StepResult) error
 		if hook != nil {
 			reconWriteHook = func(step rundata.StepResult) error {
@@ -139,6 +145,12 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	if err != nil {
 		outcome.Status = StatusFailed
 		outcome.Err = fmt.Errorf("implementer agent: %w", err)
+		return outcome
+	}
+	if handleJudgeIntervention(issue.Number, "implement", implResult, hook, logger) {
+		runPostMortem(issue.Number, implResult, hook, logger)
+		outcome.Status = StatusFailed
+		outcome.Err = fmt.Errorf("implementer agent killed by judge: %s", implResult.JudgeIntervention.Rule)
 		return outcome
 	}
 	if implResult.TimedOut {
@@ -334,6 +346,9 @@ func runVerifyPhase(
 					if err != nil {
 						return fmt.Errorf("verify-fix agent: %w", err)
 					}
+					if handleJudgeIntervention(issue.Number, "verify_fix", fixResult, hook, logger) {
+						return fmt.Errorf("verify-fix agent killed by judge: %s", fixResult.JudgeIntervention.Rule)
+					}
 					if fixResult.TimedOut {
 						return fmt.Errorf("verify-fix agent timed out")
 					}
@@ -416,6 +431,9 @@ func runVerifyPhase(
 				fixResult, err := VerifyFix(ctx, issue, prNum, verifyErrors, *sessionID, cfg, prompts, authEnv, logger)
 				if err != nil {
 					return fmt.Errorf("verify-fix agent: %w", err)
+				}
+				if handleJudgeIntervention(issue.Number, "verify_fix", fixResult, hook, logger) {
+					return fmt.Errorf("verify-fix agent killed by judge: %s", fixResult.JudgeIntervention.Rule)
 				}
 				if fixResult.TimedOut {
 					return fmt.Errorf("verify-fix agent timed out")
@@ -845,6 +863,9 @@ func runFunctionalReviewCycle(
 					if err != nil {
 						return StatusFailed, false, 0, fmt.Errorf("CI fix agent: %w", err)
 					}
+					if handleJudgeIntervention(issue.Number, "ci_fix", fixResult, hook, logger) {
+						return StatusFailed, false, 0, fmt.Errorf("CI fix agent killed by judge: %s", fixResult.JudgeIntervention.Rule)
+					}
 					if fixResult.TimedOut {
 						return StatusFailed, false, 0, fmt.Errorf("CI fix agent timed out")
 					}
@@ -913,6 +934,9 @@ func runFunctionalReviewCycle(
 			retryResult, err := Retry(ctx, issue, prNum, *sessionID, "", handoff, cfg, prompts, authEnv, logger)
 			if err != nil {
 				return StatusFailed, false, 0, fmt.Errorf("retry agent: %w", err)
+			}
+			if handleJudgeIntervention(issue.Number, "retry", retryResult, hook, logger) {
+				return StatusFailed, false, 0, fmt.Errorf("retry agent killed by judge: %s", retryResult.JudgeIntervention.Rule)
 			}
 			if retryResult.TimedOut {
 				return StatusFailed, false, 0, fmt.Errorf("retry agent timed out")
@@ -1132,6 +1156,54 @@ func hasQualityFlag(flags []quality.Flag, code string) bool {
 		}
 	}
 	return false
+}
+
+// handleJudgeIntervention writes a judge intervention to run data and logs it.
+// Returns true if the judge killed the container with no usable result (caller
+// should treat as terminal for this attempt). Returns false if there was no
+// intervention, or if the kill produced a usable result (caller should proceed
+// normally).
+func handleJudgeIntervention(issueNum int, step string, result *Result, hook RunDataHook, logger *slog.Logger) (terminalKill bool) {
+	if result == nil || !result.JudgeKilled || result.JudgeIntervention == nil {
+		return false
+	}
+
+	iv := result.JudgeIntervention
+	logger.Warn("judge intervention",
+		"issue_number", issueNum,
+		"step", step,
+		"rule", iv.Rule,
+		"judgment", string(iv.Judgment),
+		"detail", iv.Detail,
+	)
+
+	if hook != nil {
+		ji := rundata.JudgeIntervention{
+			Rule:       iv.Rule,
+			Judgment:   string(iv.Judgment),
+			Detail:     iv.Detail,
+			Counts:     iv.Counts,
+			DetectedAt: iv.DetectedAt,
+			Step:       step,
+		}
+		if err := hook.WriteJudgeIntervention(issueNum, ji); err != nil {
+			logger.Warn("failed to write judge intervention", "issue_number", issueNum, "error", err)
+		}
+	}
+
+	// Kill with usable result: the agent completed work before going idle.
+	// Proceed normally — the kill was benign.
+	if result.ResultText != "" {
+		logger.Info("judge killed container but result is usable, proceeding",
+			"issue_number", issueNum, "step", step)
+		return false
+	}
+
+	// Kill with no result: the agent stalled before producing output.
+	// Terminal for this attempt.
+	logger.Warn("judge killed container with no usable result",
+		"issue_number", issueNum, "step", step, "rule", iv.Rule)
+	return true
 }
 
 // runPostMortem performs best-effort post-mortem analysis on a failed agent result

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/peter-stratton/dark-factory/internal/agent/judge"
 	"github.com/peter-stratton/dark-factory/internal/config"
 	"github.com/peter-stratton/dark-factory/internal/github"
 	"github.com/peter-stratton/dark-factory/internal/label"
@@ -964,6 +965,7 @@ type testRunDataHook struct {
 	outcomes                   []rundata.Outcome
 	issueStatuses              []rundata.IssueStatus
 	riskAssessments            []rundata.RiskAssessment
+	judgeInterventions         []rundata.JudgeIntervention
 }
 
 func (h *testRunDataHook) WriteReconResult(_ int, _ rundata.StepResult) error {
@@ -1012,6 +1014,10 @@ func (h *testRunDataHook) WriteRiskAssessment(_ int, a rundata.RiskAssessment) e
 }
 func (h *testRunDataHook) WriteFailureAnalysis(_ int, _ rundata.FailureAnalysis) error { return nil }
 func (h *testRunDataHook) WriteContainerLog(_ int, _ string) error                     { return nil }
+func (h *testRunDataHook) WriteJudgeIntervention(_ int, ji rundata.JudgeIntervention) error {
+	h.judgeInterventions = append(h.judgeInterventions, ji)
+	return nil
+}
 
 func TestProcessIssue_HookCalledOnImplement(t *testing.T) {
 	hook := &testRunDataHook{}
@@ -4835,5 +4841,101 @@ func TestProcessIssue_RetryReentersImplementStage(t *testing.T) {
 	count := reporter.countStageChanges("implement")
 	if count < 2 {
 		t.Errorf("IssueStageChanged(_, %q) called %d time(s), want at least 2 (initial + retry)", "implement", count)
+	}
+}
+
+// --- Judge intervention tests ---
+
+func TestHandleJudgeIntervention_NoIntervention(t *testing.T) {
+	hook := &testRunDataHook{}
+	result := &Result{JudgeKilled: false}
+	terminal := handleJudgeIntervention(42, "implement", result, hook, testLogger(t))
+	if terminal {
+		t.Error("expected false for non-killed result")
+	}
+	if len(hook.judgeInterventions) != 0 {
+		t.Errorf("expected no interventions written, got %d", len(hook.judgeInterventions))
+	}
+}
+
+func TestHandleJudgeIntervention_KillWithUsableResult(t *testing.T) {
+	hook := &testRunDataHook{}
+	result := &Result{
+		JudgeKilled: true,
+		JudgeIntervention: &judge.Intervention{
+			Rule:     "idle_timeout",
+			Judgment: judge.Kill,
+			Detail:   "no tool call for 300s",
+		},
+		ResultText: "Implementation complete",
+	}
+	terminal := handleJudgeIntervention(42, "implement", result, hook, testLogger(t))
+	if terminal {
+		t.Error("expected false for kill with usable result")
+	}
+	if len(hook.judgeInterventions) != 1 {
+		t.Fatalf("expected 1 intervention written, got %d", len(hook.judgeInterventions))
+	}
+	ji := hook.judgeInterventions[0]
+	if ji.Rule != "idle_timeout" {
+		t.Errorf("Rule = %q, want %q", ji.Rule, "idle_timeout")
+	}
+	if ji.Step != "implement" {
+		t.Errorf("Step = %q, want %q", ji.Step, "implement")
+	}
+	if ji.Judgment != "kill" {
+		t.Errorf("Judgment = %q, want %q", ji.Judgment, "kill")
+	}
+}
+
+func TestHandleJudgeIntervention_KillWithNoResult(t *testing.T) {
+	hook := &testRunDataHook{}
+	result := &Result{
+		JudgeKilled: true,
+		JudgeIntervention: &judge.Intervention{
+			Rule:     "idle_timeout",
+			Judgment: judge.Kill,
+			Detail:   "no tool call for 300s",
+		},
+		ResultText: "",
+	}
+	terminal := handleJudgeIntervention(42, "implement", result, hook, testLogger(t))
+	if !terminal {
+		t.Error("expected true for kill with no usable result")
+	}
+	if len(hook.judgeInterventions) != 1 {
+		t.Fatalf("expected 1 intervention written, got %d", len(hook.judgeInterventions))
+	}
+}
+
+func TestHandleJudgeIntervention_NilResult(t *testing.T) {
+	hook := &testRunDataHook{}
+	terminal := handleJudgeIntervention(42, "implement", nil, hook, testLogger(t))
+	if terminal {
+		t.Error("expected false for nil result")
+	}
+}
+
+func TestHandleJudgeIntervention_CorrectStepName(t *testing.T) {
+	steps := []string{"implement", "retry", "verify_fix", "ci_fix", "recon", "spec_generator"}
+	for _, step := range steps {
+		hook := &testRunDataHook{}
+		result := &Result{
+			JudgeKilled: true,
+			JudgeIntervention: &judge.Intervention{
+				Rule:     "tool_thrash",
+				Judgment: judge.Kill,
+				Detail:   "ToolSearch repeated",
+			},
+			ResultText: "done",
+		}
+		handleJudgeIntervention(42, step, result, hook, testLogger(t))
+		if len(hook.judgeInterventions) != 1 {
+			t.Errorf("step %q: expected 1 intervention, got %d", step, len(hook.judgeInterventions))
+			continue
+		}
+		if hook.judgeInterventions[0].Step != step {
+			t.Errorf("step %q: got Step=%q", step, hook.judgeInterventions[0].Step)
+		}
 	}
 }

--- a/internal/agent/runhook.go
+++ b/internal/agent/runhook.go
@@ -19,4 +19,5 @@ type RunDataHook interface {
 	WriteRiskAssessment(issueNumber int, assessment rundata.RiskAssessment) error
 	WriteFailureAnalysis(issueNumber int, analysis rundata.FailureAnalysis) error
 	WriteContainerLog(issueNumber int, log string) error
+	WriteJudgeIntervention(issueNumber int, intervention rundata.JudgeIntervention) error
 }


### PR DESCRIPTION
Closes #646

## Summary
- Add `WriteJudgeIntervention` to `RunDataHook` interface
- Add `handleJudgeIntervention()` helper that converts `judge.Intervention` → `rundata.JudgeIntervention` and distinguishes kill-with-usable-result (proceed) from kill-with-no-result (terminal)
- Wire into all agent call sites: implement, retry, verify_fix, ci_fix, recon, spec_generator
- Extract `buildJudgeCallback()` from `runSandbox()` to fix cyclop lint (complexity 19 → under 18)

## Test plan
- [x] 5 new unit tests for `handleJudgeIntervention` covering: no intervention, kill with usable result, kill with no result, nil result, correct step names
- [x] All 9 existing launcher judge tests pass
- [x] Full test suite passes (37 packages)
- [x] Lint clean (cyclop resolved)