### PR TITLE
feat(tui): surface judge interventions in TUI and progress reporters

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -93,7 +93,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		logger.Info("no scenario spec found, generating", "issue_number", issue.Number)
 		specResult, err := GenerateSpec(ctx, issue, cfg, prompts, authEnv, logger)
 		if specResult != nil {
-			handleJudgeIntervention(issue.Number, "spec_generator", specResult, hook, logger)
+			handleJudgeIntervention(issue.Number, "spec_generator", specResult, hook, reporter, logger)
 		}
 		var specWriteHook func(rundata.StepResult) error
 		if hook != nil {
@@ -127,7 +127,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		}
 		reconResult, reconErr := Recon(ctx, issue, cfg, prompts, authEnv, logger)
 		if reconResult != nil {
-			handleJudgeIntervention(issue.Number, "recon", reconResult, hook, logger)
+			handleJudgeIntervention(issue.Number, "recon", reconResult, hook, reporter, logger)
 		}
 		var reconWriteHook func(rundata.StepResult) error
 		if hook != nil {
@@ -147,7 +147,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 		outcome.Err = fmt.Errorf("implementer agent: %w", err)
 		return outcome
 	}
-	if handleJudgeIntervention(issue.Number, "implement", implResult, hook, logger) {
+	if handleJudgeIntervention(issue.Number, "implement", implResult, hook, reporter, logger) {
 		runPostMortem(issue.Number, implResult, hook, logger)
 		outcome.Status = StatusFailed
 		outcome.Err = fmt.Errorf("implementer agent killed by judge: %s", implResult.JudgeIntervention.Rule)
@@ -229,7 +229,7 @@ func ProcessIssue(ctx context.Context, issue github.Issue, cfg *config.Config, p
 	if reporter != nil {
 		reporter.IssueStageChanged(issue.Number, "verify")
 	}
-	if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, &sessionID, &fixCycles); verifyErr != nil {
+	if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, reporter, &sessionID, &fixCycles); verifyErr != nil {
 		outcome.Status = StatusFailed
 		outcome.Err = verifyErr
 		return outcome
@@ -288,6 +288,7 @@ func runVerifyPhase(
 	authEnv map[string]string,
 	logger *slog.Logger,
 	hook RunDataHook,
+	reporter progress.ProgressReporter,
 	sessionID *string,
 	fixCycles *int,
 ) error {
@@ -346,7 +347,7 @@ func runVerifyPhase(
 					if err != nil {
 						return fmt.Errorf("verify-fix agent: %w", err)
 					}
-					if handleJudgeIntervention(issue.Number, "verify_fix", fixResult, hook, logger) {
+					if handleJudgeIntervention(issue.Number, "verify_fix", fixResult, hook, reporter, logger) {
 						return fmt.Errorf("verify-fix agent killed by judge: %s", fixResult.JudgeIntervention.Rule)
 					}
 					if fixResult.TimedOut {
@@ -432,7 +433,7 @@ func runVerifyPhase(
 				if err != nil {
 					return fmt.Errorf("verify-fix agent: %w", err)
 				}
-				if handleJudgeIntervention(issue.Number, "verify_fix", fixResult, hook, logger) {
+				if handleJudgeIntervention(issue.Number, "verify_fix", fixResult, hook, reporter, logger) {
 					return fmt.Errorf("verify-fix agent killed by judge: %s", fixResult.JudgeIntervention.Rule)
 				}
 				if fixResult.TimedOut {
@@ -637,7 +638,7 @@ func runQualityReviewCycle(
 
 			// Re-run verify after quality-gate retry so that changes introduced
 			// by the retry agent are caught before the next quality review cycle.
-			if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, sessionID, fixCycles); verifyErr != nil {
+			if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, reporter, sessionID, fixCycles); verifyErr != nil {
 				return false, fmt.Errorf("verify after quality-gate retry: %w", verifyErr)
 			}
 
@@ -809,7 +810,7 @@ func runFunctionalReviewCycle(
 			// mergeable after approval; if not, attempts automatic rebase or
 			// triggers a conflict-fix cycle.
 			if needsHR, rebaseErr := runPreMergeRebasePhase(
-				ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, sessionID, fixCycles,
+				ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, reporter, sessionID, fixCycles,
 			); rebaseErr != nil {
 				return StatusFailed, false, 0, rebaseErr
 			} else if needsHR {
@@ -863,7 +864,7 @@ func runFunctionalReviewCycle(
 					if err != nil {
 						return StatusFailed, false, 0, fmt.Errorf("CI fix agent: %w", err)
 					}
-					if handleJudgeIntervention(issue.Number, "ci_fix", fixResult, hook, logger) {
+					if handleJudgeIntervention(issue.Number, "ci_fix", fixResult, hook, reporter, logger) {
 						return StatusFailed, false, 0, fmt.Errorf("CI fix agent killed by judge: %s", fixResult.JudgeIntervention.Rule)
 					}
 					if fixResult.TimedOut {
@@ -935,7 +936,7 @@ func runFunctionalReviewCycle(
 			if err != nil {
 				return StatusFailed, false, 0, fmt.Errorf("retry agent: %w", err)
 			}
-			if handleJudgeIntervention(issue.Number, "retry", retryResult, hook, logger) {
+			if handleJudgeIntervention(issue.Number, "retry", retryResult, hook, reporter, logger) {
 				return StatusFailed, false, 0, fmt.Errorf("retry agent killed by judge: %s", retryResult.JudgeIntervention.Rule)
 			}
 			if retryResult.TimedOut {
@@ -1163,7 +1164,7 @@ func hasQualityFlag(flags []quality.Flag, code string) bool {
 // should treat as terminal for this attempt). Returns false if there was no
 // intervention, or if the kill produced a usable result (caller should proceed
 // normally).
-func handleJudgeIntervention(issueNum int, step string, result *Result, hook RunDataHook, logger *slog.Logger) (terminalKill bool) {
+func handleJudgeIntervention(issueNum int, step string, result *Result, hook RunDataHook, reporter progress.ProgressReporter, logger *slog.Logger) (terminalKill bool) {
 	if result == nil || !result.JudgeKilled || result.JudgeIntervention == nil {
 		return false
 	}
@@ -1176,6 +1177,10 @@ func handleJudgeIntervention(issueNum int, step string, result *Result, hook Run
 		"judgment", string(iv.Judgment),
 		"detail", iv.Detail,
 	)
+
+	if reporter != nil {
+		reporter.JudgeIntervention(issueNum, iv.Rule, string(iv.Judgment), iv.Detail, step)
+	}
 
 	if hook != nil {
 		ji := rundata.JudgeIntervention{
@@ -1357,6 +1362,7 @@ func runPreMergeRebasePhase(
 	authEnv map[string]string,
 	logger *slog.Logger,
 	hook RunDataHook,
+	reporter progress.ProgressReporter,
 	sessionID *string,
 	fixCycles *int,
 ) (needsHumanReview bool, err error) {
@@ -1414,7 +1420,7 @@ func runPreMergeRebasePhase(
 
 		// Re-run verify since the branch content has changed (either by
 		// automatic rebase or by the implementer's conflict fix).
-		if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, sessionID, fixCycles); verifyErr != nil {
+		if verifyErr := runVerifyPhase(ctx, issue, prNum, branch, baseSHA, cfg, prompts, authEnv, logger, hook, reporter, sessionID, fixCycles); verifyErr != nil {
 			return false, fmt.Errorf("verify after rebase attempt %d: %w", attempt+1, verifyErr)
 		}
 	}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -4721,7 +4721,8 @@ func (r *mockReporter) WaveStarted(_, _ int)                  {}
 func (r *mockReporter) AllBlocked(_, _ int)                   {}
 func (r *mockReporter) RollupCreated(_ int, _ string, _ bool) {}
 func (r *mockReporter) RunFinished(_, _, _, _, _ int)         {}
-func (r *mockReporter) PunchlistText(_ string)                {}
+func (r *mockReporter) JudgeIntervention(_ int, _, _, _, _ string) {}
+func (r *mockReporter) PunchlistText(_ string)                    {}
 
 func (r *mockReporter) hasStageChange(number int, stage string) bool {
 	for _, sc := range r.stageChanges {
@@ -4849,7 +4850,7 @@ func TestProcessIssue_RetryReentersImplementStage(t *testing.T) {
 func TestHandleJudgeIntervention_NoIntervention(t *testing.T) {
 	hook := &testRunDataHook{}
 	result := &Result{JudgeKilled: false}
-	terminal := handleJudgeIntervention(42, "implement", result, hook, testLogger(t))
+	terminal := handleJudgeIntervention(42, "implement", result, hook, nil, testLogger(t))
 	if terminal {
 		t.Error("expected false for non-killed result")
 	}
@@ -4869,7 +4870,7 @@ func TestHandleJudgeIntervention_KillWithUsableResult(t *testing.T) {
 		},
 		ResultText: "Implementation complete",
 	}
-	terminal := handleJudgeIntervention(42, "implement", result, hook, testLogger(t))
+	terminal := handleJudgeIntervention(42, "implement", result, hook, nil, testLogger(t))
 	if terminal {
 		t.Error("expected false for kill with usable result")
 	}
@@ -4899,7 +4900,7 @@ func TestHandleJudgeIntervention_KillWithNoResult(t *testing.T) {
 		},
 		ResultText: "",
 	}
-	terminal := handleJudgeIntervention(42, "implement", result, hook, testLogger(t))
+	terminal := handleJudgeIntervention(42, "implement", result, hook, nil, testLogger(t))
 	if !terminal {
 		t.Error("expected true for kill with no usable result")
 	}
@@ -4910,7 +4911,7 @@ func TestHandleJudgeIntervention_KillWithNoResult(t *testing.T) {
 
 func TestHandleJudgeIntervention_NilResult(t *testing.T) {
 	hook := &testRunDataHook{}
-	terminal := handleJudgeIntervention(42, "implement", nil, hook, testLogger(t))
+	terminal := handleJudgeIntervention(42, "implement", nil, hook, nil, testLogger(t))
 	if terminal {
 		t.Error("expected false for nil result")
 	}
@@ -4929,7 +4930,7 @@ func TestHandleJudgeIntervention_CorrectStepName(t *testing.T) {
 			},
 			ResultText: "done",
 		}
-		handleJudgeIntervention(42, step, result, hook, testLogger(t))
+		handleJudgeIntervention(42, step, result, hook, nil, testLogger(t))
 		if len(hook.judgeInterventions) != 1 {
 			t.Errorf("step %q: expected 1 intervention, got %d", step, len(hook.judgeInterventions))
 			continue

--- a/internal/agent/rebase_test.go
+++ b/internal/agent/rebase_test.go
@@ -58,7 +58,7 @@ func TestRunPreMergeRebasePhase_Disabled(t *testing.T) {
 	fc := 0
 	needsHR, err := runPreMergeRebasePhase(
 		context.Background(), testIssue(), 42, "42-test", "abc123",
-		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+		cfg, testPrompts(t), nil, testLogger(t), nil, nil, &sid, &fc,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -89,7 +89,7 @@ func TestRunPreMergeRebasePhase_Mergeable(t *testing.T) {
 	fc := 0
 	needsHR, err := runPreMergeRebasePhase(
 		context.Background(), testIssue(), 42, "42-test", "abc123",
-		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+		cfg, testPrompts(t), nil, testLogger(t), nil, nil, &sid, &fc,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -117,7 +117,7 @@ func TestRunPreMergeRebasePhase_Unknown(t *testing.T) {
 	fc := 0
 	needsHR, err := runPreMergeRebasePhase(
 		context.Background(), testIssue(), 42, "42-test", "abc123",
-		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+		cfg, testPrompts(t), nil, testLogger(t), nil, nil, &sid, &fc,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -142,7 +142,7 @@ func TestRunPreMergeRebasePhase_CheckMergeableError(t *testing.T) {
 	fc := 0
 	needsHR, err := runPreMergeRebasePhase(
 		context.Background(), testIssue(), 42, "42-test", "abc123",
-		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+		cfg, testPrompts(t), nil, testLogger(t), nil, nil, &sid, &fc,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -181,7 +181,7 @@ func TestRunPreMergeRebasePhase_ConflictingAutoRebaseSuccess(t *testing.T) {
 	fc := 0
 	needsHR, err := runPreMergeRebasePhase(
 		context.Background(), testIssue(), 42, "42-test", "abc123",
-		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+		cfg, testPrompts(t), nil, testLogger(t), nil, nil, &sid, &fc,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -229,7 +229,7 @@ func TestRunPreMergeRebasePhase_ConflictingUpdateBranchFails_ImplementerFixes(t 
 	fc := 0
 	needsHR, err := runPreMergeRebasePhase(
 		context.Background(), testIssue(), 42, "42-test", "abc123",
-		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+		cfg, testPrompts(t), nil, testLogger(t), nil, nil, &sid, &fc,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -270,7 +270,7 @@ func TestRunPreMergeRebasePhase_ExhaustsAttempts_NeedsHumanReview(t *testing.T) 
 	fc := 0
 	needsHR, err := runPreMergeRebasePhase(
 		context.Background(), testIssue(), 42, "42-test", "abc123",
-		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+		cfg, testPrompts(t), nil, testLogger(t), nil, nil, &sid, &fc,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -313,7 +313,7 @@ func TestRunPreMergeRebasePhase_MultipleAttempts(t *testing.T) {
 	fc := 0
 	needsHR, err := runPreMergeRebasePhase(
 		context.Background(), testIssue(), 42, "42-test", "abc123",
-		cfg, testPrompts(t), nil, testLogger(t), nil, &sid, &fc,
+		cfg, testPrompts(t), nil, testLogger(t), nil, nil, &sid, &fc,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/implement_test.go
+++ b/internal/cmd/implement_test.go
@@ -40,6 +40,7 @@ func (r *stubProgressReporter) WaveStarted(_ int, _ int)                        
 func (r *stubProgressReporter) AllBlocked(_ int, _ int)                                      {}
 func (r *stubProgressReporter) RollupCreated(_ int, _ string, _ bool)                        {}
 func (r *stubProgressReporter) RunFinished(_ int, _ int, _ int, _ int, _ int)                {}
+func (r *stubProgressReporter) JudgeIntervention(_ int, _, _, _, _ string)                   {}
 func (r *stubProgressReporter) PunchlistText(_ string)                                       {}
 
 // stubNotifier records sent events and optionally returns an error.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -97,6 +97,7 @@ func (r *fakeReporter) RollupCreated(prNumber int, prURL string, merged bool) {
 func (r *fakeReporter) RunFinished(implemented, readyToMerge, needsHumanReview, failed, blocked int) {
 	r.runFinished = append(r.runFinished, fakeRunFinished{implemented, readyToMerge, needsHumanReview, failed, blocked})
 }
+func (r *fakeReporter) JudgeIntervention(_ int, _, _, _, _ string) {}
 func (r *fakeReporter) PunchlistText(text string) {
 	r.punchlistTexts = append(r.punchlistTexts, text)
 }

--- a/internal/progress/reporter.go
+++ b/internal/progress/reporter.go
@@ -26,6 +26,8 @@ type ProgressReporter interface {
 	RollupCreated(prNumber int, prURL string, merged bool)
 	// RunFinished signals the final summary.
 	RunFinished(implemented, readyToMerge, needsHumanReview, failed, blocked int)
+	// JudgeIntervention signals that the judge intervened during an agent step.
+	JudgeIntervention(issueNumber int, rule, judgment, detail, step string)
 	// PunchlistText outputs a punchlist fragment as it becomes available.
 	PunchlistText(text string)
 }

--- a/internal/progress/text.go
+++ b/internal/progress/text.go
@@ -77,6 +77,11 @@ func (r *TextReporter) RunFinished(implemented, readyToMerge, needsHumanReview, 
 		implemented, readyToMerge, needsHumanReview, failed, blocked)
 }
 
+// JudgeIntervention writes a judge intervention line.
+func (r *TextReporter) JudgeIntervention(issueNumber int, rule, judgment, detail, step string) {
+	fmt.Fprintf(r.w, "  #%d — judge %s: %s (%s) [%s]\n", issueNumber, judgment, rule, detail, step)
+}
+
 // PunchlistText writes a punchlist fragment directly.
 func (r *TextReporter) PunchlistText(text string) {
 	fmt.Fprint(r.w, text)

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -68,6 +68,15 @@ type RollupCreatedMsg struct {
 // spinner running to indicate active polling.
 type WatchingMsg struct{}
 
+// JudgeInterventionMsg is sent when the judge intervenes during an agent step.
+type JudgeInterventionMsg struct {
+	IssueNumber int
+	Rule        string
+	Judgment    string
+	Detail      string
+	Step        string
+}
+
 // RunDoneMsg is sent when the orchestrator goroutine finishes. The TUI stays
 // on screen so the user can review results; pressing q/esc/ctrl+c exits.
 type RunDoneMsg struct{}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -93,6 +93,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.issues[idx].stage = msg.Stage
 		}
 
+	case JudgeInterventionMsg:
+		if idx, ok := m.issueIndex[msg.IssueNumber]; ok {
+			reason := strings.ToTitle(msg.Judgment) + ": " + msg.Rule
+			if msg.Step != "" {
+				reason += " (" + msg.Step + ")"
+			}
+			m.issues[idx].judgeReason = reason
+		}
+
 	case IssueCompletedMsg:
 		m.handleIssueCompleted(msg)
 

--- a/internal/tui/reporter.go
+++ b/internal/tui/reporter.go
@@ -92,6 +92,17 @@ func (r *TUIReporter) RunFinished(implemented, readyToMerge, needsHumanReview, f
 	})
 }
 
+// JudgeIntervention sends JudgeInterventionMsg when the judge intervenes.
+func (r *TUIReporter) JudgeIntervention(issueNumber int, rule, judgment, detail, step string) {
+	r.p.Send(JudgeInterventionMsg{
+		IssueNumber: issueNumber,
+		Rule:        rule,
+		Judgment:    judgment,
+		Detail:      detail,
+		Step:        step,
+	})
+}
+
 // PunchlistText is a no-op in TUI mode. The punchlist is written to a file;
 // the TUI does not display it inline.
 func (r *TUIReporter) PunchlistText(text string) {}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -95,6 +95,12 @@ var (
 				Bold(true).
 				Padding(0, 1)
 
+	badgeJudgeStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "#FFFDF5", Dark: "#1A1A1A"}).
+			Background(lipgloss.AdaptiveColor{Light: "#D4760A", Dark: "#FF8C00"}).
+			Bold(true).
+			Padding(0, 1)
+
 	// dividerStyle styles the horizontal rule between table and summary.
 	dividerStyle = lipgloss.NewStyle().
 			Foreground(colorMuted)

--- a/internal/tui/table.go
+++ b/internal/tui/table.go
@@ -10,13 +10,14 @@ import (
 
 // issueRow holds all display state for a single issue in the table.
 type issueRow struct {
-	number   int
-	title    string
-	status   string
-	stage    string
-	prNumber int
-	retries  int
-	errMsg   string
+	number      int
+	title       string
+	status      string
+	stage       string
+	prNumber    int
+	retries     int
+	errMsg      string
+	judgeReason string // e.g. "Killed: idle 300s" — set by JudgeInterventionMsg
 }
 
 // Status marker constants.
@@ -25,6 +26,7 @@ const (
 	markerCompleted = "■"
 	markerReview    = "●"
 	markerFailed    = "✕"
+	markerJudge     = "⚖"
 )
 
 // Lipgloss styles for status markers.
@@ -33,6 +35,7 @@ var (
 	markerCompletedStyle = lipgloss.NewStyle().Foreground(colorGreen)
 	markerReviewStyle    = lipgloss.NewStyle().Foreground(colorYellow)
 	markerFailedStyle    = lipgloss.NewStyle().Foreground(colorRed)
+	markerJudgeStyle     = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#D4760A", Dark: "#FF8C00"})
 	rowNumberStyle       = lipgloss.NewStyle().Foreground(colorMuted)
 	rowTitleStyle = lipgloss.NewStyle().Foreground(colorBright)
 	rowErrStyle   = lipgloss.NewStyle().Foreground(colorRed)
@@ -88,7 +91,9 @@ func renderRow(row issueRow, spin spinner.Model, width int) string {
 
 	line := left + strings.Repeat(" ", gap) + badge
 
-	if row.errMsg != "" {
+	if row.judgeReason != "" {
+		line += " " + markerJudgeStyle.Render(row.judgeReason)
+	} else if row.errMsg != "" {
 		line += " " + rowErrStyle.Render(row.errMsg)
 	}
 
@@ -112,6 +117,9 @@ func badgeFor(row issueRow) string {
 	case "ready-to-merge", "needs-human-review":
 		return badgeReviewStyle.Render("REVIEW")
 	case "failed":
+		if row.judgeReason != "" {
+			return badgeJudgeStyle.Render("JUDGE")
+		}
 		return badgeFailedStyle.Render("FAILED")
 	default:
 		if row.stage != "" {
@@ -137,6 +145,9 @@ func markerFor(row issueRow, spin spinner.Model) string {
 	case "ready-to-merge", "needs-human-review":
 		return markerReviewStyle.Render(markerReview)
 	case "failed":
+		if row.judgeReason != "" {
+			return markerJudgeStyle.Render(markerJudge)
+		}
 		return markerFailedStyle.Render(markerFailed)
 	default:
 		// No terminal status: distinguish in-progress (stage set) from queued.


### PR DESCRIPTION
Closes #648

## Summary
- `JudgeInterventionMsg` in TUI with distinct orange JUDGE badge and scale marker
- `JudgeIntervention` method on `ProgressReporter` interface, implemented in TUI and text reporters
- Wired into `handleJudgeIntervention` in the agent loop
- All mock/stub reporters updated across agent, orchestrator, and cmd tests

## Test plan
- [x] Full test suite passes (37 packages)
- [x] Lint clean
- [x] TUI and progress packages compile and test