### PR TITLE
Add runtime mismatch and multi-runtime doctor checks

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -20,26 +20,36 @@ any check fails.
 Checks:
   • Docker daemon running
   • gh CLI installed and authenticated
-  • Anthropic auth token set`,
+  • Anthropic auth token set
+  • Configured runtime matches repo files (when both are detectable)
+  • Multi-runtime repo has modules: configured (when more than one runtime is detected)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Best-effort runtime detection from the current directory.
 		runtime := ""
 		if dp, err := detect.DetectRuntime("."); err == nil {
 			runtime = dp.Runtime.Name
 		}
+		detectedRuntimes := detect.DetectAllRuntimes(".")
 
-		// Best-effort config load to obtain lint_command and compose config.
+		// Best-effort config load to obtain lint_command, modules, compose, oauth.
 		lintCommand := ""
+		configuredRuntime := ""
+		modulesConfigured := false
 		composeConfigured := false
 		oauthTokenEnv := ""
 		if cfg, err := config.Load("godark.yaml", config.CLIFlags{}); err == nil {
 			lintCommand = cfg.LintCommand
+			configuredRuntime = cfg.Runtime.Name
+			modulesConfigured = len(cfg.Modules) > 0
 			composeConfigured = cfg.DockerCompose != nil
 			oauthTokenEnv = cfg.OAuthTokenEnv
 		}
 
 		checks := doctor.Checks(doctor.Opts{
 			Runtime:           runtime,
+			ConfiguredRuntime: configuredRuntime,
+			DetectedRuntimes:  detectedRuntimes,
+			ModulesConfigured: modulesConfigured,
 			LintCommand:       lintCommand,
 			ComposeConfigured: composeConfigured,
 			OAuthTokenEnv:     oauthTokenEnv,

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -20,6 +20,47 @@ type DetectedProject struct {
 	TestCommand  string
 }
 
+// DetectAllRuntimes scans repoPath for language marker files and returns every
+// runtime whose marker file is present. The returned slice is deduplicated and
+// in deterministic priority order: go, flutter, node, rust, elixir, python.
+// Returns an empty slice if no known marker files are found.
+//
+// This is meant for callers that need to detect multi-runtime repos (e.g.
+// pre-flight checks that warn when modules: is not configured for a repo with
+// both go.mod and pyproject.toml). For "what runtime is this project?" use
+// DetectRuntime instead.
+func DetectAllRuntimes(repoPath string) []string {
+	var runtimes []string
+	if _, err := os.Stat(filepath.Join(repoPath, "go.mod")); err == nil {
+		runtimes = append(runtimes, "go")
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, "pubspec.yaml")); err == nil {
+		runtimes = append(runtimes, "flutter")
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, "package.json")); err == nil {
+		runtimes = append(runtimes, "node")
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, "Cargo.toml")); err == nil {
+		runtimes = append(runtimes, "rust")
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, "mix.exs")); err == nil {
+		runtimes = append(runtimes, "elixir")
+	}
+	pyProject := false
+	if _, err := os.Stat(filepath.Join(repoPath, "pyproject.toml")); err == nil {
+		pyProject = true
+	}
+	if !pyProject {
+		if _, err := os.Stat(filepath.Join(repoPath, "requirements.txt")); err == nil {
+			pyProject = true
+		}
+	}
+	if pyProject {
+		runtimes = append(runtimes, "python")
+	}
+	return runtimes
+}
+
 // DetectRuntime scans repoPath for language marker files and returns a
 // DetectedProject with sensible defaults. First match wins.
 // Returns an error if no known marker file is found.

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -313,6 +313,75 @@ func TestDetectRuntime_ElixirLongerAtomKeyNotMatched(t *testing.T) {
 	}
 }
 
+// --- DetectAllRuntimes ---
+
+func TestDetectAllRuntimes_Empty(t *testing.T) {
+	dir := t.TempDir()
+	got := DetectAllRuntimes(dir)
+	if len(got) != 0 {
+		t.Errorf("DetectAllRuntimes = %v, want empty slice", got)
+	}
+}
+
+func TestDetectAllRuntimes_SingleRuntime(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/foo\n\ngo 1.22\n")
+
+	got := DetectAllRuntimes(dir)
+	if len(got) != 1 || got[0] != "go" {
+		t.Errorf("DetectAllRuntimes = %v, want [go]", got)
+	}
+}
+
+func TestDetectAllRuntimes_MultipleRuntimes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/foo\n")
+	writeFile(t, filepath.Join(dir, "pyproject.toml"), "[project]\nname = \"x\"\n")
+
+	got := DetectAllRuntimes(dir)
+	if len(got) != 2 {
+		t.Fatalf("DetectAllRuntimes = %v, want length 2", got)
+	}
+	// Priority order: go before python.
+	if got[0] != "go" || got[1] != "python" {
+		t.Errorf("DetectAllRuntimes = %v, want [go python]", got)
+	}
+}
+
+func TestDetectAllRuntimes_PythonMarkerEitherFile(t *testing.T) {
+	// Either pyproject.toml or requirements.txt counts as one "python" entry,
+	// never two.
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "pyproject.toml"), "[project]\nname = \"x\"\n")
+	writeFile(t, filepath.Join(dir, "requirements.txt"), "requests\n")
+
+	got := DetectAllRuntimes(dir)
+	if len(got) != 1 || got[0] != "python" {
+		t.Errorf("DetectAllRuntimes = %v, want [python]", got)
+	}
+}
+
+func TestDetectAllRuntimes_AllRuntimesPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module x\n")
+	writeFile(t, filepath.Join(dir, "pubspec.yaml"), "name: x\n")
+	writeFile(t, filepath.Join(dir, "package.json"), "{}")
+	writeFile(t, filepath.Join(dir, "Cargo.toml"), "[package]\nname=\"x\"\n")
+	writeFile(t, filepath.Join(dir, "mix.exs"), "defmodule X.MixProject do\nend\n")
+	writeFile(t, filepath.Join(dir, "pyproject.toml"), "[project]\nname=\"x\"\n")
+
+	got := DetectAllRuntimes(dir)
+	want := []string{"go", "flutter", "node", "rust", "elixir", "python"}
+	if len(got) != len(want) {
+		t.Fatalf("DetectAllRuntimes = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("DetectAllRuntimes[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // writeFile is a test helper that creates a file with the given content.
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -59,10 +59,13 @@ func runtimeVersionCmd(runtime string) (string, []string) {
 
 // Opts controls which checks are included.
 type Opts struct {
-	Runtime           string // detected runtime name (e.g. "go")
-	LintCommand       string // configured lint command
-	ComposeConfigured bool   // docker_compose block is present
-	OAuthTokenEnv     string // host env var name for Claude OAuth token (default CLAUDE_CODE_OAUTH_TOKEN)
+	Runtime           string   // detected runtime name (e.g. "go")
+	ConfiguredRuntime string   // runtime.name from godark.yaml (e.g. "python")
+	DetectedRuntimes  []string // every runtime whose marker file is present in the repo
+	ModulesConfigured bool     // a non-empty modules: block is present in godark.yaml
+	LintCommand       string   // configured lint command
+	ComposeConfigured bool     // docker_compose block is present
+	OAuthTokenEnv     string   // host env var name for Claude OAuth token (default CLAUDE_CODE_OAUTH_TOKEN)
 }
 
 // Checks returns the full ordered list of pre-flight checks.
@@ -112,6 +115,31 @@ func Checks(opts Opts) []*Check {
 			}
 		}(),
 	)
+
+	if opts.ConfiguredRuntime != "" && opts.Runtime != "" && opts.ConfiguredRuntime != opts.Runtime {
+		configured := opts.ConfiguredRuntime
+		detected := opts.Runtime
+		checks = append(checks, &Check{
+			Name: "Configured runtime matches repo files",
+			Fix: fmt.Sprintf(
+				"godark.yaml has runtime.name=%q but the repo contains %s marker files. Update godark.yaml to runtime.name=%q, or configure a modules: block if this is a multi-runtime repo.",
+				configured, detected, detected,
+			),
+			run: func() bool { return false },
+		})
+	}
+
+	if len(opts.DetectedRuntimes) > 1 && !opts.ModulesConfigured {
+		detected := strings.Join(opts.DetectedRuntimes, ", ")
+		checks = append(checks, &Check{
+			Name: "Multi-runtime repo has modules: configured",
+			Fix: fmt.Sprintf(
+				"Detected multiple runtimes (%s) but no modules: block in godark.yaml. Add a modules: map keyed by directory so each module has its own build_command and test_command, or remove marker files for runtimes you don't use.",
+				detected,
+			),
+			run: func() bool { return false },
+		})
+	}
 
 	if opts.ComposeConfigured {
 		checks = append(checks, &Check{

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -299,6 +299,115 @@ func TestRuntimeVersionCmd(t *testing.T) {
 	}
 }
 
+// --- Runtime mismatch and multi-runtime checks ---
+
+func TestChecks_RuntimeMatch_NoExtraCheck(t *testing.T) {
+	checks := Checks(Opts{Runtime: "go", ConfiguredRuntime: "go"})
+	for _, c := range checks {
+		if strings.Contains(c.Name, "runtime matches") {
+			t.Errorf("unexpected runtime mismatch check when runtimes match: %s", c.Name)
+		}
+	}
+}
+
+func TestChecks_RuntimeMismatch_AddsFailingCheck(t *testing.T) {
+	checks := Checks(Opts{Runtime: "go", ConfiguredRuntime: "python"})
+	var found *Check
+	for _, c := range checks {
+		if c.Name == "Configured runtime matches repo files" {
+			found = c
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected runtime mismatch check to be added")
+	}
+	if found.run() {
+		t.Error("expected runtime mismatch check to fail")
+	}
+}
+
+func TestChecks_RuntimeMismatch_FixMentionsBoth(t *testing.T) {
+	checks := Checks(Opts{Runtime: "go", ConfiguredRuntime: "python"})
+	for _, c := range checks {
+		if c.Name != "Configured runtime matches repo files" {
+			continue
+		}
+		if !strings.Contains(c.Fix, "python") {
+			t.Errorf("Fix should mention configured runtime 'python': %s", c.Fix)
+		}
+		if !strings.Contains(c.Fix, "go") {
+			t.Errorf("Fix should mention detected runtime 'go': %s", c.Fix)
+		}
+		return
+	}
+	t.Fatal("expected runtime mismatch check to be present")
+}
+
+func TestChecks_RuntimeMismatch_SkippedWhenConfiguredEmpty(t *testing.T) {
+	// When godark.yaml has no runtime.name, we can't compare. Skip the check.
+	checks := Checks(Opts{Runtime: "go", ConfiguredRuntime: ""})
+	for _, c := range checks {
+		if c.Name == "Configured runtime matches repo files" {
+			t.Error("expected mismatch check to be skipped when ConfiguredRuntime is empty")
+		}
+	}
+}
+
+func TestChecks_RuntimeMismatch_SkippedWhenDetectedEmpty(t *testing.T) {
+	// When no marker files are found, we can't tell what the project is. Skip.
+	checks := Checks(Opts{Runtime: "", ConfiguredRuntime: "go"})
+	for _, c := range checks {
+		if c.Name == "Configured runtime matches repo files" {
+			t.Error("expected mismatch check to be skipped when Runtime is empty")
+		}
+	}
+}
+
+func TestChecks_SingleRuntime_NoMultiRuntimeCheck(t *testing.T) {
+	checks := Checks(Opts{DetectedRuntimes: []string{"go"}})
+	for _, c := range checks {
+		if c.Name == "Multi-runtime repo has modules: configured" {
+			t.Error("expected multi-runtime check to be skipped for single runtime")
+		}
+	}
+}
+
+func TestChecks_MultiRuntime_NoModules_AddsFailingCheck(t *testing.T) {
+	checks := Checks(Opts{
+		DetectedRuntimes:  []string{"go", "python"},
+		ModulesConfigured: false,
+	})
+	var found *Check
+	for _, c := range checks {
+		if c.Name == "Multi-runtime repo has modules: configured" {
+			found = c
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected multi-runtime check to be added")
+	}
+	if found.run() {
+		t.Error("expected multi-runtime check to fail when modules: is missing")
+	}
+	if !strings.Contains(found.Fix, "go") || !strings.Contains(found.Fix, "python") {
+		t.Errorf("Fix should mention both detected runtimes: %s", found.Fix)
+	}
+}
+
+func TestChecks_MultiRuntime_WithModules_NoCheck(t *testing.T) {
+	checks := Checks(Opts{
+		DetectedRuntimes:  []string{"go", "python"},
+		ModulesConfigured: true,
+	})
+	for _, c := range checks {
+		if c.Name == "Multi-runtime repo has modules: configured" {
+			t.Error("expected multi-runtime check to be skipped when ModulesConfigured is true")
+		}
+	}
+}
+
 func TestRun_Timeout(t *testing.T) {
 	origTimeout := CheckTimeout
 	defer func() { CheckTimeout = origTimeout }()


### PR DESCRIPTION
## Summary

- `internal/detect`: new `DetectAllRuntimes` returns every runtime whose marker file is present, in priority order.
- `internal/doctor`: two new conditional checks driven by three new `Opts` fields (`ConfiguredRuntime`, `DetectedRuntimes`, `ModulesConfigured`).
- `internal/cmd/doctor`: populates the new `Opts` from `config.Load` and `detect.DetectAllRuntimes`.

Both checks are no-ops when the inputs are absent (no `godark.yaml`, no marker files), so existing flows are unchanged.

## Motivation

Watched a real run stall silently. Project had:

```yaml
# godark.yaml
runtime:
  name: python
test_command: "pytest"
```

The actual project code was Go (`server/go.mod`). The implementer agent dutifully wrote the Go scaffold, then noticed the test command and tried to "help" by adding `pyproject.toml` and appending `pytest>=8.0.0` to `requirements.txt`. The PR landed with that cruft. Downstream, the quality reviewer shell-exec'd `pytest` directly and got `sh: 1: pytest: not found` because the sandbox image had Python but no pytest. The TUI just sat at `QUEUED` with no error surfaced.

These checks would have caught the misalignment at `godark doctor` time before any agent work began.

## Sample output

When the configured runtime disagrees with the repo:

```
[FAIL] Configured runtime matches repo files
       Fix: godark.yaml has runtime.name="python" but the repo contains go marker files. Update godark.yaml to runtime.name="go", or configure a modules: block if this is a multi-runtime repo.
```

When the repo has multiple runtime markers but no `modules:`:

```
[FAIL] Multi-runtime repo has modules: configured
       Fix: Detected multiple runtimes (go, python) but no modules: block in godark.yaml. Add a modules: map keyed by directory so each module has its own build_command and test_command, or remove marker files for runtimes you don't use.
```

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite)
- [x] New tests in `internal/detect/detect_test.go` cover empty/single/multi/python-either-file/all-runtimes cases for `DetectAllRuntimes`
- [x] New tests in `internal/doctor/doctor_test.go` cover the seven branches of the two new checks (match/mismatch, empty inputs, single vs multi runtime, with/without modules)
- [x] Verified no existing doctor tests broken; baseline check count unchanged when new fields are zero-valued