### PR TITLE
feat(agent): container retry for transport failures

### DIFF
--- a/internal/agent/launcher.go
+++ b/internal/agent/launcher.go
@@ -260,7 +260,7 @@ func buildJudgeCallback(
 		}
 		// Store the intervention (first one wins).
 		interventionPtr.CompareAndSwap(nil, iv)
-		if iv.Judgment == judge.Kill {
+		if iv.Judgment == judge.Kill || iv.Judgment == judge.RetryContainer {
 			judgeKilled.Store(true)
 			cancel()
 		}
@@ -295,17 +295,14 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 	}
 	entrypoint := sandbox.EntrypointScript(cloneScript, agentCmd)
 
-	// Wrap the context with cancel so the judge can stop the container
-	// independently of the timeout.
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Set up judge and log callback when judge is enabled.
-	var (
-		interventionPtr atomic.Pointer[judge.Intervention]
-		judgeKilled     atomic.Bool
-	)
-	logCallback := buildJudgeCallback(opts, cancel, &interventionPtr, &judgeKilled, logger)
+	// Determine the container retry limit for transport failures.
+	containerRetryLimit := 0
+	if opts.JudgeConfig != nil {
+		containerRetryLimit = opts.JudgeConfig.ContainerRetryLimit
+		if containerRetryLimit == 0 {
+			containerRetryLimit = 2 // default
+		}
+	}
 
 	sandboxOpts := sandbox.RunOpts{
 		Image:             opts.Image,
@@ -313,12 +310,57 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 		Env:               env,
 		Timeout:           opts.Timeout,
 		MountDockerSocket: opts.MountDockerSocket,
-		LogCallback:       logCallback,
 	}
 
 	startedAt := time.Now()
-	result, err := SandboxRunner(ctx, sandboxOpts, logger)
-	finishedAt := time.Now()
+	var res *Result
+
+	for attempt := 0; attempt <= containerRetryLimit; attempt++ {
+		if attempt > 0 {
+			logger.Warn("retrying container after transport failure",
+				"attempt", attempt+1,
+				"max_attempts", containerRetryLimit+1,
+			)
+			refreshGHToken(env, logger)
+		}
+
+		var err error
+		res, err = runSandboxOnce(ctx, opts, sandboxOpts, startedAt, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		// If judge returned RetryContainer and we have retries left, loop.
+		if res.JudgeKilled && res.JudgeIntervention != nil &&
+			res.JudgeIntervention.Judgment == judge.RetryContainer &&
+			attempt < containerRetryLimit {
+			logger.Warn("judge recommends container retry",
+				"rule", res.JudgeIntervention.Rule,
+				"detail", res.JudgeIntervention.Detail,
+				"attempt", attempt+1,
+			)
+			continue
+		}
+		break
+	}
+
+	return res, nil
+}
+
+// runSandboxOnce executes a single container attempt with judge monitoring.
+// It creates a fresh judge and context cancel per attempt so previous state
+// doesn't carry over.
+func runSandboxOnce(ctx context.Context, opts RunOpts, sandboxOpts sandbox.RunOpts, startedAt time.Time, logger *slog.Logger) (*Result, error) {
+	attemptCtx, attemptCancel := context.WithCancel(ctx)
+	defer attemptCancel()
+
+	var (
+		interventionPtr atomic.Pointer[judge.Intervention]
+		judgeKilled     atomic.Bool
+	)
+	sandboxOpts.LogCallback = buildJudgeCallback(opts, attemptCancel, &interventionPtr, &judgeKilled, logger)
+
+	result, err := SandboxRunner(attemptCtx, sandboxOpts, logger)
 	if err != nil {
 		return nil, fmt.Errorf("running sandbox container: %w", err)
 	}
@@ -336,11 +378,11 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 		ExitCode:          result.ExitCode,
 		Stdout:            result.Stdout,
 		Stderr:            result.Stderr,
-		TimedOut:          result.TimedOut && !killed, // judge kill is not a timeout
+		TimedOut:          result.TimedOut && !killed,
 		JudgeKilled:       killed,
 		JudgeIntervention: interventionPtr.Load(),
 		StartedAt:         startedAt,
-		FinishedAt:        finishedAt,
+		FinishedAt:        time.Now(),
 		PeakMemoryBytes:   result.PeakMemoryBytes,
 		CPUNanoseconds:    result.CPUNanoseconds,
 	}
@@ -357,7 +399,6 @@ func runSandbox(ctx context.Context, opts RunOpts, logger *slog.Logger) (*Result
 	}
 
 	// Capture bounded container log for post-mortem on failure only.
-	// Must run after parseRunnerOutput so ExitCode reflects IsError upgrades.
 	if res.TimedOut || res.ExitCode != 0 {
 		combined := result.Stdout + result.Stderr
 		res.ContainerLog = boundLog(combined, maxPostMortemLines, maxPostMortemBytes)

--- a/internal/agent/launcher_judge_test.go
+++ b/internal/agent/launcher_judge_test.go
@@ -356,3 +356,184 @@ func TestRunSandbox_TimingFields(t *testing.T) {
 		t.Errorf("FinishedAt %v is before StartedAt %v", result.FinishedAt, result.StartedAt)
 	}
 }
+
+// --- Container retry tests ---
+
+// TestRunSandbox_RetrySucceeds verifies that a transport failure on the first
+// container triggers a retry, and the second container's result is returned.
+func TestRunSandbox_RetrySucceeds(t *testing.T) {
+	callCount := 0
+	stubSandboxRunner(t, func(ctx context.Context, opts sandbox.RunOpts, logger *slog.Logger) (*sandbox.RunResult, error) {
+		callCount++
+		if callCount == 1 {
+			// First container: feed stream errors to trigger transport failure.
+			if opts.LogCallback != nil {
+				for i := 0; i < 12; i++ {
+					opts.LogCallback("stream closed: EOF")
+				}
+			}
+			return sandboxResult("", 1, false), nil
+		}
+		// Second container: success.
+		if opts.LogCallback != nil {
+			opts.LogCallback(`{"tool":"Read","path":"foo.go"}`)
+		}
+		return sandboxResult(`{"session_id":"s-ok","result":"done","cost_usd":0.2,"is_error":false}`, 0, false), nil
+	})
+
+	enabled := true
+	opts := RunOpts{
+		Prompt: "test",
+		Role:   "implementer",
+		Repo:   "owner/repo",
+		JudgeConfig: &config.Judge{
+			Enabled:                   &enabled,
+			TransportFailureThreshold: 10,
+			ContainerRetryLimit:       2,
+		},
+	}
+	result, err := Run(context.Background(), opts, false, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("SandboxRunner called %d times, want 2", callCount)
+	}
+	if result.JudgeKilled {
+		t.Error("JudgeKilled should be false after successful retry")
+	}
+	if result.SessionID != "s-ok" {
+		t.Errorf("SessionID = %q, want %q", result.SessionID, "s-ok")
+	}
+}
+
+// TestRunSandbox_RetryLimitExhausted verifies that when all container retries
+// hit transport failures, the final result has JudgeKilled=true.
+func TestRunSandbox_RetryLimitExhausted(t *testing.T) {
+	callCount := 0
+	stubSandboxRunner(t, func(ctx context.Context, opts sandbox.RunOpts, logger *slog.Logger) (*sandbox.RunResult, error) {
+		callCount++
+		// Every container hits transport failure.
+		if opts.LogCallback != nil {
+			for i := 0; i < 12; i++ {
+				opts.LogCallback("stream closed: EOF")
+			}
+		}
+		return sandboxResult("", 1, false), nil
+	})
+
+	enabled := true
+	opts := RunOpts{
+		Prompt: "test",
+		Role:   "implementer",
+		Repo:   "owner/repo",
+		JudgeConfig: &config.Judge{
+			Enabled:                   &enabled,
+			TransportFailureThreshold: 10,
+			ContainerRetryLimit:       2,
+		},
+	}
+	result, err := Run(context.Background(), opts, false, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	// 1 initial + 2 retries = 3 total calls.
+	if callCount != 3 {
+		t.Errorf("SandboxRunner called %d times, want 3", callCount)
+	}
+	if !result.JudgeKilled {
+		t.Error("JudgeKilled should be true after exhausting retries")
+	}
+	if result.JudgeIntervention == nil {
+		t.Fatal("JudgeIntervention should be non-nil")
+	}
+	if result.JudgeIntervention.Rule != "transport_failure" {
+		t.Errorf("Rule = %q, want %q", result.JudgeIntervention.Rule, "transport_failure")
+	}
+}
+
+// TestRunSandbox_KillDoesNotRetry verifies that a Kill judgment (not
+// RetryContainer) does not trigger container retries.
+func TestRunSandbox_KillDoesNotRetry(t *testing.T) {
+	callCount := 0
+	stubSandboxRunner(t, func(ctx context.Context, opts sandbox.RunOpts, logger *slog.Logger) (*sandbox.RunResult, error) {
+		callCount++
+		// Trigger tool thrash → Kill (not RetryContainer).
+		if opts.LogCallback != nil {
+			for i := 0; i < 5; i++ {
+				opts.LogCallback(`ToolSearch("same query")`)
+			}
+		}
+		return sandboxResult("", 1, false), nil
+	})
+
+	enabled := true
+	opts := RunOpts{
+		Prompt: "test",
+		Role:   "implementer",
+		Repo:   "owner/repo",
+		JudgeConfig: &config.Judge{
+			Enabled:              &enabled,
+			ToolThrashThreshold:  3,
+			ToolThrashWindowSecs: 60,
+			ContainerRetryLimit:  2,
+		},
+	}
+	result, err := Run(context.Background(), opts, false, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if callCount != 1 {
+		t.Errorf("SandboxRunner called %d times, want 1 (no retry for Kill)", callCount)
+	}
+	if !result.JudgeKilled {
+		t.Error("JudgeKilled should be true")
+	}
+}
+
+// TestRunSandbox_RetryRunsTwiceOnTransportFailure is a simpler verification
+// that the retry loop executes exactly N+1 times (1 initial + N retries)
+// when transport failures persist, and the final result reflects the last
+// container's state.
+func TestRunSandbox_RetryRunsTwiceOnTransportFailure(t *testing.T) {
+	callCount := 0
+	stubSandboxRunner(t, func(ctx context.Context, opts sandbox.RunOpts, logger *slog.Logger) (*sandbox.RunResult, error) {
+		callCount++
+		if callCount <= 2 {
+			// First two containers: transport failure.
+			if opts.LogCallback != nil {
+				for i := 0; i < 12; i++ {
+					opts.LogCallback("stream error: connection reset")
+				}
+			}
+			return sandboxResult("", 1, false), nil
+		}
+		// Third container: success.
+		return sandboxResult(`{"session_id":"s3","result":"ok","cost_usd":0,"is_error":false}`, 0, false), nil
+	})
+
+	enabled := true
+	opts := RunOpts{
+		Prompt: "test",
+		Role:   "implementer",
+		Repo:   "owner/repo",
+		JudgeConfig: &config.Judge{
+			Enabled:                   &enabled,
+			TransportFailureThreshold: 10,
+			ContainerRetryLimit:       2,
+		},
+	}
+	result, err := Run(context.Background(), opts, false, testLogger(t))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if callCount != 3 {
+		t.Errorf("SandboxRunner called %d times, want 3 (1 initial + 2 retries)", callCount)
+	}
+	if result.JudgeKilled {
+		t.Error("JudgeKilled should be false after successful retry")
+	}
+	if result.SessionID != "s3" {
+		t.Errorf("SessionID = %q, want %q (from third container)", result.SessionID, "s3")
+	}
+}


### PR DESCRIPTION
Closes #647

## Summary
- Wrap container execution in a retry loop for `RetryContainer` judgments
- Extract `runSandboxOnce()` to keep complexity under cyclop threshold
- Update `buildJudgeCallback` to cancel context on `RetryContainer` (not just `Kill`)
- Each retry: fresh judge state, fresh context, refreshed GH App token

## Test plan
- [x] `TestRunSandbox_RetrySucceeds` — first container fails, second succeeds
- [x] `TestRunSandbox_RetryLimitExhausted` — all containers fail, 3 total calls
- [x] `TestRunSandbox_KillDoesNotRetry` — Kill judgment, no retry
- [x] `TestRunSandbox_RetryRunsTwiceOnTransportFailure` — 2 failures then success
- [x] All 9 existing launcher judge tests still pass
- [x] Full test suite passes, lint clean