### PR TITLE
feat: transcript capture and harness/prompt hashing for meta-agent groundwork

### DIFF
--- a/docs/planning/phase-37-benchmarking-framework.md
+++ b/docs/planning/phase-37-benchmarking-framework.md
@@ -3,6 +3,11 @@
 > **Goal:** A repeatable, automated way to measure godark's speed, token
 > efficiency, and output quality across versions — using a Go REST API benchmark
 > repo with a hidden test suite, frozen issue snapshots, and a scoring pipeline.
+>
+> **Companion:** `docs/planning/phase-37-metric-gaming-pre-mortem.md`
+> enumerates how a meta-agent editing godark's prompts could game the score
+> and lists the tripwires, hard constraints, and holdouts that the issues
+> below implement.
 
 ## Milestone
 
@@ -175,21 +180,44 @@ and rewrites `Blocked by` references to point to the new issue numbers.
 
 Add a `godark bench compare` command that queries `stats.db` to compare metrics
 across runs. Given two or more run IDs (or a repo + milestone filter), produce a
-tabular report showing per-step cost, duration, and model, plus totals.
+tabular report showing per-step cost, duration, and model, plus totals,
+secondary metrics, and tripwire flags.
 
 This is the primary tool for evaluating whether a godark change improved
-performance. Output should be terminal-friendly (aligned columns) with an
-optional `--json` flag for programmatic consumption.
+performance. The metric-gaming pre-mortem
+(`docs/planning/phase-37-metric-gaming-pre-mortem.md`) establishes that raw
+score deltas are not sufficient — a run that improved score while doubling
+cost or tripping reviewer approval rate is not a clean win. `bench compare`
+must surface tripwires prominently so improvement claims can be evaluated
+against the full picture.
+
+Output should be terminal-friendly (aligned columns) with an optional `--json`
+flag for programmatic consumption.
 
 ### Key constraints
 
 - New command in `internal/cmd/bench.go` (parent `bench` command with
   `snapshot`, `restore`, `compare` subcommands)
 - Query logic in `internal/stats/query.go` — add functions to fetch step results
-  by run ID and aggregate totals
+  by run ID and aggregate totals, plus aggregate functions for secondary metrics
+  below
 - Report formatting in `internal/report/` or inline in the command
-- Comparison table columns: step name, model, cost (USD), duration (s), and
-  delta (%) between runs
+- Primary comparison table columns: step name, model, cost (USD), duration (s),
+  and delta (%) between runs
+- **Secondary metrics section** displays per run and per delta:
+  - Cost per merged issue (USD / implemented count)
+  - Reviewer approval rate (APPROVED verdicts / all review verdicts)
+  - Retry rate (retry steps / issue count)
+  - Flag rate (total reviewer flags / review count)
+  - Model mix (fraction of steps per model tier)
+- **Tripwires section** evaluates against a baseline run and displays PASS/FAIL
+  for each:
+  - Cost cap: mean cost per merged issue within 2x of baseline
+  - Approval ceiling: reviewer approval rate ≤ 95%
+  - Model mix pin: model mix matches baseline (no silent downgrades)
+- Tripwire thresholds are configurable via flags; defaults documented inline
+- Runs that trip any tripwire display a visible warning in the terminal output
+  and a `tripwires_failed` array in the `--json` output
 - Support comparing 2+ runs side-by-side
 - `--json` flag outputs structured JSON instead of table
 
@@ -198,7 +226,12 @@ optional `--json` flag for programmatic consumption.
 - [ ] `godark bench compare <run-id-1> <run-id-2>` produces a tabular comparison
 - [ ] Table shows per-step cost, duration, and model for each run
 - [ ] Delta column shows percentage change between runs
-- [ ] `--json` flag outputs machine-readable JSON
+- [ ] Secondary metrics section shows cost-per-merge, approval rate, retry rate,
+      flag rate, model mix for each run
+- [ ] Tripwires section evaluates cost cap, approval ceiling, and model mix pin
+      and marks runs that fail them
+- [ ] `--json` flag outputs machine-readable JSON including `secondary_metrics`
+      and `tripwires_failed` arrays
 - [ ] Graceful error when run IDs don't exist in stats.db
 
 ### Test cases
@@ -207,9 +240,17 @@ optional `--json` flag for programmatic consumption.
   table shows correct deltas
 - **Model difference highlighted**: Two runs where recon uses different models;
   verify both models appear in output
+- **Cost cap tripwire**: Construct a run with cost per merge > 2x baseline;
+  verify the cost tripwire fires and is listed in `tripwires_failed`
+- **Approval ceiling tripwire**: Construct a run with 100% reviewer approval
+  rate; verify the approval tripwire fires
+- **Model mix tripwire**: Construct a run whose model mix differs from baseline;
+  verify the mix tripwire fires
+- **Clean comparison**: Two runs with similar costs and normal approval rates;
+  verify no tripwires fire
 - **Missing run**: Compare with a nonexistent run ID; verify error message
 - **JSON output**: Compare two runs with `--json`; verify valid JSON with
-  expected structure
+  `secondary_metrics` and `tripwires_failed` fields
 
 ---
 
@@ -317,6 +358,15 @@ This lives in `eval/` in the benchmark repo and is excluded from the sandbox via
 `sandbox.exclude`. After a benchmark run, the eval harness starts the built API
 server and runs HTTP tests against it.
 
+The metric-gaming pre-mortem
+(`docs/planning/phase-37-metric-gaming-pre-mortem.md`, vector #1) flags
+hidden-test-name leakage as the sharpest gaming vector: if named failures
+like `TestAuthorDelete_BlockedByBooks` flow into any artifact that a
+meta-agent reads when optimizing prompts, the meta-agent can reverse-engineer
+the hidden suite over many iterations. The scoring harness must keep raw
+test names confined to the human-facing JSON report and never write them to
+`stats.db` or any per-run artifact in `~/.godark/runs/`.
+
 ### Key constraints
 
 - Test runner: Go test binary in `eval/tests/` using standard `testing` +
@@ -332,8 +382,10 @@ server and runs HTTP tests against it.
   - Start the server on a random port
   - Run the test suite against it
   - Collect: total tests, passed, failed, build success/failure, lint results
-  - Output a JSON score report
-- Score report format:
+  - Output a JSON score report with raw names (human-facing only)
+  - Output a secondary JSON record with hashed failure codes for ingestion
+    into `stats.db` — raw test names never leave the `eval/` directory
+- Score report format (human-facing, written to `eval/reports/`):
   ```json
   {
     "build_ok": true,
@@ -345,14 +397,35 @@ server and runs HTTP tests against it.
     "failures": ["TestAuthorDelete_BlockedByBooks", ...]
   }
   ```
+- Redacted record (ingestion format, written to the run directory):
+  ```json
+  {
+    "build_ok": true,
+    "lint_ok": true,
+    "total_tests": 25,
+    "passed": 22,
+    "failed": 3,
+    "score": 0.88,
+    "failure_hashes": ["a1b2c3d4", "e5f6a7b8", ...]
+  }
+  ```
+- Failure hashes are 8-character SHA256 prefixes of the test name. Stable
+  per binary, not reversible in practice, sufficient for counting and
+  correlation.
+- Test names must not appear in any `~/.godark/runs/<run>/` artifact,
+  `stats.db` row, dashboard output, or container stdout that the agent
+  could read.
 
 ### Acceptance criteria
 
 - [ ] Test suite covers all five feature areas from the spec
-- [ ] Scoring harness builds the server, runs tests, and produces a JSON report
+- [ ] Scoring harness builds the server, runs tests, and produces both the
+      human-facing JSON report and the redacted ingestion record
 - [ ] Tests are independent (no ordering dependency between test cases)
 - [ ] Score is a simple pass ratio: `passed / total`
 - [ ] Build or lint failure is captured in the report (not a crash)
+- [ ] Grep for raw test names in a sample run's artifacts produces zero hits
+      outside `eval/reports/`
 
 ### Test cases
 
@@ -364,6 +437,140 @@ server and runs HTTP tests against it.
   `build_ok: false` in report
 - **Server start failure**: Run eval against code that builds but crashes on
   start; verify graceful failure in report
+- **Name redaction**: After a run, grep `~/.godark/runs/` for a known test
+  name from the suite; verify zero matches
+- **Hash stability**: Hash the same failing test twice; verify identical
+  8-char prefix
+
+---
+
+## Issue 786: Add held-out secondary test suite for generalization check
+
+### Description
+
+Build a second, disjoint test suite in the benchmark repo that is run by the
+scoring harness but whose failure information is never surfaced in any form
+— no names, no hashes, no counts per test. Only a single aggregate pass
+ratio is emitted.
+
+The metric-gaming pre-mortem
+(`docs/planning/phase-37-metric-gaming-pre-mortem.md`, vector #1 and the
+holdout scenarios section) establishes that the primary suite, even with
+name redaction, still provides signal per-test (via failure hashes) that a
+meta-agent can correlate over many runs. A held-out secondary suite whose
+results are emitted only as a single number closes that channel and makes
+overfitting detectable: if the primary score climbs but the secondary score
+stagnates or drops, the meta-agent has learned shortcuts specific to the
+primary suite rather than the underlying capability.
+
+### Key constraints
+
+- Second suite lives at `eval/holdout/` in the benchmark repo, excluded from
+  the sandbox alongside the primary `eval/` via `sandbox.exclude`
+- Tests cover the same five feature areas from the spec but with different
+  fixtures, edge cases, and assertion phrasing — not a copy
+- Scoring harness runs both suites in sequence
+- Score report gains one new field: `holdout_score` (float, 0 to 1)
+- No per-test information for holdout appears anywhere — no `holdout_failures`
+  array, no `holdout_failure_hashes`, no counts. A run either has a
+  `holdout_score` of 0.72 or doesn't; the meta-agent cannot tell which
+  specific tests failed
+- `bench compare` (Issue 781) treats `holdout_score` as a secondary metric
+  and shows divergence from primary as a diagnostic
+
+### Acceptance criteria
+
+- [ ] `eval/holdout/` exists with a second test suite covering the five
+      feature areas
+- [ ] Scoring harness runs both suites and emits `holdout_score` in both
+      the human-facing and ingestion records
+- [ ] Holdout suite contains at least 15 tests (enough to be statistically
+      meaningful, not so many that flakes dominate)
+- [ ] No per-test details for the holdout suite appear in any artifact
+- [ ] `bench compare` displays `holdout_score` alongside primary score and
+      flags divergence (primary improved by > 5%, holdout did not)
+
+### Test cases
+
+- **Both suites run**: Run against the golden implementation; verify both
+  `score` and `holdout_score` are present and near 1.0
+- **Holdout opacity**: After a run, grep the run directory and `stats.db`
+  for any holdout test name; verify zero matches
+- **Divergence detected**: Construct two runs where primary score diverges
+  from holdout; verify `bench compare` flags the divergence
+
+---
+
+## Issue 787: Add `godark bench audit` command with known-bad reviewer fixture
+
+### Description
+
+Build a `godark bench audit` subcommand that verifies the current reviewer
+prompts still catch intentionally-bad implementations. It runs one or more
+hand-crafted bad implementations past the quality and functional reviewers
+in isolation and asserts each reviewer returns `CHANGES_REQUESTED`.
+
+The metric-gaming pre-mortem
+(`docs/planning/phase-37-metric-gaming-pre-mortem.md`, vector #2)
+establishes reviewer rubber-stamping as the most insidious gaming vector:
+a meta-agent that rewrites reviewer prompts to approve everything will
+trip the approval-rate tripwire only if real task agents are producing
+genuinely-bad output at scale. A direct audit against a known-bad fixture
+catches the regression immediately, not two benchmark runs later.
+
+This is a harness-validation tool, not part of the normal benchmark run.
+
+### Key constraints
+
+- New `audit` subcommand under `bench` in `internal/cmd/bench.go`
+- Fixtures live at `eval/audit/fixtures/` in the benchmark repo — each
+  fixture is a directory containing:
+  - A flawed implementation (e.g. auth middleware that accepts any API key,
+    a DELETE endpoint that ignores ownership, a pagination bug that returns
+    all rows)
+  - A `fixture.json` describing the flaw and the expected reviewer verdict
+    (always `CHANGES_REQUESTED`), plus the expected flag codes
+- Audit runs each fixture through the quality reviewer and the functional
+  reviewer independently (not the full pipeline)
+- Agent invocation reuses `internal/agent/` runner with the reviewer prompt
+  but skips the implementer, tests, and merge-coordinator steps entirely
+- Exit code 0 if every reviewer bounced every fixture; non-zero otherwise
+- `--json` flag outputs structured audit results
+- Audit result format:
+  ```json
+  {
+    "passed": true,
+    "fixtures": [
+      {
+        "name": "auth-accepts-any-key",
+        "quality_verdict": "CHANGES_REQUESTED",
+        "functional_verdict": "CHANGES_REQUESTED",
+        "expected": "CHANGES_REQUESTED",
+        "pass": true
+      }
+    ]
+  }
+  ```
+- Intended to run before declaring any new harness a winner. Not scheduled
+  automatically; an operator runs it.
+
+### Acceptance criteria
+
+- [ ] `godark bench audit` runs one or more audit fixtures through the
+      quality and functional reviewers
+- [ ] Exit code 0 iff every reviewer bounced every fixture
+- [ ] At least three audit fixtures exist in `eval/audit/fixtures/`
+- [ ] `--json` flag produces machine-readable output
+- [ ] Fixtures run in isolation without touching GitHub or a real repo
+
+### Test cases
+
+- **All fixtures bounce**: Run audit with current reviewers; verify exit 0
+- **Rubber-stamp reviewer fails audit**: Manually override the reviewer
+  prompt to "always approve"; verify audit exits non-zero with clear
+  messaging about which fixture was missed
+- **JSON output**: Run audit with `--json`; verify schema matches the
+  documented format
 
 ---
 
@@ -373,7 +580,9 @@ server and runs HTTP tests against it.
 config and sandbox directory exclusion, Build issue snapshot export and import
 tooling, Add benchmark comparison report command, Create benchmark Go REST API
 repo with starter scaffolding, Write feature spec for benchmark API, Build
-hidden eval test suite and scoring harness
+hidden eval test suite and scoring harness, Add held-out secondary test suite
+for generalization check, Add `godark bench audit` command with known-bad
+reviewer fixture
 
 ### Description
 
@@ -385,8 +594,10 @@ Steps:
 1. Run godark skill pipeline against the feature spec to produce issues
 2. Snapshot the issues as `v0.23.0-baseline.json`
 3. Run `godark run` against the benchmark repo
-4. Run the eval harness against the output
-5. Record metrics (cost, duration, score) and note the baseline
+4. Run the eval harness against the output (primary + holdout suites)
+5. Run `godark bench audit` to validate reviewers still bounce bad fixtures
+6. Record metrics (cost, duration, score, holdout score, secondary metrics)
+   and note the baseline
 
 This is a manual/operational task, not a code issue. It validates the framework.
 
@@ -396,6 +607,10 @@ This is a manual/operational task, not a code issue. It validates the framework.
 - Run the full skill pipeline: `create-milestone` → `create-planning-doc` →
   `create-issues` → `create-scenarios`
 - Snapshot the generated issues before running
+- Baseline documents the numbers that future runs' tripwires measure against:
+  - Cost per merged issue (seeds the 2x cost cap)
+  - Reviewer approval rate (seeds the 95% ceiling)
+  - Model mix (seeds the model-pin tripwire)
 - Document the baseline results somewhere accessible (benchmark repo README or
   a results file)
 
@@ -404,8 +619,11 @@ This is a manual/operational task, not a code issue. It validates the framework.
 - [ ] Skill pipeline runs successfully against the benchmark repo
 - [ ] Issue snapshot saved as `eval/snapshots/v0.23.0-baseline.json`
 - [ ] godark run completes (success or failure — both are valid baseline data)
-- [ ] Eval harness produces a score report
-- [ ] Baseline metrics documented: total cost, wall time, score
+- [ ] Eval harness produces a score report with `score` and `holdout_score`
+- [ ] `godark bench audit` exits 0 against v0.23.0 reviewers
+- [ ] Baseline metrics documented: total cost, wall time, primary score,
+      holdout score, cost per merged issue, reviewer approval rate, retry rate,
+      flag rate, model mix
 
 ### Test cases
 

--- a/docs/planning/phase-37-metric-gaming-pre-mortem.md
+++ b/docs/planning/phase-37-metric-gaming-pre-mortem.md
@@ -1,0 +1,157 @@
+# Phase 37: Metric-Gaming Pre-Mortem
+
+> **Purpose:** Before Phase 37 wires a scoring function into `bench compare`,
+> adversarially attack it. Any metric that graduates to "primary" must survive
+> the gaming vectors below, or be paired with a tripwire that catches them.
+>
+> **Threat model:** The adversary is a meta-agent editing prompts, skill
+> configs, and harness templates in the godark repo between runs. The task
+> agent in the sandbox is not the threat - it already runs against a hidden
+> test suite. The meta-agent is the threat because it sees the score, and
+> "the score" is whatever Phase 37 decides to emit.
+
+---
+
+## Proposed primary score
+
+Phase 37 (Issue 784) outputs:
+
+```json
+{ "build_ok": true, "lint_ok": true, "total_tests": 25, "passed": 22,
+  "failed": 3, "score": 0.88, "failures": [...] }
+```
+
+The default reading: `score = passed / total`, with `build_ok` and `lint_ok`
+as hard gates that zero the score when false. Cost, duration, and retry
+counts live in `stats.db` but are not part of the score.
+
+This is a solid anti-gaming choice *for the task agent*, because the hidden
+test suite is excluded via `sandbox.exclude`. It is not automatically safe
+for the meta-agent, because the meta-agent sees the score, the failure
+names, and the trajectory of many runs.
+
+---
+
+## Gaming vector table
+
+| # | Category | Vector | Tripwire |
+|---|----------|--------|----------|
+| 1 | Hidden-test leakage | Failure names in the report ("TestAuthorDelete_BlockedByBooks") slowly describe the test suite. Over many iterations a meta-agent can optimize prompts that target named failures specifically. | Keep a second, never-surfaced test suite. Rotate primary tests between iteration windows. Never include test names in training context. |
+| 2 | Reviewer rubber-stamping | Meta-agent rewrites the quality or functional reviewer to approve everything. Score unaffected if tests still run, but cost per merged PR explodes and real regressions reach main. | Track reviewer approval rate per harness_hash. Flag when it drifts above a ceiling (say, 95%). Inject known-bad PR fixtures and require the reviewer to bounce them. |
+| 3 | Prompt bloat | Meta-agent adds "verify twice, write tests, run linters" everywhere. Score goes up; tokens/run triples. | Hard-cap total cost per issue at 2x baseline. Runs that exceed it are excluded from score improvement claims. |
+| 4 | Model downgrade | Meta-agent rewrites `model_overrides` so every step uses the cheapest model. Score probably drops, but if cost becomes a metric later, this becomes attractive. | Pin the model mix as part of the harness hash inputs, or score every run at a fixed model config and evaluate cost separately. |
+| 5 | Issue pipeline gaming | Meta-agent edits `create-issues` / `create-scenarios` prompts to emit simpler, more unambiguous issues from the same spec. Downstream implementation is easier, score rises, but the benchmark drifted. | Separate "skill pipeline hash" from "execution harness hash." Pin generated issues to a snapshot (Phase 37 already plans this) and forbid regeneration inside iteration windows. |
+| 6 | Retry milking | If retries are cheap relative to first-try cost, meta-agent trains the implementer to produce lazy first attempts and rely on retry. Score holds, cost rises, wall time rises. | Track retry rate per harness. Cost cap (#3) also backstops this. |
+| 7 | Flag suppression | Meta-agent rewrites reviewers to stop emitting `flags` on marginal code. Downstream quality-gating logic sees a cleaner stream than reality. | Flag counts should be tracked independently and compared across harnesses. Abrupt drops are suspicious. |
+| 8 | Two-reviewer division of labor | Quality and functional reviewers were designed as independent perspectives. Meta-agent could specialize one into a compiler and the other into a rubber stamp, covering the score surface without matching intent. | Keep an independent human review sample. Track agreement rate between the two reviewers; near-zero disagreement or near-total disagreement are both red flags. |
+| 9 | Dependency graph gaming | Meta-agent edits the dependency-resolution prompt to mark everything independent, enabling parallel wave execution that happens to fit the benchmark better than the sequential intent. | Pin issue dependency graph in the snapshot; compare the actual executed order against the snapshot order. |
+| 10 | Build-ok / lint-ok pinpointing | `build_ok` and `lint_ok` as hard gates create a discontinuous reward. Meta-agent learns to prioritize "make it compile, make lint pass" over correctness once those gates are at risk. | Deliberate. This is arguably what we want. But track the ratio of "compiles-and-lints but fails many tests" vs "compiles-and-lints and passes many tests" to detect if prompts are drifting toward surface compliance. |
+| 11 | Spec-delta cheating | Phase 32's `spec-delta.json` captures scenario changes. If spec-delta is used for scoring, meta-agent could game it by rewriting scenarios in the spec rather than the code. | Spec delta is diagnostic, not scoring. Keep it that way. |
+| 12 | PR description stuffing | If any reviewer or merge coordinator reads the PR body for signal, meta-agent learns to include reassuring text there. | Reviewers should read code and tests only. Audit reviewer prompts for PR-body references. |
+
+---
+
+## Hard constraints (non-negotiable gates)
+
+Score improvements that violate these are thrown out regardless of numbers:
+
+1. **Cost cap.** Mean cost per merged issue must stay within 2x of baseline.
+   Phase 37's `bench compare` already surfaces this; it needs to become a
+   filter, not just a column.
+2. **Reviewer approval ceiling.** Reviewer approval rate across a harness
+   cannot exceed 95% without human audit of a random sample.
+3. **Model mix pin.** The active model for each step is part of what's being
+   optimized-against, not a free optimization variable. Changing `model_overrides`
+   between iterations produces a new baseline, not an improvement claim.
+4. **Snapshot lock.** Issues, dependency graph, and spec text are immutable
+   per iteration window. Only prompts, harness scaffolding, and godark code
+   are editable.
+
+---
+
+## Holdout scenarios
+
+Phase 37 plans one benchmark repo with one test suite. The pre-mortem
+recommends three additional held-out artifacts before declaring any
+score improvement credible:
+
+1. **Known-bad implementation fixture.** A hand-crafted implementation with
+   a subtle bug (e.g., auth middleware that accepts any API key). Runs the
+   reviewer in isolation and asserts `CHANGES_REQUESTED`. A reviewer that
+   passes this without flagging is compromised. Not part of the main score;
+   run on demand to audit reviewers.
+2. **Secondary test suite, never surfaced.** A disjoint set of tests in a
+   separate file, never included in failure names shown to the agent or
+   logged to `~/.godark/stats.db`. Used to verify that score improvements
+   on the primary suite generalize, not overfit to named failures.
+3. **Adversarial issue set.** A handful of issues designed to tempt the
+   specific gaming vectors above - a deliberately ambiguous spec (tests
+   #5 and #9), an issue with an intentional dependency trap (#9), an issue
+   whose best implementation requires flagging a scenario bug (#7).
+
+---
+
+## Metrics taxonomy
+
+Three tiers with different roles. Phase 37 should emit all three, but only
+one is the optimization target:
+
+**Primary (what the loop optimizes):**
+- `score = passed / total` on the primary hidden suite, subject to
+  `build_ok && lint_ok`.
+
+**Secondary (tracked per run, not optimized):**
+- Cost per merged issue (USD)
+- Reviewer approval rate (quality, functional, both)
+- Retry rate
+- Flag rate per review
+- Model mix (fraction of steps per model tier)
+
+**Tripwires (runs that hit these are excluded from improvement claims):**
+- Cost > 2x baseline
+- Reviewer approval rate > 95%
+- Model mix drifted from pinned config
+- Primary score improved but held-out secondary score did not
+
+---
+
+## Implications for Phase 37
+
+The current plan is adequate as a v1 scoring infrastructure. The pre-mortem
+surfaces the following additions that should land in Phase 37 rather than
+bolted on later:
+
+1. **Issue 781 (`bench compare`) should compute tripwire flags, not just
+   deltas.** A run that improved the primary score but tripped a cost cap
+   should be displayed differently from one that improved cleanly.
+2. **Issue 784 (eval harness) should suppress test names in any artifact
+   that could flow back to training.** The JSON score report can keep them;
+   `stats.db`, `failure-analysis.json`, and the dashboard should redact or
+   hash them.
+3. **Add a secondary, never-surfaced test suite in `eval/` that the scoring
+   harness runs but does not emit failure names for.** Used as a
+   generalization check.
+4. **Track `reviewer_approval_rate` per harness_hash in `stats.db` as part
+   of the summary**, not derived at query time. Same for cost-per-merge
+   and retry rate. These become first-class secondary metrics.
+5. **A `godark bench audit` subcommand** (not yet planned) that runs the
+   known-bad implementation fixture against the current reviewer prompts
+   and asserts bounce. Called before any new harness is declared a winner.
+
+Items 1 and 4 are small additions to existing issues. Items 2, 3, and 5
+are new issues worth adding to Phase 37's scope.
+
+---
+
+## What this document is not
+
+It is not a security analysis. The threat is a meta-agent optimizing for
+a score, not an attacker exfiltrating data. Tripwires here exist to
+preserve the *validity* of score claims, not to prevent a motivated
+adversary from cheating. A human reviewing improvement claims remains
+necessary.
+
+It is also not exhaustive. New gaming vectors will surface as soon as
+real meta-agent runs produce unexpected score jumps. This document should
+be updated when that happens - a gaming vector caught in practice is
+worth more than any number predicted on paper.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -45,4 +45,6 @@
 - [Phase 36: Structured Frontend Issue Decomposition](phase-36.md)
 - [Phase 37: Benchmarking Framework](phase-37.md)
 - [Phase 38: Security-Aware Review & Prompt Auditability](phase-38.md)
+- [Phase 39: Meta-Agent Human Mode](phase-39.md)
+- [Phase 40: Meta-Agent Autonomous Mode](phase-40.md)
 - [Future considerations](future-considerations.md)

--- a/docs/roadmap/phase-39.md
+++ b/docs/roadmap/phase-39.md
@@ -1,0 +1,21 @@
+## Phase 39: Meta-Agent Human Mode
+
+**Goal**: A `godark meta propose` command that reads trace data and emits cited
+prompt-edit proposals for humans to review and apply manually. No side effects
+beyond a proposals directory. Automates the "find the gap" half of the
+prompt-tuning workflow described in `docs/philosophy/engineering-roles.md`;
+humans still own the "adjust and commit" half.
+
+**Milestone**: `Phase 39: Meta-Agent Human Mode` | **Label**: `phase-39`
+
+**Depends on**: Phase 37 (Benchmarking Framework)
+
+- Corpus query helpers — aggregation functions over `stats.db` grouped by `harness_hash`, `prompt_hash`, `trace_id`, and outcome status
+- Transcript reader — decompress and iterate `*-transcript.jsonl.gz` artifacts from run directories
+- `godark meta` command skeleton — parent command, shared flags, `propose` subcommand stub
+- Proposal JSON schema — structured format (file path, anchor text, replacement, rationale, cited `trace_id`s and `prompt_hash`es)
+- Meta-agent prompt template — system prompt that forces citations and rejects hand-wavy proposals
+- `meta propose` implementation — invoke Claude Code with read-only corpus tools, parse output, write to `~/.godark/proposals/<timestamp>/`
+- Citation validator — verify every cited `trace_id` and `prompt_hash` resolves against `stats.db`; reject proposals with dead citations
+- Markdown report generator — human-readable report from the proposal JSON with links into `godark trace`
+- First real proposal run — evaluate output quality against existing godark traces

--- a/docs/roadmap/phase-40.md
+++ b/docs/roadmap/phase-40.md
@@ -1,0 +1,22 @@
+## Phase 40: Meta-Agent Autonomous Mode
+
+**Goal**: A `godark meta loop` command that iterates propose → apply →
+benchmark → keep-or-revert on an isolated worktree, emitting a ranked branch of
+winning experiments for human review. Rule-preserving by physical isolation, a
+write allowlist, Phase 37 tripwires, and a final human promotion gate. The
+meta-agent never commits to main; humans always own the merge step.
+
+**Milestone**: `Phase 40: Meta-Agent Autonomous Mode` | **Label**: `phase-40`
+
+**Depends on**: Phase 37 (Benchmarking Framework), Phase 39 (Meta-Agent Human Mode)
+
+- Worktree isolation helper — `git worktree` create/clean for meta-agent experiments, never touching main
+- Write allowlist enforcement — block writes outside a configured allowlist at the tool layer (inverted `ProtectedPaths`); default allowlist is `prompts/*.txt`
+- `meta apply` subcommand — apply a proposal JSON to a worktree, produce a commit
+- Experiment commit convention — structured commit trailers plus `experiment.json` sidecar per iteration
+- `meta loop` subcommand — orchestrate propose, apply, benchmark, keep-or-revert; share the propose core from Phase 39
+- Tripwire integration — consult Phase 37 `bench compare` and auto-revert experiments that trip cost cap, approval ceiling, model mix pin, or holdout-vs-primary divergence
+- Budget and iteration caps — max iterations, max cumulative cost, max wall time; loop exits gracefully at any cap
+- Audit log — per-loop structured log of every experiment (kept, reverted, tripped) for post-hoc review
+- Ranked-branch output — final worktree branch with winning experiments ordered by score delta, formatted as a reviewable PR-style summary
+- First autonomous loop run — against the Phase 37 benchmark repo; evaluate by eye before promoting anything

--- a/internal/agent/launcher.go
+++ b/internal/agent/launcher.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -450,6 +452,59 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return "..." + s[len(s)-n:]
+}
+
+// FilterTranscript parses ndjson stdout from the Claude CLI stream-json mode
+// and returns a gzipped transcript of the agent's reasoning trajectory.
+//
+// Kept: "assistant" messages (text and tool_use blocks) and "user" messages
+// (tool_result blocks). These capture the agent's decisions and the tool
+// responses it reasoned over.
+//
+// Dropped: "system" init messages, "result" final summary, rate_limit_event
+// envelopes, CLONE_SHA sentinel lines, and any non-JSON output. These are
+// orchestration noise and are already captured elsewhere (StepResult fields,
+// container-log.txt on failure).
+//
+// Returns nil if no transcript lines were found.
+func FilterTranscript(stdout string) ([]byte, error) {
+	var kept [][]byte
+	for _, line := range strings.Split(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || trimmed[0] != '{' {
+			continue
+		}
+		var peek struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(trimmed), &peek); err != nil {
+			continue
+		}
+		if peek.Type != "assistant" && peek.Type != "user" {
+			continue
+		}
+		kept = append(kept, []byte(trimmed))
+	}
+	if len(kept) == 0 {
+		return nil, nil
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	for i, line := range kept {
+		if i > 0 {
+			if _, err := gz.Write([]byte{'\n'}); err != nil {
+				return nil, fmt.Errorf("gzip write: %w", err)
+			}
+		}
+		if _, err := gz.Write(line); err != nil {
+			return nil, fmt.Errorf("gzip write: %w", err)
+		}
+	}
+	if err := gz.Close(); err != nil {
+		return nil, fmt.Errorf("gzip close: %w", err)
+	}
+	return buf.Bytes(), nil
 }
 
 // extractToolTrace scans CLI stream-json stdout for assistant messages

--- a/internal/agent/launcher_test.go
+++ b/internal/agent/launcher_test.go
@@ -1,10 +1,16 @@
 package agent
 
 import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -175,6 +181,81 @@ func TestRunSandboxOnce_UsageLimitedFallback(t *testing.T) {
 	}
 	if !res.ResetsAt.IsZero() {
 		t.Errorf("expected ResetsAt to be zero for fallback, got %v", res.ResetsAt)
+	}
+}
+
+func TestFilterTranscript_KeepsAssistantAndUserEvents(t *testing.T) {
+	stdout := strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"s1"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"thinking"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/foo.go"}}]}}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result","content":"file contents"}]}}`,
+		`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed"}}`,
+		`CLONE_SHA=deadbeef`,
+		`{"type":"result","session_id":"s1","result":"done"}`,
+		``,
+	}, "\n")
+
+	compressed, err := FilterTranscript(stdout)
+	if err != nil {
+		t.Fatalf("FilterTranscript() error: %v", err)
+	}
+	if len(compressed) == 0 {
+		t.Fatal("expected non-empty transcript")
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		t.Fatalf("gzip.NewReader() error: %v", err)
+	}
+	defer gz.Close()
+	decompressed, err := io.ReadAll(gz)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error: %v", err)
+	}
+
+	var gotTypes []string
+	scanner := bufio.NewScanner(bytes.NewReader(decompressed))
+	for scanner.Scan() {
+		var peek struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &peek); err != nil {
+			t.Fatalf("each kept line must be valid JSON, got %q: %v", scanner.Text(), err)
+		}
+		gotTypes = append(gotTypes, peek.Type)
+	}
+
+	wantTypes := []string{"assistant", "assistant", "user"}
+	if len(gotTypes) != len(wantTypes) {
+		t.Fatalf("kept %d lines, want %d: %v", len(gotTypes), len(wantTypes), gotTypes)
+	}
+	for i, want := range wantTypes {
+		if gotTypes[i] != want {
+			t.Errorf("line %d type = %q, want %q", i, gotTypes[i], want)
+		}
+	}
+}
+
+func TestFilterTranscript_EmptyStdoutReturnsNil(t *testing.T) {
+	got, err := FilterTranscript("")
+	if err != nil {
+		t.Fatalf("FilterTranscript() error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for empty stdout, got %d bytes", len(got))
+	}
+}
+
+func TestFilterTranscript_NoRelevantEventsReturnsNil(t *testing.T) {
+	stdout := `{"type":"system","subtype":"init"}` + "\n" +
+		`{"type":"result","session_id":"s1","result":"done"}`
+	got, err := FilterTranscript(stdout)
+	if err != nil {
+		t.Fatalf("FilterTranscript() error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil when only system/result events present, got %d bytes", len(got))
 	}
 }
 

--- a/internal/agent/rundata.go
+++ b/internal/agent/rundata.go
@@ -1,6 +1,9 @@
 package agent
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+
 	"github.com/peter-stratton/dark-factory/internal/quality"
 	"github.com/peter-stratton/dark-factory/internal/rundata"
 )
@@ -28,6 +31,13 @@ func ResultToStep(r *Result) rundata.StepResult {
 	}
 	if step.StartedAt != nil && step.FinishedAt != nil {
 		step.DurationSeconds = r.FinishedAt.Sub(r.StartedAt).Seconds()
+	}
+	if transcript, err := FilterTranscript(r.Stdout); err == nil {
+		step.Transcript = transcript
+	}
+	if r.Prompt != "" {
+		sum := sha256.Sum256([]byte(r.Prompt))
+		step.PromptHash = hex.EncodeToString(sum[:])
 	}
 	return step
 }

--- a/internal/agent/rundata_test.go
+++ b/internal/agent/rundata_test.go
@@ -104,6 +104,66 @@ func TestResultToStep_EmptyPrompt(t *testing.T) {
 	}
 }
 
+func TestResultToStep_PromptHashPopulatedFromPrompt(t *testing.T) {
+	r := &Result{
+		ResultText: "done",
+		Prompt:     "You are an implementer agent.",
+	}
+
+	step := ResultToStep(r)
+
+	if len(step.PromptHash) != 64 {
+		t.Fatalf("PromptHash length = %d, want 64 hex chars", len(step.PromptHash))
+	}
+	step2 := ResultToStep(r)
+	if step2.PromptHash != step.PromptHash {
+		t.Errorf("PromptHash not deterministic: %q vs %q", step.PromptHash, step2.PromptHash)
+	}
+	r.Prompt = "You are a reviewer agent."
+	step3 := ResultToStep(r)
+	if step3.PromptHash == step.PromptHash {
+		t.Errorf("PromptHash did not change when prompt changed")
+	}
+}
+
+func TestResultToStep_EmptyPromptProducesEmptyHash(t *testing.T) {
+	r := &Result{ResultText: "done"}
+
+	step := ResultToStep(r)
+
+	if step.PromptHash != "" {
+		t.Errorf("PromptHash = %q, want empty when Prompt is empty", step.PromptHash)
+	}
+}
+
+func TestResultToStep_PopulatesTranscriptFromStdout(t *testing.T) {
+	r := &Result{
+		ResultText: "done",
+		Stdout: `{"type":"system","subtype":"init"}` + "\n" +
+			`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n" +
+			`{"type":"result","session_id":"s","result":"done"}`,
+	}
+
+	step := ResultToStep(r)
+
+	if len(step.Transcript) == 0 {
+		t.Fatal("expected Transcript to be populated from Stdout")
+	}
+}
+
+func TestResultToStep_NilTranscriptWhenStdoutHasNoRelevantEvents(t *testing.T) {
+	r := &Result{
+		ResultText: "done",
+		Stdout:     `{"type":"result","session_id":"s","result":"done"}`,
+	}
+
+	step := ResultToStep(r)
+
+	if step.Transcript != nil {
+		t.Errorf("Transcript = %v, want nil when Stdout has only result/system events", step.Transcript)
+	}
+}
+
 func TestResultToStep_DurationSeconds_Positive(t *testing.T) {
 	started := time.Now()
 	finished := started.Add(5 * time.Second)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1412,18 +1412,7 @@ func resolveRollupConflicts(ctx context.Context, cfg *config.Config, runMode con
 		}
 
 		if writer != nil {
-			step := rundata.StepResult{
-				Output:          result.ResultText,
-				TimedOut:        result.TimedOut,
-				StartedAt:       &result.StartedAt,
-				FinishedAt:      &result.FinishedAt,
-				DurationSeconds: result.FinishedAt.Sub(result.StartedAt).Seconds(),
-				CostUSD:         result.CostUSD,
-				ToolTrace:       result.ToolTrace,
-				SessionID:       result.SessionID,
-				PeakMemoryBytes: result.PeakMemoryBytes,
-				CPUNanoseconds:  result.CPUNanoseconds,
-			}
+			step := agent.ResultToStep(result)
 			if wErr := writer.WriteRollupMergeCoordinatorResult(attempt, step); wErr != nil {
 				logger.Warn("failed to write rollup merge coordinator result",
 					"attempt", attempt, "error", wErr)

--- a/internal/orchestrator/statswriter.go
+++ b/internal/orchestrator/statswriter.go
@@ -150,6 +150,7 @@ func buildRunRecord(runID, repo string, detail *rundata.RunDetail, summary runda
 		Implemented:      summary.Implemented,
 		Failed:           summary.Failed,
 		AbortReason:      summary.AbortReason,
+		HarnessHash:      detail.HarnessHash,
 	}
 }
 
@@ -222,5 +223,7 @@ func stepToRecord(runID string, issueNumber int, stepName string, step rundata.S
 		PeakMemoryBytes: step.PeakMemoryBytes,
 		CPUNanoseconds:  step.CPUNanoseconds,
 		TraceID:         step.TraceID,
+		Prompt:          step.Prompt,
+		PromptHash:      step.PromptHash,
 	}
 }

--- a/internal/rundata/writer.go
+++ b/internal/rundata/writer.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/peter-stratton/dark-factory/prompts"
 )
 
 // AutoMerge holds the auto-merge strategy settings recorded at run start.
@@ -32,6 +34,10 @@ type RunMeta struct {
 	IssueDeps          []IssueDep        `json:"issue_deps,omitempty"`
 	IssueTitles        map[string]string `json:"issue_titles,omitempty"`
 	GodarkVersion      string            `json:"godark_version,omitempty"`
+	// HarnessHash identifies the prompt bundle embedded in the godark binary
+	// that produced this run. A meta-agent can use it to distinguish runs that
+	// share a godark version but differ in prompt edits.
+	HarnessHash        string            `json:"harness_hash,omitempty"`
 	StartedAt          time.Time         `json:"started_at"`
 	FinishedAt         *time.Time        `json:"finished_at,omitempty"`
 	Summary            *RunSummary       `json:"summary,omitempty"`
@@ -82,6 +88,14 @@ type StepResult struct {
 	CPUNanoseconds   int64      `json:"cpu_nanoseconds,omitempty"`
 	TraceID          string     `json:"trace_id,omitempty"`
 	Prompt           string     `json:"prompt,omitempty"`
+	// PromptHash is a SHA256 hex digest of the rendered prompt sent to the
+	// agent. Lets a meta-agent correlate step outcomes with specific prompt
+	// versions without rereading the full Prompt text.
+	PromptHash       string     `json:"prompt_hash,omitempty"`
+	// Transcript holds the gzipped filtered ndjson stream of assistant and
+	// tool-result events from the agent's run. Persisted as a sibling
+	// <step>-transcript.jsonl.gz file, not serialized into the step JSON.
+	Transcript       []byte     `json:"-"`
 }
 
 // OutcomeStatus constants mirror the agent.OutcomeStatus values for use in
@@ -162,6 +176,7 @@ func NewWithBase(baseDir, repo, milestone string, issueNumbers []int, baseBranch
 		AutoMerge:     autoMergePtr,
 		IssueNumbers:  issueNumbers,
 		GodarkVersion: version,
+		HarnessHash:   prompts.Hash(),
 		StartedAt:     now,
 	}
 	if err := writeJSON(filepath.Join(dir, "run.json"), meta); err != nil {
@@ -239,35 +254,35 @@ func (w *Writer) issueRetryDir(issueNum, retryNum int) string {
 // Path: issues/<issueNum>/recon.json
 func (w *Writer) WriteReconResult(issueNum int, step StepResult) error {
 	path := filepath.Join(w.issueDir(issueNum), "recon.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WritePlannerResult writes the planner step result for the given issue.
 // Path: issues/<issueNum>/planner.json
 func (w *Writer) WritePlannerResult(issueNum int, step StepResult) error {
 	path := filepath.Join(w.issueDir(issueNum), "planner.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WriteSpecGeneratorResult writes the spec generator step result for the given issue.
 // Path: issues/<issueNum>/spec-generator.json
 func (w *Writer) WriteSpecGeneratorResult(issueNum int, step StepResult) error {
 	path := filepath.Join(w.issueDir(issueNum), "spec-generator.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WriteImplementResult writes the implement step result for the given issue.
 // Path: issues/<issueNum>/implement.json
 func (w *Writer) WriteImplementResult(issueNum int, step StepResult) error {
 	path := filepath.Join(w.issueDir(issueNum), "implement.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WriteMergeCoordinatorResult writes the merge coordinator step result for the given issue.
 // Path: issues/<issueNum>/merge_coordinator.json
 func (w *Writer) WriteMergeCoordinatorResult(issueNum int, step StepResult) error {
 	path := filepath.Join(w.issueDir(issueNum), "merge_coordinator.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WriteReviewResult writes a review step result for the given issue.
@@ -278,28 +293,28 @@ func (w *Writer) WriteReviewResult(issueNum int, kind string, step StepResult) e
 		return fmt.Errorf("review kind must be %q or %q, got %q", "quality", "functional", kind)
 	}
 	path := filepath.Join(w.issueDir(issueNum), kind+"-review.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WriteRetryResult writes a retry step result for the given issue and retry number.
 // Path: issues/<issueNum>/retries/<retryNum>/retry.json
 func (w *Writer) WriteRetryResult(issueNum, retryNum int, step StepResult) error {
 	path := filepath.Join(w.issueRetryDir(issueNum, retryNum), "retry.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WriteRetryReviewResult writes a quality review result for a retry step.
 // Path: issues/<issueNum>/retries/<retryNum>/quality-review.json
 func (w *Writer) WriteRetryReviewResult(issueNum, retryNum int, step StepResult) error {
 	path := filepath.Join(w.issueRetryDir(issueNum, retryNum), "quality-review.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WriteRetryFunctionalReviewResult writes the functional review that triggered a retry.
 // Path: issues/<issueNum>/retries/<retryNum>/functional-review.json
 func (w *Writer) WriteRetryFunctionalReviewResult(issueNum, retryNum int, step StepResult) error {
 	path := filepath.Join(w.issueRetryDir(issueNum, retryNum), "functional-review.json")
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // WriteOutcome writes the outcome for the issue identified by outcome.IssueNumber.
@@ -417,7 +432,7 @@ func (w *Writer) WriteRollupVerifyResult(step VerifyStepResult) error {
 // Path: rollup/merge_coordinator-<attempt>.json
 func (w *Writer) WriteRollupMergeCoordinatorResult(attempt int, step StepResult) error {
 	path := filepath.Join(w.dir, "rollup", fmt.Sprintf("merge_coordinator-%d.json", attempt))
-	return writeJSONMkdirs(path, step)
+	return writeStepArtifact(path, step)
 }
 
 // RiskGate records the outcome of a single risk gate evaluation.
@@ -675,4 +690,29 @@ func writeJSONMkdirs(path string, v any) error {
 		return fmt.Errorf("creating directories for %s: %w", path, err)
 	}
 	return writeJSON(path, v)
+}
+
+// writeStepArtifact writes a StepResult JSON file, and if step.Transcript is
+// non-empty, also writes a sibling <basename>-transcript.jsonl.gz containing
+// the pre-gzipped transcript bytes. The transcript is already filtered and
+// compressed by the caller; this function only persists it.
+func writeStepArtifact(jsonPath string, step StepResult) error {
+	transcript := step.Transcript
+	if err := writeJSONMkdirs(jsonPath, step); err != nil {
+		return err
+	}
+	if len(transcript) == 0 {
+		return nil
+	}
+	transcriptPath := transcriptPathFor(jsonPath)
+	if err := os.WriteFile(transcriptPath, transcript, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", transcriptPath, err)
+	}
+	return nil
+}
+
+// transcriptPathFor derives the transcript path sibling to a step JSON file.
+// Example: issues/42/implement.json -> issues/42/implement-transcript.jsonl.gz.
+func transcriptPathFor(jsonPath string) string {
+	return strings.TrimSuffix(jsonPath, ".json") + "-transcript.jsonl.gz"
 }

--- a/internal/rundata/writer_test.go
+++ b/internal/rundata/writer_test.go
@@ -1,6 +1,7 @@
 package rundata
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -469,6 +470,105 @@ func TestToolTraceWrittenToJSON(t *testing.T) {
 		if written.ToolTrace[i] != want {
 			t.Errorf("ToolTrace[%d] = %q, want %q", i, written.ToolTrace[i], want)
 		}
+	}
+}
+
+func TestHarnessHashWrittenToRunJSON(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{1})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(w.Dir(), "run.json"))
+	if err != nil {
+		t.Fatalf("reading run.json: %v", err)
+	}
+	var meta RunMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("parsing run.json: %v", err)
+	}
+
+	if len(meta.HarnessHash) != 64 {
+		t.Errorf("HarnessHash length = %d, want 64 hex chars (got %q)", len(meta.HarnessHash), meta.HarnessHash)
+	}
+}
+
+func TestTranscriptWrittenAsSiblingGzip(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	transcript := []byte("gzipped-bytes-from-filter")
+	step := StepResult{Output: "done", Transcript: transcript}
+	if err := w.WriteImplementResult(42, step); err != nil {
+		t.Fatalf("WriteImplementResult() error: %v", err)
+	}
+
+	jsonPath := filepath.Join(w.Dir(), "issues", "42", "implement.json")
+	if _, err := os.Stat(jsonPath); err != nil {
+		t.Fatalf("implement.json not written: %v", err)
+	}
+
+	transcriptPath := filepath.Join(w.Dir(), "issues", "42", "implement-transcript.jsonl.gz")
+	got, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatalf("reading transcript: %v", err)
+	}
+	if !bytes.Equal(got, transcript) {
+		t.Errorf("transcript bytes mismatch: got %q, want %q", got, transcript)
+	}
+
+	// Transcript field is not serialized into the JSON artifact.
+	jsonData, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatalf("reading implement.json: %v", err)
+	}
+	if strings.Contains(string(jsonData), "transcript") {
+		t.Errorf("transcript leaked into JSON: %s", jsonData)
+	}
+}
+
+func TestTranscriptNotWrittenWhenEmpty(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	step := StepResult{Output: "done"}
+	if err := w.WriteImplementResult(42, step); err != nil {
+		t.Fatalf("WriteImplementResult() error: %v", err)
+	}
+
+	transcriptPath := filepath.Join(w.Dir(), "issues", "42", "implement-transcript.jsonl.gz")
+	if _, err := os.Stat(transcriptPath); !os.IsNotExist(err) {
+		t.Errorf("transcript file should not exist when Transcript is nil, stat err = %v", err)
+	}
+}
+
+func TestTranscriptWrittenForRetry(t *testing.T) {
+	base := t.TempDir()
+	w, err := newWithBase(t, base, "owner/repo", "Phase 7", []int{42})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	transcript := []byte("retry-transcript-bytes")
+	step := StepResult{Output: "done", Transcript: transcript}
+	if err := w.WriteRetryResult(42, 1, step); err != nil {
+		t.Fatalf("WriteRetryResult() error: %v", err)
+	}
+
+	transcriptPath := filepath.Join(w.Dir(), "issues", "42", "retries", "1", "retry-transcript.jsonl.gz")
+	got, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatalf("reading retry transcript: %v", err)
+	}
+	if !bytes.Equal(got, transcript) {
+		t.Errorf("retry transcript bytes mismatch: got %q, want %q", got, transcript)
 	}
 }
 

--- a/internal/stats/convert.go
+++ b/internal/stats/convert.go
@@ -104,10 +104,11 @@ func ToRunDetails(runs []RunRecord, outcomes []IssueOutcomeRecord, steps []StepR
 // toRunMeta converts a RunRecord into a rundata.RunMeta.
 func toRunMeta(r RunRecord) rundata.RunMeta {
 	meta := rundata.RunMeta{
-		Repo:       r.Repo,
-		Milestone:  r.Milestone,
-		BaseBranch: r.BaseBranch,
-		StartedAt:  r.StartedAt,
+		Repo:        r.Repo,
+		Milestone:   r.Milestone,
+		BaseBranch:  r.BaseBranch,
+		StartedAt:   r.StartedAt,
+		HarnessHash: r.HarnessHash,
 	}
 
 	if r.AutoMergeFeature != "" || r.AutoMergeRollup != "" {
@@ -144,6 +145,7 @@ func toStepResult(s StepResultRecord) rundata.StepResult {
 		CPUNanoseconds:  s.CPUNanoseconds,
 		TraceID:         s.TraceID,
 		Prompt:          s.Prompt,
+		PromptHash:      s.PromptHash,
 	}
 
 	if !s.StartedAt.IsZero() {

--- a/internal/stats/query.go
+++ b/internal/stats/query.go
@@ -33,7 +33,7 @@ type RunFilter struct {
 func QueryRuns(ctx context.Context, db *DB, filter RunFilter) ([]RunRecord, error) {
 	where, args := buildRunWhere(filter)
 	const runsBase = `SELECT id, repo, milestone, base_branch, auto_merge_feature, auto_merge_rollup,
-	             started_at, finished_at, total, implemented, failed, abort_reason
+	             started_at, finished_at, total, implemented, failed, abort_reason, harness_hash
 	      FROM runs`
 	q := runsBase + where + ` ORDER BY started_at ASC` // #nosec G202 -- where contains only hardcoded clauses with ? placeholders
 
@@ -52,6 +52,7 @@ func QueryRuns(ctx context.Context, db *DB, filter RunFilter) ([]RunRecord, erro
 			&r.AutoMergeFeature, &r.AutoMergeRollup,
 			&startedAt, &finishedAt,
 			&r.Total, &r.Implemented, &r.Failed, &r.AbortReason,
+			&r.HarnessHash,
 		); scanErr != nil {
 			return nil, fmt.Errorf("scan run: %w", scanErr)
 		}
@@ -115,7 +116,7 @@ func QueryIssueOutcomes(ctx context.Context, db *DB, filter RunFilter) ([]IssueO
 func QueryStepResults(ctx context.Context, db *DB, filter RunFilter) ([]StepResultRecord, error) {
 	where, args := buildRunJoinWhere(filter)
 	const stepResultsBase = `SELECT sr.run_id, sr.issue_number, sr.step_name, sr.cost_usd, sr.duration_seconds,
-	             sr.flags, sr.started_at, sr.finished_at, sr.peak_memory_bytes, sr.cpu_nanoseconds, sr.trace_id, sr.prompt
+	             sr.flags, sr.started_at, sr.finished_at, sr.peak_memory_bytes, sr.cpu_nanoseconds, sr.trace_id, sr.prompt, sr.prompt_hash
 	      FROM step_results sr
 	      INNER JOIN runs r ON r.id = sr.run_id`
 	q := stepResultsBase + where + ` ORDER BY r.started_at ASC` // #nosec G202 -- where contains only hardcoded clauses with ? placeholders
@@ -132,7 +133,7 @@ func QueryStepResults(ctx context.Context, db *DB, filter RunFilter) ([]StepResu
 		var flagsJSON, startedAt, finishedAt string
 		if scanErr := rows.Scan(
 			&s.RunID, &s.IssueNumber, &s.StepName, &s.CostUSD, &s.DurationSeconds,
-			&flagsJSON, &startedAt, &finishedAt, &s.PeakMemoryBytes, &s.CPUNanoseconds, &s.TraceID, &s.Prompt,
+			&flagsJSON, &startedAt, &finishedAt, &s.PeakMemoryBytes, &s.CPUNanoseconds, &s.TraceID, &s.Prompt, &s.PromptHash,
 		); scanErr != nil {
 			return nil, fmt.Errorf("scan step result: %w", scanErr)
 		}
@@ -164,7 +165,7 @@ func QueryStepResults(ctx context.Context, db *DB, filter RunFilter) ([]StepResu
 // sorted by started_at ascending. Returns an empty slice if none found.
 func QueryStepsByTraceID(ctx context.Context, db *DB, traceID string) ([]StepResultRecord, error) {
 	const q = `SELECT run_id, issue_number, step_name, cost_usd, duration_seconds,
-	             flags, started_at, finished_at, peak_memory_bytes, cpu_nanoseconds, trace_id, prompt
+	             flags, started_at, finished_at, peak_memory_bytes, cpu_nanoseconds, trace_id, prompt, prompt_hash
 	      FROM step_results WHERE trace_id = ? ORDER BY started_at ASC`
 
 	rows, err := db.db.QueryContext(ctx, q, traceID)
@@ -179,7 +180,7 @@ func QueryStepsByTraceID(ctx context.Context, db *DB, traceID string) ([]StepRes
 		var flagsJSON, startedAt, finishedAt string
 		if scanErr := rows.Scan(
 			&s.RunID, &s.IssueNumber, &s.StepName, &s.CostUSD, &s.DurationSeconds,
-			&flagsJSON, &startedAt, &finishedAt, &s.PeakMemoryBytes, &s.CPUNanoseconds, &s.TraceID, &s.Prompt,
+			&flagsJSON, &startedAt, &finishedAt, &s.PeakMemoryBytes, &s.CPUNanoseconds, &s.TraceID, &s.Prompt, &s.PromptHash,
 		); scanErr != nil {
 			return nil, fmt.Errorf("scan step result: %w", scanErr)
 		}
@@ -210,7 +211,7 @@ func QueryStepsByTraceID(ctx context.Context, db *DB, traceID string) ([]StepRes
 // QueryRunByID returns a single RunRecord by run_id (the timestamp), or nil if not found.
 func QueryRunByID(ctx context.Context, db *DB, runID string) (*RunRecord, error) {
 	const q = `SELECT id, repo, milestone, base_branch, auto_merge_feature, auto_merge_rollup,
-	             started_at, finished_at, total, implemented, failed, abort_reason
+	             started_at, finished_at, total, implemented, failed, abort_reason, harness_hash
 	      FROM runs WHERE id = ? LIMIT 1`
 
 	var r RunRecord
@@ -220,6 +221,7 @@ func QueryRunByID(ctx context.Context, db *DB, runID string) (*RunRecord, error)
 		&r.AutoMergeFeature, &r.AutoMergeRollup,
 		&startedAt, &finishedAt,
 		&r.Total, &r.Implemented, &r.Failed, &r.AbortReason,
+		&r.HarnessHash,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/internal/stats/schema.go
+++ b/internal/stats/schema.go
@@ -69,8 +69,10 @@ func migrate(db *sql.DB) error {
 		`ALTER TABLE step_results ADD COLUMN cpu_nanoseconds INTEGER DEFAULT 0`,
 		`ALTER TABLE step_results ADD COLUMN trace_id TEXT DEFAULT ''`,
 		`ALTER TABLE step_results ADD COLUMN prompt TEXT DEFAULT ''`,
+		`ALTER TABLE step_results ADD COLUMN prompt_hash TEXT DEFAULT ''`,
 		`ALTER TABLE issue_outcomes ADD COLUMN trace_id TEXT DEFAULT ''`,
 		`ALTER TABLE issue_outcomes ADD COLUMN clone_sha TEXT DEFAULT ''`,
+		`ALTER TABLE runs ADD COLUMN harness_hash TEXT DEFAULT ''`,
 	}
 	for _, stmt := range alterStmts {
 		if _, err := db.Exec(stmt); err != nil {

--- a/internal/stats/types.go
+++ b/internal/stats/types.go
@@ -17,6 +17,7 @@ type RunRecord struct {
 	Implemented      int
 	Failed           int
 	AbortReason      string
+	HarnessHash      string
 }
 
 // IssueOutcomeRecord holds the data for a single row in issue_outcomes.
@@ -48,4 +49,5 @@ type StepResultRecord struct {
 	CPUNanoseconds   int64
 	TraceID          string
 	Prompt           string
+	PromptHash       string
 }

--- a/internal/stats/write.go
+++ b/internal/stats/write.go
@@ -45,8 +45,8 @@ func doWriteRun(ctx context.Context, ex execContext, run RunRecord) error {
 	_, err := ex.ExecContext(ctx,
 		`INSERT OR REPLACE INTO runs
 			(id, repo, milestone, base_branch, auto_merge_feature, auto_merge_rollup,
-			 started_at, finished_at, total, implemented, failed, abort_reason)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 started_at, finished_at, total, implemented, failed, abort_reason, harness_hash)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.ID,
 		run.Repo,
 		run.Milestone,
@@ -59,6 +59,7 @@ func doWriteRun(ctx context.Context, ex execContext, run RunRecord) error {
 		run.Implemented,
 		run.Failed,
 		run.AbortReason,
+		run.HarnessHash,
 	)
 	if err != nil {
 		return fmt.Errorf("write run %q: %w", run.ID, err)
@@ -122,8 +123,8 @@ func doWriteStepResult(ctx context.Context, ex execContext, step StepResultRecor
 	_, err = ex.ExecContext(ctx,
 		`INSERT OR REPLACE INTO step_results
 			(run_id, issue_number, step_name, cost_usd, duration_seconds, flags,
-			 started_at, finished_at, peak_memory_bytes, cpu_nanoseconds, trace_id, prompt)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 started_at, finished_at, peak_memory_bytes, cpu_nanoseconds, trace_id, prompt, prompt_hash)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		step.RunID,
 		step.IssueNumber,
 		step.StepName,
@@ -136,6 +137,7 @@ func doWriteStepResult(ctx context.Context, ex execContext, step StepResultRecor
 		step.CPUNanoseconds,
 		step.TraceID,
 		capPrompt(step.Prompt),
+		step.PromptHash,
 	)
 	if err != nil {
 		return fmt.Errorf("write step result (run=%q issue=%d step=%q): %w", step.RunID, step.IssueNumber, step.StepName, err)

--- a/internal/stats/write_test.go
+++ b/internal/stats/write_test.go
@@ -631,6 +631,74 @@ func TestWriteStepResult_EmptyPrompt(t *testing.T) {
 	}
 }
 
+func TestWriteRun_HarnessHashRoundtrip(t *testing.T) {
+	db := openTestDB(t)
+
+	run := RunRecord{
+		ID:          "20260420-120000",
+		Repo:        "org/repo",
+		Milestone:   "Phase 39",
+		StartedAt:   time.Date(2026, 4, 20, 12, 0, 0, 0, time.UTC),
+		FinishedAt:  time.Date(2026, 4, 20, 13, 0, 0, 0, time.UTC),
+		HarnessHash: "deadbeef" + "cafebabe" + "deadbeef" + "cafebabe" + "deadbeef" + "cafebabe" + "deadbeef" + "cafebabe",
+	}
+	if err := WriteRun(context.Background(), db, run); err != nil {
+		t.Fatalf("WriteRun: %v", err)
+	}
+
+	got, err := QueryRunByID(context.Background(), db, run.ID)
+	if err != nil {
+		t.Fatalf("QueryRunByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("QueryRunByID returned nil")
+	}
+	if got.HarnessHash != run.HarnessHash {
+		t.Errorf("HarnessHash: got %q, want %q", got.HarnessHash, run.HarnessHash)
+	}
+}
+
+func TestWriteStepResult_PromptHashRoundtrip(t *testing.T) {
+	db := openTestDB(t)
+
+	run := RunRecord{
+		ID:         "20260420-130000",
+		Repo:       "org/repo",
+		StartedAt:  time.Date(2026, 4, 20, 13, 0, 0, 0, time.UTC),
+		FinishedAt: time.Date(2026, 4, 20, 13, 30, 0, 0, time.UTC),
+	}
+	if err := WriteRun(context.Background(), db, run); err != nil {
+		t.Fatalf("WriteRun: %v", err)
+	}
+
+	step := StepResultRecord{
+		RunID:       run.ID,
+		IssueNumber: 1,
+		StepName:    "implement",
+		StartedAt:   run.StartedAt,
+		FinishedAt:  run.FinishedAt,
+		Prompt:      "rendered prompt text",
+		PromptHash:  "cafebabe" + "deadbeef" + "cafebabe" + "deadbeef" + "cafebabe" + "deadbeef" + "cafebabe" + "deadbeef",
+	}
+	if err := WriteStepResult(context.Background(), db, step); err != nil {
+		t.Fatalf("WriteStepResult: %v", err)
+	}
+
+	steps, err := QueryStepResults(context.Background(), db, RunFilter{Repo: "org/repo"})
+	if err != nil {
+		t.Fatalf("QueryStepResults: %v", err)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("got %d steps, want 1", len(steps))
+	}
+	if steps[0].PromptHash != step.PromptHash {
+		t.Errorf("PromptHash: got %q, want %q", steps[0].PromptHash, step.PromptHash)
+	}
+	if steps[0].Prompt != step.Prompt {
+		t.Errorf("Prompt: got %q, want %q", steps[0].Prompt, step.Prompt)
+	}
+}
+
 func TestMigrateIdempotent(t *testing.T) {
 	db := openTestDB(t)
 

--- a/prompts/hash.go
+++ b/prompts/hash.go
@@ -1,0 +1,64 @@
+package prompts
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"sort"
+	"sync"
+)
+
+// Hash returns a SHA256 hex digest over all embedded prompt files. The digest
+// is stable for a given binary: it identifies which prompt bundle shipped with
+// godark at build time. A meta-agent editing prompts between runs can use the
+// hash to attribute improvements to specific harness versions rather than to
+// benchmark drift.
+//
+// The computation walks the embed.FS in sorted filename order and feeds each
+// "<name>\x00<contents>\x00" segment into the hasher. It is computed once per
+// process and memoized.
+func Hash() string {
+	hashOnce.Do(computeHash)
+	return hashValue
+}
+
+var (
+	hashOnce  sync.Once
+	hashValue string
+)
+
+func computeHash() {
+	names, err := collectNames()
+	if err != nil {
+		return
+	}
+	sort.Strings(names)
+
+	h := sha256.New()
+	for _, name := range names {
+		data, err := FS.ReadFile(name)
+		if err != nil {
+			return
+		}
+		h.Write([]byte(name))
+		h.Write([]byte{0})
+		h.Write(data)
+		h.Write([]byte{0})
+	}
+	hashValue = hex.EncodeToString(h.Sum(nil))
+}
+
+func collectNames() ([]string, error) {
+	var names []string
+	err := fs.WalkDir(FS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		names = append(names, path)
+		return nil
+	})
+	return names, err
+}

--- a/prompts/hash_test.go
+++ b/prompts/hash_test.go
@@ -1,0 +1,24 @@
+package prompts
+
+import "testing"
+
+func TestHash_ReturnsHexDigest(t *testing.T) {
+	got := Hash()
+	if len(got) != 64 {
+		t.Errorf("Hash() length = %d, want 64 hex chars", len(got))
+	}
+	for _, c := range got {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("Hash() contains non-hex character %q: %s", c, got)
+			break
+		}
+	}
+}
+
+func TestHash_Deterministic(t *testing.T) {
+	first := Hash()
+	second := Hash()
+	if first != second {
+		t.Errorf("Hash() not deterministic: %q vs %q", first, second)
+	}
+}

--- a/prompts/hash_test.go
+++ b/prompts/hash_test.go
@@ -8,7 +8,7 @@ func TestHash_ReturnsHexDigest(t *testing.T) {
 		t.Errorf("Hash() length = %d, want 64 hex chars", len(got))
 	}
 	for _, c := range got {
-		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
 			t.Errorf("Hash() contains non-hex character %q: %s", c, got)
 			break
 		}


### PR DESCRIPTION
## Summary

Lays the trace-infrastructure groundwork needed before Phase 37 (benchmarking) and Phases 39/40 (meta-agent human and autonomous modes).

- **Transcript capture:** filters the Claude Code ndjson stdout down to assistant and user events, gzips it, and writes `<step>-transcript.jsonl.gz` alongside each step JSON. Raw stdout was previously discarded on successful runs, so this is additive.
- **Harness and prompt identifiers:** `HarnessHash` on `RunMeta` (SHA256 over embedded prompt files, memoized) and `PromptHash` on `StepResult` (SHA256 of the rendered prompt). Plumbed through `stats.db` via idempotent migrations.
- **Phase 38 fix:** `stepToRecord` wasn't copying `step.Prompt` into `StepResultRecord`, so `step_results.prompt` had been silently empty. Now carries `Prompt` and the new `PromptHash`.
- **Planning:** metric-gaming pre-mortem for Phase 37, Phase 37 plan updates (new Issues 786/787, modifications to 781/784/785), and roadmap entries for Phase 39 (Meta-Agent Human Mode) and Phase 40 (Meta-Agent Autonomous Mode).

## Design notes

- `StepResult.Transcript []byte \`json:\"-\"\`` pattern mirrors how Phase 32 added `TraceID` without touching the 15-method `RunDataHook` interface. Writer peels the transcript off and writes the sibling file; JSON-encoder skips it.
- `FilterTranscript` is exported so future tooling (the Phase 39 corpus reader) can re-run the filter on archived stdout if the filter definition changes.
- `prompts.Hash()` walks the `embed.FS` in sorted order, so the hash is deterministic and stable for a given binary across invocations.

## Test plan

- [x] `go test ./...` — all packages pass locally
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — passed via pre-push hook
- [x] `godark vet architecture` — all layer checks pass
- [x] Unit tests added for `FilterTranscript` (kept/dropped event types, nil on empty, gzip roundtrip)
- [x] Unit tests added for `writeStepArtifact` (sibling transcript written, not written when empty, retry path)
- [x] Unit tests added for `ResultToStep` (PromptHash populated/deterministic, Transcript populated from Stdout)
- [x] Unit tests added for `prompts.Hash` (hex shape, determinism)
- [x] Unit tests added for stats roundtrip (`harness_hash` on runs, `prompt_hash` on step_results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)