### PR TITLE
fix(agent): wire JudgeConfig into RunOpts

### DIFF
--- a/internal/agent/implementer.go
+++ b/internal/agent/implementer.go
@@ -271,6 +271,7 @@ func newRunOpts(rendered string, cfg *config.Config, authEnv map[string]string, 
 	env["GODARK_GENERATED_PATHS"] = strings.Join(cfg.GeneratedPaths, ",")
 	env["GODARK_DENIED_COMMANDS"] = strings.Join(cfg.DeniedCommands, ",")
 
+	jc := cfg.JudgeConfig()
 	return RunOpts{
 		Prompt:            rendered,
 		Role:              role,
@@ -280,6 +281,7 @@ func newRunOpts(rendered string, cfg *config.Config, authEnv map[string]string, 
 		WorkDir:           "/workspace",
 		Timeout:           timeout,
 		MountDockerSocket: cfg.DockerCompose != nil,
+		JudgeConfig:       &jc,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- `newRunOpts` was not setting `RunOpts.JudgeConfig`, so the judge was never activated during real runs
- One-line fix: pass `cfg.JudgeConfig()` through to all agent calls

Without this fix, the entire judge system (log streaming, rules, interventions, container retry) was built but never turned on.