### PR TITLE
fix: set GOBIN for Go runtime so go install binaries are in PATH

### DIFF
--- a/internal/sandbox/dockerfile.go
+++ b/internal/sandbox/dockerfile.go
@@ -52,6 +52,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     curl -fsSL https://go.dev/dl/go{{.RuntimeVersion}}.linux-${ARCH}.tar.gz \
       | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
+ENV GOBIN=/usr/local/bin
 {{else if eq .RuntimeName "flutter"}}
 # Install Flutter SDK
 RUN apt-get update && apt-get install -y --no-install-recommends unzip xz-utils \

--- a/internal/sandbox/dockerfile_test.go
+++ b/internal/sandbox/dockerfile_test.go
@@ -888,3 +888,31 @@ func TestGenerateDockerfileClaudeCLIInstalled(t *testing.T) {
 	}
 }
 
+func TestGenerateDockerfileGoRuntimeSetsGOBIN(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.Runtime = config.Runtime{Name: "go", Version: "1.26.0"}
+
+	df, err := GenerateDockerfile(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(df, "ENV GOBIN=/usr/local/bin") {
+		t.Error("Dockerfile missing GOBIN env for go runtime")
+	}
+}
+
+func TestGenerateDockerfileNonGoRuntimeOmitsGOBIN(t *testing.T) {
+	cfg := DefaultDockerConfig()
+	cfg.Runtime = config.Runtime{Name: "node", Version: "20"}
+
+	df, err := GenerateDockerfile(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(df, "GOBIN") {
+		t.Error("Dockerfile should not contain GOBIN for non-Go runtime")
+	}
+}
+


### PR DESCRIPTION
## Summary

- Add `ENV GOBIN=/usr/local/bin` to the Go runtime block in the Dockerfile template so `go install` binaries land in a directory already on PATH and accessible to the non-root `devloop` user
- Add positive test (Go runtime includes GOBIN) and negative test (non-Go runtime omits GOBIN)

Closes #742

## Implementation Notes

### Approach
Single `ENV GOBIN=/usr/local/bin` line added inside the `{{if eq .RuntimeName "go"}}` block in the Dockerfile template, immediately after the existing `ENV PATH` directive. This makes `go install` place binaries in `/usr/local/bin` instead of `/root/go/bin/`.

### Key Decisions
- Used `GOBIN` rather than adding `/root/go/bin` to PATH — avoids exposing root-owned directories to the non-root user and is cleaner than chown workarounds.
- Scoped inside the Go runtime conditional — other runtimes (node, python, etc.) are unaffected.
- Hardcoded in template, not user-configurable — this is an implementation detail of Go install behavior, not a user-facing setting.

### Known Limitations
None. The fix is minimal and fully addresses the issue.

### Architecture
Only the **infrastructure** layer (`internal/sandbox/`) was touched. No cross-layer dependencies added or modified.

## Test plan
- [x] `TestGenerateDockerfileGoRuntimeSetsGOBIN` — asserts `ENV GOBIN=/usr/local/bin` appears in generated Dockerfile for Go runtime
- [x] `TestGenerateDockerfileNonGoRuntimeOmitsGOBIN` — asserts GOBIN does not appear for node runtime
- [x] Full `./internal/sandbox/` test suite passes (39/39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)